### PR TITLE
Add Email::send stdlib extension with integration test

### DIFF
--- a/backend/apps/ballerina-samples-integration-test/Program.fs
+++ b/backend/apps/ballerina-samples-integration-test/Program.fs
@@ -22,7 +22,8 @@ type RuntimeValueExt = ValueExt<unit, MutableMemoryDB<unit, unit>, unit>
 type ProjectExecutionSuccess =
   { Value: Value<TypeValue<RuntimeValueExt>, RuntimeValueExt>
     TypeValue: TypeValue<RuntimeValueExt>
-    ExpressionCount: int }
+    ExpressionCount: int
+    EmailEvents: string list }
 
 [<CLIMutable>]
 type SampleExpectationDto =
@@ -69,9 +70,13 @@ let private expectations =
 let private buildAndEvalProject
   (project: ProjectBuildConfiguration)
   : Sum<ProjectExecutionSuccess, string> =
+  let emailEvents = ResizeArray<string>()
+
   let _, context, typeCheckingConfig, buildCache =
     hddcacheWithStdExtensions<unit, MutableMemoryDB<unit, unit>>
       (Ballerina.DSL.Next.StdLib.String.Extension.StringTypeClass<_>.Console())
+      (Ballerina.DSL.Next.StdLib.Email.Extension.EmailTypeClass<_>.FromRuntimeContext(fun _ toEmail subject body ->
+        emailEvents.Add($"email_send|to={toEmail}|subject={subject}|body={body}")))
       (db_ops ())
       id
       id
@@ -95,7 +100,8 @@ let private buildAndEvalProject
       Left
         { Value = value
           TypeValue = typeValue
-          ExpressionCount = NonEmptyList.ToList exprs |> List.length }
+          ExpressionCount = NonEmptyList.ToList exprs |> List.length
+          EmailEvents = emailEvents |> Seq.toList }
     | Right e -> Right(sprintf "Evaluation failed: %s" (Errors.ToString(e, "\n")))
   | Right e -> Right(sprintf "Build failed: %s" (Errors.ToString(e, "\n")))
 
@@ -117,7 +123,14 @@ let private validateExpectation
   : bool * string =
   match expectation, executionResult with
   | expectation, Left result when expectation.Mode = "run" || expectation.Mode = "success" ->
-    let valueText = result.Value.AsFSharpString
+    let valueText =
+      let events = result.EmailEvents |> String.concat "\n"
+
+      if String.IsNullOrWhiteSpace(events) then
+        result.Value.AsFSharpString
+      else
+        $"{result.Value.AsFSharpString}\n{events}"
+
     let typeText = result.TypeValue.AsFSharpString
     let valueOk, missingValue = matchesAll expectation.ValueRegexes valueText
     let typeOk, missingType = matchesAll expectation.TypeRegexes typeText

--- a/backend/apps/ballerina-samples-integration-test/sample-expectations.json
+++ b/backend/apps/ballerina-samples-integration-test/sample-expectations.json
@@ -122,6 +122,15 @@
         "Malformed type declaration for 'Broken' at 20-malformed-type-after-many-definitions-integration.bl:31:5",
         "while parsing 20-malformed-type-after-many-definitions-integration.bl"
       ]
+    },
+    "21-email-send-integration": {
+      "mode": "run",
+      "valueRegexes": [
+          "Primitive \\(Bool true\\)",
+        "email_send\\|to=alice@example.com\\|subject=Integration Subject\\|body=Hello from integration sample"
+      ],
+      "typeRegexes": ["Primitive.*Bool"],
+      "errorRegexes": []
     }
   }
 }

--- a/backend/libraries/ballerina-api-filedb-factory/MemoryDBFactory.fs
+++ b/backend/libraries/ballerina-api-filedb-factory/MemoryDBFactory.fs
@@ -33,6 +33,7 @@ module MemoryDBAPIFactory =
   let contextFactory dbFileConfig =
     hddcacheWithStdExtensions
       (Ballerina.DSL.Next.StdLib.String.Extension.StringTypeClass<_>.Console())
+      (Ballerina.DSL.Next.StdLib.Email.Extension.EmailTypeClass<_>.Console())
       (fileDbOps dbFileConfig)
       id
       id

--- a/backend/libraries/ballerina-api-filedb-factory/Utils.fs
+++ b/backend/libraries/ballerina-api-filedb-factory/Utils.fs
@@ -27,6 +27,7 @@ module Utils =
   let contextFactory (dbFileConfig: DbFileConfig) =
     hddcacheWithStdExtensions
       (Ballerina.DSL.Next.StdLib.String.Extension.StringTypeClass<_>.Console())
+      (Ballerina.DSL.Next.StdLib.Email.Extension.EmailTypeClass<_>.Console())
       (fileDbOps dbFileConfig)
       id
       id
@@ -51,6 +52,7 @@ module Utils =
         hddcacheWithStdExtensions
           (Ballerina.DSL.Next.StdLib.String.Extension.StringTypeClass<_>
             .Console())
+          (Ballerina.DSL.Next.StdLib.Email.Extension.EmailTypeClass<_>.Console())
           (fileDbOps dbFileConfig)
           (TypeCheckContext.Updaters.BackgroundHooksExtraScope
             addBackgroundHookScope

--- a/backend/libraries/ballerina-lang-build/HddCache.fs
+++ b/backend/libraries/ballerina-lang-build/HddCache.fs
@@ -10,6 +10,7 @@ module HddCache =
   open Ballerina.DSL.Next.Types.TypeChecker.Expr
   open Ballerina.DSL.Next.StdLib.DB.Model
   open Ballerina.DSL.Next.StdLib.Extensions
+  open Ballerina.DSL.Next.StdLib.Email.Extension
   open Ballerina.DSL.Next.StdLib.String.Extension
   open Ballerina.Serialization.MessagePack
   open System.IO
@@ -217,6 +218,7 @@ module HddCache =
 
   let hddcacheWithStdExtensions<'runtimeContext, 'db when 'db: comparison>
     (stringOps: StringTypeClass<ValueExt<'runtimeContext, 'db, unit>>)
+    (emailOps: EmailTypeClass<'runtimeContext>)
     (dbOps:
       DBTypeClass<'runtimeContext, 'db, ValueExt<'runtimeContext, 'db, unit>>)
     (updateTypeCheckContext:
@@ -235,8 +237,13 @@ module HddCache =
     let extensions, languageContext, effectiveTypeCheckingConfig =
       match deserializedTypeCheckingConfig with
       | Some typeCheckingConfig ->
-        stdExtensions<'runtimeContext, 'db> stringOps dbOps typeCheckingConfig
-      | None -> bootstrapStdExtensions<'runtimeContext, 'db> stringOps dbOps
+        stdExtensions<'runtimeContext, 'db>
+          stringOps
+          emailOps
+          dbOps
+          typeCheckingConfig
+      | None ->
+        bootstrapStdExtensions<'runtimeContext, 'db> stringOps emailOps dbOps
 
     let languageContext =
       { languageContext with

--- a/backend/libraries/ballerina-lang-build/Project.fs
+++ b/backend/libraries/ballerina-lang-build/Project.fs
@@ -40,6 +40,10 @@ module Project =
       Ballerina.DSL.Next.StdLib.String.Extension.StringTypeClass<
         Ballerina.DSL.Next.StdLib.Extensions.ValueExt<'runtimeContext, 'db, unit>
        >)
+    (emailOps:
+      Ballerina.DSL.Next.StdLib.Email.Extension.EmailTypeClass<
+        'runtimeContext
+       >)
     (dbOps:
       Ballerina.DSL.Next.StdLib.DB.Model.DBTypeClass<
         'runtimeContext,
@@ -71,6 +75,7 @@ module Project =
     =
     HddCache.hddcacheWithStdExtensions
       stringOps
+      emailOps
       dbOps
       updateTypeCheckContext
       updateTypeCheckState

--- a/backend/libraries/ballerina-lang/Next/Stdlib/Email/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Email/Extension.fs
@@ -1,0 +1,110 @@
+namespace Ballerina.DSL.Next.StdLib.Email
+
+[<AutoOpen>]
+module Extension =
+  open Ballerina
+  open Ballerina.Collections.Sum
+  open Ballerina.Reader.WithError
+  open Ballerina.LocalizedErrors
+  open Ballerina.Errors
+  open Ballerina.DSL.Next.Terms.Model
+  open Ballerina.DSL.Next.Terms.Patterns
+  open Ballerina.DSL.Next.Types.Model
+  open Ballerina.DSL.Next.Types.Patterns
+  open Ballerina.Lenses
+  open Ballerina.DSL.Next.Extensions
+
+  type EmailTypeClass<'runtimeContext> =
+    { send: 'runtimeContext -> string -> string -> string -> unit }
+
+    static member Console() : EmailTypeClass<'runtimeContext> =
+      { send =
+          fun _ toEmail subject body ->
+            System.Console.WriteLine(
+              $"Email::send to={toEmail} subject={subject} body={body}"
+            ) }
+
+    static member FromRuntimeContext
+      (send: 'runtimeContext -> string -> string -> string -> unit)
+      : EmailTypeClass<'runtimeContext> =
+      { send = send }
+
+  let EmailExtension<'runtimeContext, 'ext>
+    (email_ops: EmailTypeClass<'runtimeContext>)
+    (operationLens: PartialLens<'ext, EmailOperations<'ext>>)
+    : OperationsExtension<'runtimeContext, 'ext, EmailOperations<'ext>> =
+
+    let stringTypeValue = TypeValue.CreateString()
+    let unitTypeValue = TypeValue.CreatePrimitive PrimitiveType.Unit
+
+    let emailSendId =
+      Identifier.FullyQualified([ "Email" ], "send")
+      |> TypeCheckScope.Empty.Resolve
+
+    let sendOperation
+      : ResolvedIdentifier *
+        OperationExtension<'runtimeContext, 'ext, EmailOperations<'ext>> =
+      emailSendId,
+      { PublicIdentifiers =
+          Some
+          <| (TypeValue.CreateArrow(
+                stringTypeValue,
+                TypeValue.CreateArrow(
+                  stringTypeValue,
+                  TypeValue.CreateArrow(stringTypeValue, unitTypeValue)
+                )
+              ),
+              Kind.Star,
+              EmailOperations.Send
+                {| toEmail = None
+                   subject = None |})
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | EmailOperations.Send state -> Some(EmailOperations.Send state))
+        Apply =
+          fun loc0 _rest (op, v) ->
+            reader {
+              let! state =
+                op
+                |> EmailOperations.AsSend
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              let! v =
+                v
+                |> Value.AsPrimitive
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              let! arg =
+                v
+                |> PrimitiveValue.AsString
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              match state.toEmail, state.subject with
+              | None, _ ->
+                return
+                  (EmailOperations.Send
+                    {| toEmail = Some arg
+                       subject = None |}
+                   |> operationLens.Set,
+                   Some emailSendId)
+                  |> Ext
+              | Some toEmail, None ->
+                return
+                  (EmailOperations.Send
+                    {| toEmail = Some toEmail
+                       subject = Some arg |}
+                   |> operationLens.Set,
+                   Some emailSendId)
+                  |> Ext
+              | Some toEmail, Some subject ->
+                let! ctx = reader.GetContext()
+                do email_ops.send ctx.RuntimeContext toEmail subject arg
+                return Value<TypeValue<'ext>, 'ext>.Primitive(PrimitiveValue.Unit)
+            } }
+
+    { TypeVars = []
+      Operations = [ sendOperation ] |> Map.ofList }

--- a/backend/libraries/ballerina-lang/Next/Stdlib/Email/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Email/Model.fs
@@ -1,0 +1,6 @@
+namespace Ballerina.DSL.Next.StdLib.Email
+
+[<AutoOpen>]
+module Model =
+  type EmailOperations<'ext> =
+    | Send of {| toEmail: Option<string>; subject: Option<string> |}

--- a/backend/libraries/ballerina-lang/Next/Stdlib/Email/Patterns.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Email/Patterns.fs
@@ -1,0 +1,14 @@
+namespace Ballerina.DSL.Next.StdLib.Email
+
+[<AutoOpen>]
+module Patterns =
+  open Ballerina
+  open Ballerina.Collections.Sum
+  open Ballerina.Errors
+
+  type EmailOperations<'ext> with
+    static member AsSend
+      (op: EmailOperations<'ext>)
+      : Sum<{| toEmail: Option<string>; subject: Option<string> |}, Errors<Unit>> =
+      match op with
+      | EmailOperations.Send state -> sum.Return state

--- a/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
@@ -13,6 +13,7 @@ open Ballerina.DSL.Next.StdLib.List.Model
 open Ballerina.DSL.Next.StdLib.Map.Model
 open Ballerina.DSL.Next.StdLib.DB
 open Ballerina.Data.Delta
+open Ballerina.DSL.Next.StdLib.Email
 open Ballerina.DSL.Next.StdLib.String
 open Ballerina.DSL.Next.Types.TypeChecker.Model
 open Ballerina.DSL.Next.StdLib.DB.Extension.DBRun
@@ -237,6 +238,10 @@ and PrimitiveExt<'runtimeContext, 'db, 'customExtension
     Decimal.Model.DecimalOperations<
       ValueExt<'runtimeContext, 'db, 'customExtension>
      >
+  | EmailOperations of
+    Email.Model.EmailOperations<
+      ValueExt<'runtimeContext, 'db, 'customExtension>
+     >
   | StringOperations of
     String.Model.StringOperations<
       ValueExt<'runtimeContext, 'db, 'customExtension>
@@ -250,6 +255,7 @@ and PrimitiveExt<'runtimeContext, 'db, 'customExtension
     | Float32Operations ops -> ops.ToString()
     | Float64Operations ops -> ops.ToString()
     | DecimalOperations ops -> ops.ToString()
+    | EmailOperations ops -> ops.ToString()
     | StringOperations ops -> ops.ToString()
 
 and DeltaExt<'runtimeContext, 'db, 'customExtension
@@ -658,6 +664,7 @@ type StdExtensions<'runtimeContext, 'valueExt, 'valueExtDTO, 'deltaExt, 'deltaEx
 let makeExtensions<'runtimeContext, 'db, 'customExtension
   when 'db: comparison and 'customExtension: comparison>
   (string_ops: StringTypeClass<ValueExt<'runtimeContext, 'db, 'customExtension>>)
+  (email_ops: EmailTypeClass<'runtimeContext>)
   (db_ops:
     DBTypeClass<
       'runtimeContext,
@@ -859,6 +866,18 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
           | _ -> None
         Set = StringOperations >> Choice3Of7 >> ValueExt.ValueExt }
 
+  let emailExtension =
+    Email.Extension.EmailExtension<
+      'runtimeContext,
+      ValueExt<'runtimeContext, 'db, 'customExtension>
+     >
+      email_ops
+      { Get =
+          function
+          | ValueExt(Choice3Of7(EmailOperations x)) -> Some x
+          | _ -> None
+        Set = EmailOperations >> Choice3Of7 >> ValueExt.ValueExt }
+
   let guidExtension =
     Guid.Extension.GuidExtension<
       'runtimeContext,
@@ -943,6 +962,7 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
     |> (float32Extension |> OperationsExtension.RegisterLanguageContext)
     |> (float64Extension |> OperationsExtension.RegisterLanguageContext)
     |> (decimalExtension |> OperationsExtension.RegisterLanguageContext)
+    |> (emailExtension |> OperationsExtension.RegisterLanguageContext)
     |> (stringExtension |> OperationsExtension.RegisterLanguageContext)
     |> (updaterExtension |> OperationsExtension.RegisterLanguageContext)
     |> (mapExtension |> TypeExtension.RegisterLanguageContext)
@@ -972,25 +992,13 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
   extensions, context, typeCheckingConfig
 
 let stdExtensions<'runtimeContext, 'db when 'db: comparison> =
-  fun str_ops db_ops typeCheckingConfig ->
+  fun str_ops email_ops db_ops typeCheckingConfig ->
     makeExtensions<'runtimeContext, 'db, unit>
       str_ops
-      db_ops
-      (Some typeCheckingConfig)
-
-let customStdExtensions<'runtimeContext, 'db, 'customExtension
-  when 'db: comparison and 'customExtension: comparison> =
-  fun str_ops db_ops typeCheckingConfig ->
-    makeExtensions<'runtimeContext, 'db, 'customExtension>
-      str_ops
+      email_ops
       db_ops
       (Some typeCheckingConfig)
 
 let bootstrapStdExtensions<'runtimeContext, 'db when 'db: comparison> =
-  fun str_ops db_ops ->
-    makeExtensions<'runtimeContext, 'db, unit> str_ops db_ops None
-
-let bootstrapCustomStdExtensions<'runtimeContext, 'db, 'customExtension
-  when 'db: comparison and 'customExtension: comparison> =
-  fun str_ops db_ops ->
-    makeExtensions<'runtimeContext, 'db, 'customExtension> str_ops db_ops None
+  fun str_ops email_ops db_ops ->
+    makeExtensions<'runtimeContext, 'db, unit> str_ops email_ops db_ops None

--- a/backend/libraries/ballerina-lang/Next/Stdlib/ballerina-lang-stdlib.fsproj
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/ballerina-lang-stdlib.fsproj
@@ -29,6 +29,9 @@
     <Compile Include="Decimal/Model.fs" />
     <Compile Include="Decimal/Patterns.fs" />
     <Compile Include="Decimal/Extension.fs" />
+    <Compile Include="Email/Model.fs" />
+    <Compile Include="Email/Patterns.fs" />
+    <Compile Include="Email/Extension.fs" />
     <Compile Include="String/Model.fs" />
     <Compile Include="String/Patterns.fs" />
     <Compile Include="String/Extension.fs" />

--- a/ballerina/build.fs
+++ b/ballerina/build.fs
@@ -23,6 +23,7 @@ type ValueExt = ValueExt<unit, MutableMemoryDB<unit, unit>, unit>
 let private buildContext, languageContext, typeCheckingConfig, buildCache =
   hddcacheWithStdExtensions<unit, MutableMemoryDB<unit, unit>>
     (Ballerina.DSL.Next.StdLib.String.Extension.StringTypeClass<_>.Console())
+    (Ballerina.DSL.Next.StdLib.Email.Extension.EmailTypeClass<_>.Console())
     (db_ops ())
     id
     id

--- a/samples/21-email-send-integration.bl
+++ b/samples/21-email-send-integration.bl
@@ -1,0 +1,6 @@
+// Ballerina Integration Sample 21: Email extension callback
+//
+// This verifies Email::send is correctly wired in runtime extension dispatch.
+
+let _ = Email::send "alice@example.com" "Integration Subject" "Hello from integration sample";
+true

--- a/samples/21-email-send-integration.blproj
+++ b/samples/21-email-send-integration.blproj
@@ -1,0 +1,5 @@
+{
+  "name": "email-send-integration",
+  "sources": ["21-email-send-integration.bl"],
+  "inputProjects": []
+}


### PR DESCRIPTION
## Summary
- add `Email::send` stdlib operation with runtime callback typeclass
- wire email extension through std extension bootstrap/cache entrypoints
- add integration sample `21-email-send-integration`
- capture email callback events in samples integration harness and assert via expectations
- remove unused custom std-extension entrypoints

## Validation
- `dotnet build backend/backend.sln -v minimal`
- `dotnet run --project backend/apps/ballerina-samples-integration-test/ballerina-samples-integration-test.fsproj -- --verbose` (21/21 passed)
