### PR TITLE
fix: Fix off-by-one error in table initialization

### DIFF
--- a/frontend/libraries/ballerina-core/src/forms/domains/dispatched-forms/runner/domains/abstract-renderers/table/coroutines/runner.ts
+++ b/frontend/libraries/ballerina-core/src/forms/domains/dispatched-forms/runner/domains/abstract-renderers/table/coroutines/runner.ts
@@ -66,7 +66,7 @@ const intialiseTable = <
                 .then(
                   ValueInfiniteStreamState.Updaters.Core.position(
                     ValueStreamPosition.Updaters.Core.nextStart(
-                      replaceWith(to + 1),
+                      replaceWith(to),
                     ),
                   ),
                 ),


### PR DESCRIPTION
Corrects a position calculation within table initialization to resolve an off-by-one error. This ensures accurate data stream positioning.

* Adjusts position calculation by removing unnecessary increment
