### PR TITLE
Add parser error recovery infrastructure and dangling record destructure recovery

### DIFF
--- a/backend/apps/ballerina-samples-integration-test/sample-expectations.json
+++ b/backend/apps/ballerina-samples-integration-test/sample-expectations.json
@@ -131,6 +131,21 @@
       ],
       "typeRegexes": ["Primitive.*Bool"],
       "errorRegexes": []
+    },
+    "99-error-recovery-integration": {
+      "mode": "build-fails",
+      "valueRegexes": [],
+      "typeRegexes": [],
+      "errorRegexes": ["Expected 'in' or ';' after type let declaration", "while typechecking"]
+    },
+    "100-error-recovery-dangling-record-des": {
+      "mode": "build-fails",
+      "valueRegexes": [],
+      "typeRegexes": [],
+      "errorRegexes": [
+        "Expected field name or tuple index after '.'",
+        "while typechecking"
+      ]
     }
   }
 }

--- a/backend/libraries/ballerina-lang/Next/Eval/Expr_TypeEval.fs
+++ b/backend/libraries/ballerina-lang/Next/Eval/Expr_TypeEval.fs
@@ -240,4 +240,9 @@ module TypeEval =
               Errors.Singleton expr.Location (fun () ->
                 $"Error (typecheck): not yet implemented expression pattern query")
               |> state.Throw
+
+          | ExprRec.RecoveredSyntaxError err ->
+            return!
+              Errors.Singleton err.ErrorLocation (fun () -> err.ErrorMessage)
+              |> state.Throw
         }

--- a/backend/libraries/ballerina-lang/Next/Models/Types.fs
+++ b/backend/libraries/ballerina-lang/Next/Models/Types.fs
@@ -1496,6 +1496,14 @@ module Model =
       | Some t -> $"{self.Var}: {t} in {self.Source}"
       | None -> $"{self.Var} in {self.Source}"
 
+  and ExprRecoveredSyntaxError<'T, 'Id, 'valueExt when 'Id: comparison> =
+    { ErrorMessage: string
+      ErrorLocation: Location
+      RecoveryContext: string }
+
+    override self.ToString() =
+      $"<SyntaxError: {self.ErrorMessage}>"
+
   and ExprRec<'T, 'Id, 'valueExt when 'Id: comparison> =
     | Primitive of PrimitiveValue
     | Lookup of ExprLookup<'T, 'Id, 'valueExt>
@@ -1522,6 +1530,7 @@ module Model =
     | TupleDes of ExprTupleDes<'T, 'Id, 'valueExt>
     | SumDes of ExprSumDes<'T, 'Id, 'valueExt>
     | Query of ExprQuery<'T, 'Id, 'valueExt>
+    | RecoveredSyntaxError of ExprRecoveredSyntaxError<'T, 'Id, 'valueExt>
 
     override self.ToString() : string =
       match self with
@@ -1630,6 +1639,7 @@ module Model =
         $"(if {cond.ToString()} then {thenExpr.ToString()} else {elseExpr.ToString()})"
 
       | Query q -> q.ToString()
+      | RecoveredSyntaxError err -> err.ToString()
 
 
   and Expr<'T, 'Id, 'valueExt when 'Id: comparison> =

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Expr.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Expr.fs
@@ -34,6 +34,7 @@ module Expr =
   type ComplexExpression<'valueExt> =
     | ScopedIdentifier of NonEmptyList<string>
     | RecordOrTupleDesChain of NonEmptyList<Sum<string, int>>
+    | DanglingRecordDes of Location
     | TupleCons of
       NonEmptyList<Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>>
     | ApplicationArguments of
@@ -580,19 +581,38 @@ module Expr =
 
         return!
           parser {
-            let! fields =
-              parser.AtLeastOne(
-                parser {
-                  do! dotOperator
+            do! dotOperator
+            let! dotLoc = parser.Location
 
-                  return!
-                    parser.Any
-                      [ singleIdentifier |> parser.Map Left
-                        intLiteralToken () |> parser.Map Right ]
-                }
-              )
+            let! firstFieldOrRecover =
+              parser.Any
+                [ singleIdentifier |> parser.Map(Left >> Some)
+                  intLiteralToken () |> parser.Map(Right >> Some)
+                  parser { return None } ]
 
-            return fields |> ComplexExpression.RecordOrTupleDesChain
+            match firstFieldOrRecover with
+            | Some firstField ->
+              let! tailFields =
+                parser.AtLeastOne(
+                  parser {
+                    do! dotOperator
+
+                    return!
+                      parser.Any
+                        [ singleIdentifier |> parser.Map Left
+                          intLiteralToken () |> parser.Map Right ]
+                  }
+                )
+                |> parser.Try
+
+              let fields =
+                match tailFields with
+                | Left tail -> NonEmptyList.OfList(firstField, tail |> NonEmptyList.ToList)
+                | Right _ -> NonEmptyList.OfList(firstField, [])
+
+              return fields |> ComplexExpression.RecordOrTupleDesChain
+            | None ->
+              return dotLoc |> ComplexExpression.DanglingRecordDes
           }
           |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
       }
@@ -625,15 +645,11 @@ module Expr =
 
         let! loc' = parser.Location
 
-        do!
+        let! hasSeparator =
           parser.Any
-            [ inKeyword
-              semicolonOperator
-              (fun () -> "Expected 'in' or ';' after type let declaration")
-              |> Errors.Singleton loc'
-              |> Errors.MapPriority(replaceWith ErrorPriority.High)
-              |> parser.Throw ]
-          |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
+            [ inKeyword |> parser.Map(fun _ -> true)
+              semicolonOperator |> parser.Map(fun _ -> true)
+              parser { return false } ]
 
         let! body =
           parseBoundBody ()
@@ -662,6 +678,20 @@ module Expr =
           | _ -> [], SymbolsKind.RecordFields
 
         let typeDecl = TypeExpr.LetSymbols(symbols, symbolsKind, typeDecl)
+
+        let body =
+          if hasSeparator then
+            body
+          else
+            Expr.Do(
+              createRecoveredError
+                "Expected 'in' or ';' after type let declaration"
+                loc'
+                "missing_separator_after_type_let",
+              body,
+              loc',
+              TypeCheckScope.Empty
+            )
 
         return Expr.TypeLet(id, typeDecl, body, loc, TypeCheckScope.Empty)
       }
@@ -1109,6 +1139,17 @@ module Expr =
                             TypeCheckScope.Empty
                           ))
                       acc
+                | DanglingRecordDes errorLoc ->
+                  return
+                    Expr.Do(
+                      createRecoveredError
+                        "Expected field name or tuple index after '.'"
+                        errorLoc
+                        "dangling_record_destructure",
+                      acc,
+                      errorLoc,
+                      TypeCheckScope.Empty
+                    )
                 | TupleCons fields ->
                   return
                     Expr.TupleCons(

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Recovery.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Recovery.fs
@@ -1,0 +1,33 @@
+namespace Ballerina.DSL.Next.Syntax.Parser
+
+[<AutoOpen>]
+module Recovery =
+
+  open Ballerina.Parser
+  open Ballerina
+  open Ballerina.DSL.Next.Types.Model
+  open Ballerina.LocalizedErrors
+  open Ballerina.Errors
+  open Model
+  open Common
+
+  /// Create a RecoveredSyntaxError expression node.
+  /// Use this in the parser whenever a required token is missing but parsing
+  /// can still meaningfully continue.  The typechecker will surface the error
+  /// when it reaches the node.
+  let createRecoveredError
+    (errorMessage: string)
+    (errorLocation: Location)
+    (recoveryContext: string)
+    : Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>
+    =
+    let errorData: ExprRecoveredSyntaxError<TypeExpr<'valueExt>, Identifier, 'valueExt> =
+      { ErrorMessage = errorMessage
+        ErrorLocation = errorLocation
+        RecoveryContext = recoveryContext }
+
+    { Expr = ExprRec.RecoveredSyntaxError(errorData)
+      Scope = TypeCheckScope.Empty
+      Location = errorLocation }
+
+

--- a/backend/libraries/ballerina-lang/Next/Syntax/ballerina-lang-parser.fsproj
+++ b/backend/libraries/ballerina-lang/Next/Syntax/ballerina-lang-parser.fsproj
@@ -8,6 +8,7 @@
     <Compile Include="Parser/Precedence.fs" />
     <Compile Include="Parser/Common.fs" />
     <Compile Include="Parser/Kind.fs" />
+    <Compile Include="Parser/Recovery.fs" />
     <Compile Include="Parser/Type/HooksAndProperties.fs" />
     <Compile Include="Parser/Type/Schema.fs" />
     <Compile Include="Parser/Type.fs" />

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/Expr.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/Expr.fs
@@ -231,6 +231,11 @@ module Expr =
                     q
 
                 return TypeCheckedExpr.Query(q, t, k), ctx
+
+              | ExprRec.RecoveredSyntaxError err ->
+                return!
+                  Errors.Singleton err.ErrorLocation (fun () -> err.ErrorMessage)
+                  |> state.Throw
             }
 
           let! expr =

--- a/samples/100-error-recovery-dangling-record-des.bl
+++ b/samples/100-error-recovery-dangling-record-des.bl
@@ -1,0 +1,9 @@
+// Error recovery: dangling record destructure
+type Person = { Name: string };
+let person: Person = { Name = "Alice" };
+
+person.
+
+do string::print "This should not affect the dangling record decomposition.";
+
+()

--- a/samples/100-error-recovery-dangling-record-des.blproj
+++ b/samples/100-error-recovery-dangling-record-des.blproj
@@ -1,0 +1,5 @@
+{
+  "name": "error-recovery-dangling-record-des",
+  "sources": ["100-error-recovery-dangling-record-des.bl"],
+  "inputProjects": []
+}

--- a/samples/99-error-recovery-integration.bl
+++ b/samples/99-error-recovery-integration.bl
@@ -1,0 +1,13 @@
+// Error recovery integration test
+// This sample demonstrates the parser's ability to recover from syntax errors
+// and provide partial ASTs for better Intellisense and error messages
+
+// Test 1: Missing semicolon in let binding (should recover)
+type Person = {
+  name: string;
+  age: int32
+}
+
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      do string::print "Missing semicolon in let binding test";
+
+()

--- a/samples/99-error-recovery-integration.blproj
+++ b/samples/99-error-recovery-integration.blproj
@@ -1,0 +1,5 @@
+{
+  "name": "error-recovery-integration",
+  "sources": ["99-error-recovery-integration.bl"],
+  "inputProjects": []
+}


### PR DESCRIPTION
## Summary

This PR introduces a parser resilience layer so that certain syntax errors no longer hard-fail the parse phase but instead emit `RecoveredSyntaxError` AST nodes and continue. Downstream tooling (Intellisense, incremental rebuilds) can therefore reason about the valid portions of a partially-broken file.

## Changes

### AST model (`Next/Models/Types.fs`)
- Added `ExprRecoveredSyntaxError` record (`ErrorMessage`, `ErrorLocation`, `RecoveryContext`).
- Added `ExprRec.RecoveredSyntaxError` union case.

### Parser recovery helper (`Next/Syntax/Parser/Recovery.fs` — new file)
- `createRecoveredError`: single helper that constructs a well-formed recovered AST node.
- File added to `ballerina-lang-parser.fsproj`.

### Parser wiring (`Next/Syntax/Parser/Expr.fs`)
- **type-let separator**: missing `in`/`;` after a type declaration no longer hard-fails; parser continues and wraps the body in a `Do(RecoveredSyntaxError, body)`.
- **dangling record destructure**: `expr.` (dot with no following field/index) is captured as a new `DanglingRecordDes` complex shape, then folded into a `Do(RecoveredSyntaxError, expr)` node rather than crashing the parser.

### Typechecker / Eval (`TypeCheck/Expr.fs`, `Eval/Expr_TypeEval.fs`)
- Both throw immediately on `RecoveredSyntaxError` nodes (intentional — no silent swallowing for now).

### Test infrastructure
- New samples `99-error-recovery-integration` and `100-error-recovery-dangling-record-des` with matching `.blproj` files.
- `sample-expectations.json` updated with expected `build-fails` outcomes and error-message assertions that prove errors are reported in the **typechecking** phase, not the parsing phase.

## Validation
- `dotnet build` (backend): ✅ 0 errors / 0 warnings.
- `dotnet run` (samples integration test): ✅ 23/23 passed.
- All 8 webshop `.blproj` files: ✅ built successfully.
