### PR TITLE
fix: treat warnings as errors

### DIFF
--- a/backend/apps/automatic-tests/FormsValidator.fs
+++ b/backend/apps/automatic-tests/FormsValidator.fs
@@ -105,3 +105,13 @@ let WrongFormStructure () =
 [<Test>]
 let WrongPredicateStructure () =
   iterateTestsOverFiles "./input-forms/with errors/wrong predicate structure " 1 9 false
+
+[<Test>]
+let TestIShouldNotCompile () =
+  let whatIsThis: Sum<string, Errors> =
+    sum {
+      match true with
+      | false -> return "hello"
+    }
+
+  Assert.Fail(whatIsThis.ToString())

--- a/backend/apps/automatic-tests/FormsValidator.fs
+++ b/backend/apps/automatic-tests/FormsValidator.fs
@@ -105,13 +105,3 @@ let WrongFormStructure () =
 [<Test>]
 let WrongPredicateStructure () =
   iterateTestsOverFiles "./input-forms/with errors/wrong predicate structure " 1 9 false
-
-[<Test>]
-let TestIShouldNotCompile () =
-  let whatIsThis: Sum<string, Errors> =
-    sum {
-      match true with
-      | false -> return "hello"
-    }
-
-  Assert.Fail(whatIsThis.ToString())

--- a/backend/apps/automatic-tests/automatic-tests.fsproj
+++ b/backend/apps/automatic-tests/automatic-tests.fsproj
@@ -8,6 +8,7 @@
     <GenerateProgramFile>false</GenerateProgramFile>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode>true</RestoreLockedMode>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/apps/ballerina-runtime/ballerina-runtime.fsproj
+++ b/backend/apps/ballerina-runtime/ballerina-runtime.fsproj
@@ -8,6 +8,7 @@
     <PublishSingleFile>true</PublishSingleFile>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode>true</RestoreLockedMode>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/apps/test/test.fsproj
+++ b/backend/apps/test/test.fsproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode>true</RestoreLockedMode>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/libraries/absample/absample.fsproj
+++ b/backend/libraries/absample/absample.fsproj
@@ -5,6 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode>true</RestoreLockedMode>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/libraries/ballerina-core/ballerina-core.fsproj
+++ b/backend/libraries/ballerina-core/ballerina-core.fsproj
@@ -7,6 +7,7 @@
     <RuntimeIdentifiers>linux-x64;osx-x64;linux-arm64;win-x64</RuntimeIdentifiers>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode>true</RestoreLockedMode>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/libraries/oauth2/oauth2.fsproj
+++ b/backend/libraries/oauth2/oauth2.fsproj
@@ -5,6 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode>true</RestoreLockedMode>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/libraries/positions/positions.fsproj
+++ b/backend/libraries/positions/positions.fsproj
@@ -5,6 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode>true</RestoreLockedMode>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This solves the issue with inexhaustive match cases failing only at runtime or returning just a warning.

Proof that this works: CI fails on second commit