### PR TITLE
fix: Add support for entityIdUUID, entityIdString, and calculatedDisplayValue

### DIFF
--- a/frontend/libraries/ballerina-core/src/forms/domains/dispatched-forms/built-ins/state.ts
+++ b/frontend/libraries/ballerina-core/src/forms/domains/dispatched-forms/built-ins/state.ts
@@ -710,7 +710,9 @@ export const dispatchDefaultState =
               ? ValueOrErrors.Default.return(
                   NumberAbstractRendererState.Default(),
                 )
-              : t.name == "string"
+              : t.name == "string" ||
+                  t.name == "entityIdString" ||
+                  t.name == "calculatedDisplayValue"
                 ? ValueOrErrors.Default.return(
                     StringAbstractRendererState.Default(),
                   )

--- a/frontend/libraries/ballerina-core/src/forms/domains/dispatched-forms/deserializer/domains/specification/domains/types/state.ts
+++ b/frontend/libraries/ballerina-core/src/forms/domains/dispatched-forms/deserializer/domains/specification/domains/types/state.ts
@@ -66,6 +66,9 @@ export type SerializedType<T> =
 export const DispatchPrimitiveTypeNames = [
   "unit",
   "guid", //resolves to string
+  "entityIdString", //resolves to string
+  "entityIdUUID", //resolves to string
+  "calculatedDisplayValue", //resolves to string
   "string",
   "number",
   "boolean",
@@ -877,10 +880,18 @@ export const DispatchParsedType = {
         ],
         string
       > = (() => {
+        const stringyTypes = [
+          "guid",
+          "entityIdUUID",
+          "entityIdString",
+          "calculatedDisplayValue",
+        ];
         if (SerializedType.isPrimitive(rawType, injectedPrimitives))
           return ValueOrErrors.Default.return([
             DispatchParsedType.Default.primitive(
-              rawType == "guid" ? "string" : rawType,
+              typeof rawType === "string" && stringyTypes.includes(rawType)
+                ? "string"
+                : rawType,
             ),
             alreadyParsedTypes,
           ]);


### PR DESCRIPTION
Expands the capability to handle new string types in dispatched forms. This change improves flexibility in type resolution processes.

* Updates dispatch logic to include `entityIdString` and `calculatedDisplayValue`
* Extends parsed type handling for new string-resolvable types
* Adds comments clarifying type resolutions within `DispatchPrimitiveTypeNames`

Compatibility maintained with existing types. Further testing needed for new type integrations.