### PR TITLE
Drop 'in' keyword from type-let and do separators

### DIFF
--- a/backend/apps/ballerina-samples-integration-test/sample-expectations.json
+++ b/backend/apps/ballerina-samples-integration-test/sample-expectations.json
@@ -142,7 +142,7 @@
       "mode": "build-fails",
       "valueRegexes": [],
       "typeRegexes": [],
-      "errorRegexes": ["Expected 'in' or ';' after type let declaration", "while typechecking"]
+      "errorRegexes": ["Expected ';' before expression after type let declaration", "while parsing"]
     },
     "100-error-recovery-dangling-record-des": {
       "mode": "build-fails",

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Expr.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Expr.fs
@@ -453,10 +453,9 @@ module Expr =
 
         do!
           parser.Any
-            [ inKeyword
-              semicolonOperator
+            [ semicolonOperator
               (fun () ->
-                "Expected 'in', ';' or expression after 'do' expression")
+                "Expected ';' after 'do' expression")
               |> Errors.Singleton loc
               |> Errors.MapPriority(replaceWith ErrorPriority.High)
               |> parser.Throw ]
@@ -791,11 +790,15 @@ module Expr =
 
         let! loc' = parser.Location
 
-        let! hasSeparator =
+        do!
           parser.Any
-            [ inKeyword |> parser.Map(fun _ -> true)
-              semicolonOperator |> parser.Map(fun _ -> true)
-              parser { return false } ]
+            [ semicolonOperator
+              (fun () ->
+                "Expected ';' before expression after type let declaration")
+              |> Errors.Singleton loc'
+              |> Errors.MapPriority(replaceWith ErrorPriority.High)
+              |> parser.Throw ]
+          |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
         let! body =
           parseBoundBody ()
@@ -824,20 +827,6 @@ module Expr =
           | _ -> [], SymbolsKind.RecordFields
 
         let typeDecl = TypeExpr.LetSymbols(symbols, symbolsKind, typeDecl)
-
-        let body =
-          if hasSeparator then
-            body
-          else
-            Expr.Do(
-              createRecoveredError
-                "Expected 'in' or ';' after type let declaration"
-                loc'
-                "missing_separator_after_type_let",
-              body,
-              loc',
-              TypeCheckScope.Empty
-            )
 
         return Expr.TypeLet(id, typeDecl, body, loc, TypeCheckScope.Empty)
       }

--- a/samples/11-records-and-unions-integration.bl
+++ b/samples/11-records-and-unions-integration.bl
@@ -9,12 +9,12 @@ type ApprovalSummary = {
   Score: int32;
   Notes: string;
   Accepted: bool;
-}
-in type ReviewOutcome =
+};
+type ReviewOutcome =
 | Approved of int32
 | Rejected of string
-| Pending of bool
-in type Countainer = [a:*] -> {
+| Pending of bool;
+type Countainer = [a:*] -> {
   Value: a;
   Count: int32;
 };

--- a/vscode-bl-extension/package-lock.json
+++ b/vscode-bl-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bl-language-tools",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bl-language-tools",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.14.12",

--- a/vscode-bl-extension/package.json
+++ b/vscode-bl-extension/package.json
@@ -2,7 +2,7 @@
   "name": "bl-language-tools",
   "displayName": "Ballerina Language Tools",
   "description": "Syntax highlighting and diagnostics for .bl projects using bise-sql server mode",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "publisher": "GiuseppeMaggiore",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Remove the `in` keyword as an accepted separator after `type let` declarations and after `do` expressions. The `in` keyword is now **query-only**.

Before:
```
type let Foo = Bar in
  ...expr...
```

After (only `;` is accepted):
```
type let Foo = Bar;
  ...expr...
```

This aligns `type let` parsing with `let` and `do` expression syntax.

## Changes
- `Expr.fs`: removed `inKeyword` alternatives from both the `do` separator parser and the `type let` separator parser; removed the dead recovery branch that wrapped the body in a `Recovered` error node when `in`/`;` was absent
- `sample-expectations.json`: updated `99-error-recovery-integration` — error is now raised at parse time (`while parsing`) with message `Expected ';' before expression after type let declaration`
- `vscode-bl-extension/package.json` + `package-lock.json`: version bump from publish

## Testing
- 24/24 samples integration tests pass
- All webshop `.blproj` files pass (stdlib, simple-test, uscreen, bise, yeahgummy)
- abc playground sample passes
