### PR TITLE
fix: ensure no extra fields in JSON unmarshaling

### DIFF
--- a/backend/libraries/ballerina-core-go/delta_array.go
+++ b/backend/libraries/ballerina-core-go/delta_array.go
@@ -1,6 +1,9 @@
 package ballerina
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+)
 
 type deltaArrayEffectsEnum string
 
@@ -64,7 +67,9 @@ func (d *DeltaArray[a, deltaA]) UnmarshalJSON(data []byte) error {
 		DuplicateAt   *int
 		Add           *a
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase

--- a/backend/libraries/ballerina-core-go/delta_chunk.go
+++ b/backend/libraries/ballerina-core-go/delta_chunk.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"github.com/google/uuid"
@@ -69,7 +70,9 @@ func (d *DeltaChunk[a, deltaA]) UnmarshalJSON(data []byte) error {
 		Add           *a
 	}
 	var aux chunkAlias
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase

--- a/backend/libraries/ballerina-core-go/delta_many.go
+++ b/backend/libraries/ballerina-core-go/delta_many.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -54,7 +55,9 @@ func (d *DeltaMany[T, deltaT]) UnmarshalJSON(data []byte) error {
 		UnlinkedItems *DeltaChunk[T, deltaT]
 		AllItems      *DeltaChunk[ManyItem[T], DeltaManyItem[T, deltaT]]
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase

--- a/backend/libraries/ballerina-core-go/delta_primitive.go
+++ b/backend/libraries/ballerina-core-go/delta_primitive.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 	"time"
 
@@ -44,7 +45,9 @@ func (d *DeltaInt) UnmarshalJSON(data []byte) error {
 		Discriminator deltaIntEffectsEnum
 		Replace       int
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase
@@ -111,7 +114,9 @@ func (d *DeltaInt64) UnmarshalJSON(data []byte) error {
 		Discriminator deltaInt64EffectsEnum
 		Replace       int64
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase
@@ -178,7 +183,9 @@ func (d *DeltaString) UnmarshalJSON(data []byte) error {
 		Discriminator deltaStringEffectsEnum
 		Replace       string
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase
@@ -245,7 +252,9 @@ func (d *DeltaBool) UnmarshalJSON(data []byte) error {
 		Discriminator deltaBoolEffectsEnum
 		Replace       bool
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase
@@ -312,7 +321,9 @@ func (d *DeltaGuid) UnmarshalJSON(data []byte) error {
 		Discriminator deltaGuidEffectsEnum
 		Replace       uuid.UUID
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase
@@ -383,7 +394,9 @@ func (d *DeltaTime) UnmarshalJSON(data []byte) error {
 		Discriminator deltaTimeEffectsEnum
 		Replace       time.Time
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase
@@ -450,7 +463,9 @@ func (d *DeltaInt32) UnmarshalJSON(data []byte) error {
 		Discriminator deltaInt32EffectsEnum
 		Replace       int32
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase
@@ -519,7 +534,9 @@ func (d *DeltaFloat32) UnmarshalJSON(data []byte) error {
 		Discriminator deltaFloat32EffectsEnum
 		Replace       float32
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase
@@ -588,7 +605,9 @@ func (d *DeltaFloat64) UnmarshalJSON(data []byte) error {
 		Discriminator deltaFloat64EffectsEnum
 		Replace       float64
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase

--- a/backend/libraries/ballerina-core-go/delta_set.go
+++ b/backend/libraries/ballerina-core-go/delta_set.go
@@ -1,6 +1,9 @@
 package ballerina
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+)
 
 type deltaSetEffectsEnum string
 
@@ -49,7 +52,9 @@ func (d *DeltaSet[a, deltaA]) UnmarshalJSON(data []byte) error {
 		Add           *a
 		Remove        *a
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase

--- a/backend/libraries/ballerina-core-go/delta_sum.go
+++ b/backend/libraries/ballerina-core-go/delta_sum.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -52,7 +53,9 @@ func (d *DeltaSum[a, b, deltaA, deltaB]) UnmarshalJSON(data []byte) error {
 		Left          *deltaA
 		Right         *deltaB
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase

--- a/backend/libraries/ballerina-core-go/delta_table.go
+++ b/backend/libraries/ballerina-core-go/delta_table.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"github.com/google/uuid"
@@ -69,7 +70,9 @@ func (d *DeltaTable[a, deltaA]) UnmarshalJSON(data []byte) error {
 		DuplicateAt   *uuid.UUID
 		Add           *a
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.DeltaBase = aux.DeltaBase

--- a/backend/libraries/ballerina-core-go/filter_contains.go
+++ b/backend/libraries/ballerina-core-go/filter_contains.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -31,7 +32,9 @@ func (d *Contains[T]) UnmarshalJSON(data []byte) error {
 	var aux struct {
 		Contains T
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.contains = aux.Contains

--- a/backend/libraries/ballerina-core-go/filter_equal_to.go
+++ b/backend/libraries/ballerina-core-go/filter_equal_to.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -31,7 +32,9 @@ func (d *EqualsTo[T]) UnmarshalJSON(data []byte) error {
 	var aux struct {
 		EqualsTo T
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.equalsTo = aux.EqualsTo

--- a/backend/libraries/ballerina-core-go/filter_greater_than.go
+++ b/backend/libraries/ballerina-core-go/filter_greater_than.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -31,7 +32,9 @@ func (d *GreaterThan[T]) UnmarshalJSON(data []byte) error {
 	var aux struct {
 		GreaterThan T
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.greaterThan = aux.GreaterThan

--- a/backend/libraries/ballerina-core-go/filter_greater_than_or_equal.go
+++ b/backend/libraries/ballerina-core-go/filter_greater_than_or_equal.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -31,7 +32,9 @@ func (d *GreaterThanOrEqualsTo[T]) UnmarshalJSON(data []byte) error {
 	var aux struct {
 		GreaterThanOrEqualsTo T
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.greaterThanOrEqualsTo = aux.GreaterThanOrEqualsTo

--- a/backend/libraries/ballerina-core-go/filter_is_not_null.go
+++ b/backend/libraries/ballerina-core-go/filter_is_not_null.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -27,7 +28,9 @@ func (d *IsNotNull[T]) UnmarshalJSON(data []byte) error {
 	var aux struct {
 		IsNotNull Unit
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	return nil

--- a/backend/libraries/ballerina-core-go/filter_is_null.go
+++ b/backend/libraries/ballerina-core-go/filter_is_null.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -27,7 +28,9 @@ func (d *IsNull[T]) UnmarshalJSON(data []byte) error {
 	var aux struct {
 		IsNull Unit
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	return nil

--- a/backend/libraries/ballerina-core-go/filter_not_equal_to.go
+++ b/backend/libraries/ballerina-core-go/filter_not_equal_to.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -31,7 +32,9 @@ func (d *NotEqualsTo[T]) UnmarshalJSON(data []byte) error {
 	var aux struct {
 		NotEqualsTo T
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.notEqualsTo = aux.NotEqualsTo

--- a/backend/libraries/ballerina-core-go/filter_smaller_than.go
+++ b/backend/libraries/ballerina-core-go/filter_smaller_than.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -31,7 +32,9 @@ func (d *SmallerThan[T]) UnmarshalJSON(data []byte) error {
 	var aux struct {
 		SmallerThan T
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.smallerThan = aux.SmallerThan

--- a/backend/libraries/ballerina-core-go/filter_smaller_than_or_equal.go
+++ b/backend/libraries/ballerina-core-go/filter_smaller_than_or_equal.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -31,7 +32,9 @@ func (d *SmallerThanOrEqualsTo[T]) UnmarshalJSON(data []byte) error {
 	var aux struct {
 		SmallerThanOrEqualsTo T
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.smallerThanOrEqualsTo = aux.SmallerThanOrEqualsTo

--- a/backend/libraries/ballerina-core-go/filter_starts_with.go
+++ b/backend/libraries/ballerina-core-go/filter_starts_with.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -31,7 +32,9 @@ func (d *StartsWith[T]) UnmarshalJSON(data []byte) error {
 	var aux struct {
 		StartsWith T
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.startsWith = aux.StartsWith

--- a/backend/libraries/ballerina-core-go/sum1.go
+++ b/backend/libraries/ballerina-core-go/sum1.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -58,7 +59,9 @@ func (d *Sum1[case1]) UnmarshalJSON(data []byte) error {
 		Discriminator sum1CasesEnum
 		Case1         *case1
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.discriminator = aux.Discriminator

--- a/backend/libraries/ballerina-core-go/sum10.go
+++ b/backend/libraries/ballerina-core-go/sum10.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -196,7 +197,9 @@ func (d *Sum10[case1, case2, case3, case4, case5, case6, case7, case8, case9, ca
 		Case9         *case9
 		Case10        *case10
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.discriminator = aux.Discriminator

--- a/backend/libraries/ballerina-core-go/sum2.go
+++ b/backend/libraries/ballerina-core-go/sum2.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -70,7 +71,9 @@ func (d *Sum2[case1, case2]) UnmarshalJSON(data []byte) error {
 		Case1         *case1
 		Case2         *case2
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.discriminator = aux.Discriminator

--- a/backend/libraries/ballerina-core-go/sum3.go
+++ b/backend/libraries/ballerina-core-go/sum3.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -84,7 +85,9 @@ func (d *Sum3[case1, case2, case3]) UnmarshalJSON(data []byte) error {
 		Case2         *case2
 		Case3         *case3
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.discriminator = aux.Discriminator

--- a/backend/libraries/ballerina-core-go/sum4.go
+++ b/backend/libraries/ballerina-core-go/sum4.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -103,7 +104,9 @@ func (d *Sum4[case1, case2, case3, case4]) UnmarshalJSON(data []byte) error {
 		Case3         *case3
 		Case4         *case4
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.discriminator = aux.Discriminator

--- a/backend/libraries/ballerina-core-go/sum5.go
+++ b/backend/libraries/ballerina-core-go/sum5.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -118,7 +119,9 @@ func (d *Sum5[case1, case2, case3, case4, case5]) UnmarshalJSON(data []byte) err
 		Case4         *case4
 		Case5         *case5
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.discriminator = aux.Discriminator

--- a/backend/libraries/ballerina-core-go/sum6.go
+++ b/backend/libraries/ballerina-core-go/sum6.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -133,7 +134,9 @@ func (d *Sum6[case1, case2, case3, case4, case5, case6]) UnmarshalJSON(data []by
 		Case5         *case5
 		Case6         *case6
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.discriminator = aux.Discriminator

--- a/backend/libraries/ballerina-core-go/sum7.go
+++ b/backend/libraries/ballerina-core-go/sum7.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -148,7 +149,9 @@ func (d *Sum7[case1, case2, case3, case4, case5, case6, case7]) UnmarshalJSON(da
 		Case6         *case6
 		Case7         *case7
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.discriminator = aux.Discriminator

--- a/backend/libraries/ballerina-core-go/sum8.go
+++ b/backend/libraries/ballerina-core-go/sum8.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -163,7 +164,9 @@ func (d *Sum8[case1, case2, case3, case4, case5, case6, case7, case8]) Unmarshal
 		Case7         *case7
 		Case8         *case8
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.discriminator = aux.Discriminator

--- a/backend/libraries/ballerina-core-go/sum9.go
+++ b/backend/libraries/ballerina-core-go/sum9.go
@@ -1,6 +1,7 @@
 package ballerina
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -178,7 +179,9 @@ func (d *Sum9[case1, case2, case3, case4, case5, case6, case7, case8, case9]) Un
 		Case8         *case8
 		Case9         *case9
 	}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&aux); err != nil {
 		return err
 	}
 	d.discriminator = aux.Discriminator


### PR DESCRIPTION
Nasty one:
Go doesn't complain if fields are missing or if there are unrecognized fields. This fixes half of the problem