### PR TITLE
Add list and map literal syntax

### DIFF
--- a/backend/apps/ballerina-samples-integration-test/sample-expectations.json
+++ b/backend/apps/ballerina-samples-integration-test/sample-expectations.json
@@ -132,6 +132,12 @@
       "typeRegexes": ["Primitive.*Bool"],
       "errorRegexes": []
     },
+    "22-list-and-map-literals-integration": {
+      "mode": "run",
+      "valueRegexes": ["list_length", "map_rows", "record_sum"],
+      "typeRegexes": ["Tuple"],
+      "errorRegexes": []
+    },
     "99-error-recovery-integration": {
       "mode": "build-fails",
       "valueRegexes": [],

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Expr.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Expr.fs
@@ -495,56 +495,202 @@ module Expr =
         do! openCurlyBracketOperator
         let! loc = parser.Location
 
+        let mkListNil () =
+          Expr.Apply(
+            Expr.Lookup(
+              Identifier.FullyQualified([ "List" ], "Nil"),
+              loc,
+              TypeCheckScope.Empty
+            ),
+            Expr.Primitive(PrimitiveValue.Unit, loc, TypeCheckScope.Empty),
+            loc,
+            TypeCheckScope.Empty
+          )
+
+        let mkListCons
+          (head: Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>)
+          (tail: Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>)
+          =
+          Expr.Apply(
+            Expr.Lookup(
+              Identifier.FullyQualified([ "List" ], "Cons"),
+              loc,
+              TypeCheckScope.Empty
+            ),
+            Expr.TupleCons([ head; tail ], loc, TypeCheckScope.Empty),
+            loc,
+            TypeCheckScope.Empty
+          )
+
+        let mkListLiteral
+          (items: List<Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>>)
+          =
+          let rec build remaining =
+            match remaining with
+            | [] -> mkListNil ()
+            | head :: tail -> mkListCons head (build tail)
+
+          build items
+
+        let mkMapEmpty () =
+          Expr.Apply(
+            Expr.Lookup(
+              Identifier.FullyQualified([ "Map" ], "Empty"),
+              loc,
+              TypeCheckScope.Empty
+            ),
+            Expr.Primitive(PrimitiveValue.Unit, loc, TypeCheckScope.Empty),
+            loc,
+            TypeCheckScope.Empty
+          )
+
+        let mkMapSet
+          (key: Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>)
+          (value: Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>)
+          (acc: Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>)
+          =
+          Expr.Apply(
+            Expr.Apply(
+              Expr.Lookup(
+                Identifier.FullyQualified([ "Map" ], "set"),
+                loc,
+                TypeCheckScope.Empty
+              ),
+              Expr.TupleCons([ key; value ], loc, TypeCheckScope.Empty),
+              loc,
+              TypeCheckScope.Empty
+            ),
+            acc,
+            loc,
+            TypeCheckScope.Empty
+          )
+
+        let mkMapLiteral
+          (entries:
+            List<
+              Identifier * Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>
+             >)
+          =
+          entries
+          |> List.fold
+            (fun acc (key, value) ->
+              let keyExpr = Expr.Lookup(key, loc, TypeCheckScope.Empty)
+              mkMapSet keyExpr value acc)
+            (mkMapEmpty ())
+
         return!
           parser {
-            let! firstFieldOrWithExpr =
-              parser {
-                let! e = expr parseAllComplexShapes
+            let! isEmpty = closeCurlyBracketOperator |> parser.Try
 
+            match isEmpty with
+            | Left _ ->
+              return mkListLiteral []
+            | Right _ ->
+              let! firstExpr = expr parseAllComplexShapes
+
+              let firstLookupId =
+                match firstExpr.Expr with
+                | ExprRec.Lookup({ Id = id }) -> Some id
+                | _ -> None
+
+              let parseListLiteralFromFirst () =
+                parser {
+                  let! tailItems =
+                    parser.ManyIndex(fun _ ->
+                      parser {
+                        do! semicolonOperator
+                        let! value = expr parseAllComplexShapes
+                        return value
+                      })
+
+                  do! semicolonOperator |> parser.Try |> parser.Ignore
+                  do! closeCurlyBracketOperator
+                  return mkListLiteral (firstExpr :: tailItems)
+                }
+
+              let parseRecordWithFromFirst () =
+                parser {
+                  do! withKeyword
+
+                  let! fields =
+                    parser.ManyIndex(fun i ->
+                      parser {
+                        if i > 0 then
+                          do! semicolonOperator
+
+                        let! id = identifierLocalOrFullyQualified ()
+                        do! equalsOperator
+                        let! value = expr parseAllComplexShapes
+                        return (id, value)
+                      })
+
+                  do! semicolonOperator |> parser.Try |> parser.Ignore
+                  do! closeCurlyBracketOperator
+                  return Expr.RecordWith(firstExpr, fields, loc, TypeCheckScope.Empty)
+                }
+
+              let parseRecordFromFirst
+                (firstField: Identifier)
+                : Parser<_, _, _, _> =
+                parser {
+                  do! equalsOperator
+                  let! firstValue = expr parseAllComplexShapes
+
+                  let! fields =
+                    parser.ManyIndex(fun _ ->
+                      parser {
+                        do! semicolonOperator
+                        let! id = identifierLocalOrFullyQualified ()
+                        do! equalsOperator
+                        let! value = expr parseAllComplexShapes
+                        return (id, value)
+                      })
+
+                  do! semicolonOperator |> parser.Try |> parser.Ignore
+                  do! closeCurlyBracketOperator
+
+                  return
+                    Expr.RecordCons(
+                      (firstField, firstValue) :: fields,
+                      loc,
+                      TypeCheckScope.Empty
+                    )
+                }
+
+              let parseMapFromFirst
+                (firstKey: Identifier)
+                : Parser<_, _, _, _> =
+                parser {
+                  do! singleArrowOperator
+                  let! firstValue = expr parseAllComplexShapes
+
+                  let! entries =
+                    parser.ManyIndex(fun _ ->
+                      parser {
+                        do! semicolonOperator
+                        let! key = identifierLocalOrFullyQualified ()
+                        do! singleArrowOperator
+                        let! value = expr parseAllComplexShapes
+                        return (key, value)
+                      })
+
+                  do! semicolonOperator |> parser.Try |> parser.Ignore
+                  do! closeCurlyBracketOperator
+
+                  return mkMapLiteral ((firstKey, firstValue) :: entries)
+                }
+
+              match firstLookupId with
+              | Some firstId ->
                 return!
                   parser.Any
-                    [ parser {
-                        do! withKeyword |> parser.Ignore
-                        return Sum.Right e
-                      }
-
-                      parser {
-                        let! e =
-                          e
-                          |> Expr.AsLookup
-                          |> sum.MapError(
-                            Errors.MapContext(replaceWith e.Location)
-                          )
-                          |> parser.OfSum
-
-                        do! equalsOperator |> parser.Ignore
-                        let! value = expr parseAllComplexShapes
-                        return Sum.Left(e, value)
-                      } ]
-              }
-
-            let! fields =
-              parser.ManyIndex(fun i ->
-                parser {
-                  if firstFieldOrWithExpr.IsLeft || i > 0 then
-                    do! semicolonOperator
-
-                  let! id = identifierLocalOrFullyQualified ()
-                  do! equalsOperator
-                  let! value = expr parseAllComplexShapes
-                  return (id, value)
-                })
-
-            do! semicolonOperator |> parser.Try |> parser.Ignore
-
-            do! closeCurlyBracketOperator
-
-            match firstFieldOrWithExpr with
-            | Sum.Left({ Id = f }, v) ->
-              return
-                Expr.RecordCons((f, v) :: fields, loc, TypeCheckScope.Empty)
-            | Sum.Right e ->
-              return Expr.RecordWith(e, fields, loc, TypeCheckScope.Empty)
+                    [ parseRecordWithFromFirst ()
+                      parseRecordFromFirst firstId
+                      parseMapFromFirst firstId
+                      parseListLiteralFromFirst () ]
+                  |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
+              | None ->
+                return! parseListLiteralFromFirst ()
           }
           |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
       }

--- a/samples/02-list-manipulation.bl
+++ b/samples/02-list-manipulation.bl
@@ -9,11 +9,9 @@
 // This sample shows the core list operations you will use most often:
 // create, count, transform (map), select (filter), aggregate (fold), and merge (append).
 
-// Create lists.
-// Use List::Cons to add an item at the front, and List::Nil for an empty list.
-// Think of this as building a list one element at a time.
-let nums = List::Cons [int32] (1, List::Cons [int32] (2, List::Cons [int32] (3, List::Nil [int32] ())));
-let strs = List::Cons [string] ("a", List::Cons [string] ("b", List::Nil [string] ()));
+// Create lists with literal syntax.
+let nums = {1; 2; 3};
+let strs = {"a"; "b"};
 
 // Count items.
 // Useful when validating "do we have any data?" or checking batch sizes.
@@ -28,7 +26,7 @@ let doubled = List::map [int32][int32] (fun (x: int32) -> x * 2) nums;
 // Example use case: keep only eligible orders or active users.
 let gt_1 = List::filter [int32] (fun (x: int32) -> x > 1) nums;
 let evens = List::filter [int32] (fun (x: int32) -> (x % 2) == 0) 
-  (List::Cons [int32] (1, List::Cons [int32] (2, List::Cons [int32] (3, List::Cons [int32] (4, List::Nil [int32] ())))));
+  ({1; 2; 3; 4});
 
 // Aggregate a list into one value with fold.
 // Example use case: total revenue, total quantity, or cumulative score.
@@ -37,7 +35,7 @@ let product_res = List::fold [int32][int32] (fun (acc: int32) -> fun (x: int32) 
 
 // Merge two lists with append.
 // Example use case: combine records from two sources before processing.
-let nums2 = List::Cons [int32] (4, List::Cons [int32] (5, List::Nil [int32] ()));
+let nums2 = {4; 5};
 let combined = List::append [int32] nums nums2;
 
 // Decompose a list into head + tail.
@@ -55,7 +53,7 @@ let tail_len =
   | 2Of2 (parts -> List::length [int32] parts.2)
   | 1Of2 (_ -> 0);
 
-let empty_nums = List::Nil [int32] ();
+let empty_nums = {};
 
 let empty_check =
   match List::decompose [int32] empty_nums with

--- a/samples/03-advanced-data-types.bl
+++ b/samples/03-advanced-data-types.bl
@@ -101,7 +101,7 @@ let t2_second = t2.2;
 let t3_second = t3.2;
 
 // List of records: store many structured items and process them as a collection.
-let players = List::Cons [PlayerProfile] (player1, List::Cons [PlayerProfile] (player2, List::Nil [PlayerProfile] ()));
+let players = {player1; player2};
 let players_count = List::length [PlayerProfile] players;
 
 // Map over records to project one field from each item.
@@ -110,16 +110,7 @@ let tags_count = List::length [string] tags;
 
 // Fold + match together: extract all miss messages from a list of feedback values.
 let round_events =
-  List::Cons [ActionFeedback] (
-    Hit "target dummy",
-    List::Cons [ActionFeedback] (
-      Miss "shield blocked",
-      List::Cons [ActionFeedback] (
-        Hit "headshot",
-        List::Cons [ActionFeedback] (Miss "roll evasion", List::Nil [ActionFeedback] ())
-      )
-    )
-  );
+  {Hit "target dummy"; Miss "shield blocked"; Hit "headshot"; Miss "roll evasion"};
 
 let extracted_misses =
   List::fold [ActionFeedback][List[string]]
@@ -128,8 +119,8 @@ let extracted_misses =
       | Hit (_ -> acc)
       | Miss (msg ->
         // Append keeps original order from the source list.
-        List::append [string] acc (List::Cons [string] (msg, List::Nil [string] ()))))
-    (List::Nil [string] ())
+        List::append [string] acc {msg}))
+    {}
     round_events;
 
 let extracted_misses_count = List::length [string] extracted_misses;

--- a/samples/04-functions-and-type-inference.bl
+++ b/samples/04-functions-and-type-inference.bl
@@ -54,7 +54,7 @@ let modernCpp: Book = { Title = "Il nome della rosa"; Author = "Umberto Eco"; Ye
 
 // Build a list of books for batch operations.
 // Square-bracket type blocks are shown for readability; inference can often derive them.
-let books = List::Cons [Book] (dune, List::Cons [Book] (hobbit, List::Cons [Book] (modernCpp, List::Nil [Book] ())));
+let books = {dune; hobbit; modernCpp};
 
 // Count records in the collection.
 let totalBooks = List::length [Book] books;

--- a/samples/10-collections-and-maps-integration.bl
+++ b/samples/10-collections-and-maps-integration.bl
@@ -5,11 +5,7 @@
 // transform values, keep the valid subset, aggregate them, and reshape a map
 // into a list for downstream processing.
 
-let numbers =
-     List::Cons [int32] (
-          1,
-          List::Cons [int32] (-2, List::Cons [int32] (3, List::Nil [int32] ()))
-     );
+let numbers = {1; -2; 3};
 
 let positive_flags = List::map [int32][bool] (fun (value:int32) -> value > 0) numbers;
 let positives = List::filter [int32] (fun (value:int32) -> value > 0) numbers;
@@ -20,14 +16,13 @@ let list_pipeline_ok =
      && (List::length [int32] positives == 2)
      && (positive_sum == 4);
 
-let cons = List::Cons [string];
-let nil = List::Nil [string] ();
-let left_words = cons("hello", cons(" ", cons("world", nil)));
-let right_words = cons("bonjour", cons(" ", cons("monde", nil)));
+let left_words = {"hello"; " "; "world"};
+let right_words = {"bonjour"; " "; "monde"};
 let append_ok = List::length [string] (List::append [string] left_words right_words) == 6;
 
-let empty_scores = Map::Empty [string][int32] ();
-let scores = Map::set [string][int32] ("key1", 1) (Map::set [string][int32] ("key2", 2) empty_scores);
+let key1 = "key1";
+let key2 = "key2";
+let scores = {key1 -> 1; key2 -> 2};
 let boosted_scores = Map::map (fun (value:int32) -> value + 100) scores;
 let score_rows = Map::mapToList [string][int32] boosted_scores;
 let map_ok = List::length score_rows == 2;

--- a/samples/15-patterns-and-arrows-integration.bl
+++ b/samples/15-patterns-and-arrows-integration.bl
@@ -25,20 +25,20 @@ type T2 = {
   C: bool;
 };
 
-let choice_value: ChoicePayload = 2Of3(List::Nil [int32] ());
+let choice_value: ChoicePayload = 2Of3({});
 let choice_result = match choice_value with
 | 1Of3 (x -> x)
 | 2Of3 (x -> -1)
 | 3Of3 (x -> 0);
 
-let tuple_choice_value: TupleChoicePayload = 2Of3(List::Nil [int32] (), 42);
+let tuple_choice_value: TupleChoicePayload = 2Of3({}, 42);
 let second_item = fun (x: List [int32] * int32) -> x.2;
 let tuple_choice_result = match tuple_choice_value with
 | 1Of3 (x -> x)
 | 2Of3 (x -> second_item x)
 | 3Of3 (x -> 0);
 
-let arrow_value: ArrowList = fun flag -> if flag then List::Cons [int32] (1, List::Nil [int32] ()) else List::Nil [int32] ();
+let arrow_value: ArrowList = fun flag -> if flag then {1} else {};
 let arrow_true_length = List::length [int32] (arrow_value true);
 let arrow_false_length = List::length [int32] (arrow_value false);
 

--- a/samples/16-type-hints-and-type-lambdas-integration.bl
+++ b/samples/16-type-hints-and-type-lambdas-integration.bl
@@ -31,7 +31,7 @@ let hinted_record_result = sum_fields { A = 10; B = 20; C = 30; };
 let fold_union = fun value -> match value with | UA (v -> v) | UB (v -> v) | UC (v -> v);
 let hinted_union_result = (fold_union (UA 10)) + (fold_union (UB 20)) + (fold_union (UC 30));
 
-let singleton = fun [a:*] (value:a) -> List::Cons [a] (value, List::Nil [a] ());
+let singleton = fun [a:*] (value:a) -> {value};
 let pair = fun [a:*] [b:*] (x:a) (y:b) -> (x, y);
 let getCount = fun [a:*] (value:Countainer[a]) -> value.Count;
 let foldInt = fun (value:Countainer[int32]) -> value.Value + value.Count;

--- a/samples/22-list-and-map-literals-integration.bl
+++ b/samples/22-list-and-map-literals-integration.bl
@@ -1,0 +1,33 @@
+// Ballerina Integration Sample 22: List And Map Literals
+//
+// Verifies early disambiguation of curly literals:
+// - {a = b; c = d} => record constructor
+// - {a -> b; c -> d} => map literal
+// - {a; b; c} and {complex; ...} => list literal
+
+type Totals = {
+  A: int32;
+  B: int32;
+};
+
+let first = 10;
+let second = 20;
+let values = {first; second; first + second};
+let singleton = {first};
+let with_complex_head = {(first + 1); second};
+
+let key_a = "a";
+let key_b = "b";
+let score_map = {key_a -> 1; key_b -> 2};
+let score_rows = Map::mapToList [string][int32] score_map;
+
+let record_value: Totals = { A = first; B = second };
+let record_updated = {record_value with B = 30};
+
+(
+  ("list_length", List::length [int32] values),
+  ("singleton_length", List::length [int32] singleton),
+  ("complex_head_length", List::length [int32] with_complex_head),
+  ("map_rows", List::length score_rows),
+  ("record_sum", record_updated.A + record_updated.B)
+)

--- a/samples/22-list-and-map-literals-integration.blproj
+++ b/samples/22-list-and-map-literals-integration.blproj
@@ -1,0 +1,5 @@
+{
+  "name": "list-and-map-literals-integration",
+  "sources": ["22-list-and-map-literals-integration.bl"],
+  "inputProjects": []
+}


### PR DESCRIPTION
## Summary
- add parser support for list literals using `{a; b; c}` syntax
- add parser support for map literals using `{key -> value; ...}` syntax while preserving early disambiguation with record constructors and record-with expressions
- migrate existing samples to the new literal syntax and add a dedicated integration sample

## Testing
- dotnet run --project backend/apps/ballerina-samples-integration-test/ballerina-samples-integration-test.fsproj
- dotnet run --project /Users/giuseppemag/repos/bise/src/playgrounds/bise-sql/bise-sql.fsproj -- --file /Users/giuseppemag/repos/bise/src/playgrounds/bise-sql/Samples/ABC/abc.blproj
- validated the webshop `.blproj` files with bise-sql