### PR TITLE
chore: move ballerina external packages to peerDependencies

### DIFF
--- a/frontend/libraries/ballerina-core/package.json
+++ b/frontend/libraries/ballerina-core/package.json
@@ -5,9 +5,6 @@
   "version": "1.0.69",
   "main": "main.ts",
   "dependencies": {
-    "immutable": "^5.0.0-beta.5",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
@@ -16,5 +13,10 @@
     "@types/react-dom": "^18.2.18",
     "@types/uuid": "^9.0.8",
     "typescript": "^5.4.5"
+  },
+  "peerDependencies": {
+    "immutable": "^5.0.0-beta.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }


### PR DESCRIPTION
Moving external dependencies to peerDependencies avoid issues with having multiple versions of React when adding the package to a project.