### PR TITLE
Expose DB::calculateProps and DB::stripProps as public builtins

### DIFF
--- a/backend/apps/ballerina-samples-integration-test/sample-expectations.json
+++ b/backend/apps/ballerina-samples-integration-test/sample-expectations.json
@@ -151,6 +151,12 @@
       "errorRegexes": [
         "while typechecking"
       ]
+    },
+    "23-calculate-strip-props-integration": {
+      "mode": "run",
+      "valueRegexes": ["SchemaAsValue"],
+      "typeRegexes": ["Shop"],
+      "errorRegexes": []
     }
   }
 }

--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/CUD/DBCalculateProps.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/CUD/DBCalculateProps.fs
@@ -368,3 +368,86 @@ module CalculateProps =
         _entity_desc.Properties
 
     memoryDBCalculatePropertyId, CalculatePropertyOperation, calculateProps
+
+
+  let DBCalculatePropsPublicExtension<'runtimeContext, 'db, 'ext
+    when 'ext: comparison>
+    (db_ops: DBTypeClass<'runtimeContext, 'db, 'ext>)
+    (calculateProps:
+      DBTypeClass<'runtimeContext, 'db, 'ext>
+        -> Value<TypeValue<'ext>, 'ext>
+        -> EntityRef<'db, 'ext>
+        -> Reader<
+          Value<TypeValue<'ext>, 'ext>,
+          ExprEvalContext<'runtimeContext, 'ext>,
+          Errors<Location>
+         >)
+    (valueLens: PartialLens<'ext, DBValues<'runtimeContext, 'db, 'ext>>)
+    =
+    let memoryDBCalculatePropsId =
+      Identifier.FullyQualified([ "DB" ], "calculateProps")
+      |> TypeCheckScope.Empty.Resolve
+
+    let memoryDBCalculatePropsType =
+      TypeValue.CreateLambda(
+        TypeParameter.Create("schema", Kind.Schema),
+        TypeExpr.Lambda(
+          TypeParameter.Create("entity", Kind.Star),
+          TypeExpr.Lambda(
+            TypeParameter.Create("entity_with_props", Kind.Star),
+            TypeExpr.Lambda(
+              TypeParameter.Create("entityId", Kind.Star),
+              TypeExpr.Arrow(
+                createSchemaEntityTypeApplication
+                  "schema"
+                  "entity"
+                  "entity_with_props"
+                  "entityId",
+                TypeExpr.Arrow(
+                  TypeExpr.Lookup("entity" |> Identifier.LocalScope),
+                  TypeExpr.Lookup(
+                    "entity_with_props" |> Identifier.LocalScope
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+
+    let memoryDBCalculatePropsKind = standardSchemaOperationKind
+
+    let calculatePropsOperation: OperationExtension<'runtimeContext, _, _> =
+      { PublicIdentifiers =
+          Some
+          <| (memoryDBCalculatePropsType,
+              memoryDBCalculatePropsKind,
+              DBValues.CalculateProps {| EntityRef = None |})
+        OperationsLens =
+          valueLens
+          |> PartialLens.BindGet (function
+            | DBValues.CalculateProps v -> Some(DBValues.CalculateProps v)
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (op, v) ->
+            reader {
+              let! op =
+                op
+                |> DBValues.AsCalculateProps
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              match op with
+              | None ->
+                let! v = extractEntityRefFromValue loc0 v valueLens
+
+                return
+                  (DBValues.CalculateProps({| EntityRef = Some v |})
+                   |> valueLens.Set,
+                   Some memoryDBCalculatePropsId)
+                  |> Ext
+              | Some entity_ref ->
+                return! calculateProps db_ops v entity_ref
+            } }
+
+    memoryDBCalculatePropsId, calculatePropsOperation

--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/CUD/DBStripProps.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/CUD/DBStripProps.fs
@@ -369,3 +369,86 @@ module StripProps =
         _entity.Properties
 
     memoryDBStripPropertyId, StripPropertyOperation, stripProps
+
+
+  let DBStripPropsPublicExtension<'runtimeContext, 'db, 'ext
+    when 'ext: comparison>
+    (db_ops: DBTypeClass<'runtimeContext, 'db, 'ext>)
+    (stripProps:
+      DBTypeClass<'runtimeContext, 'db, 'ext>
+        -> Value<TypeValue<'ext>, 'ext>
+        -> EntityRef<'db, 'ext>
+        -> Reader<
+          Value<TypeValue<'ext>, 'ext>,
+          ExprEvalContext<'runtimeContext, 'ext>,
+          Errors<Location>
+         >)
+    (valueLens: PartialLens<'ext, DBValues<'runtimeContext, 'db, 'ext>>)
+    =
+    let memoryDBStripPropsId =
+      Identifier.FullyQualified([ "DB" ], "stripProps")
+      |> TypeCheckScope.Empty.Resolve
+
+    let memoryDBStripPropsType =
+      TypeValue.CreateLambda(
+        TypeParameter.Create("schema", Kind.Schema),
+        TypeExpr.Lambda(
+          TypeParameter.Create("entity", Kind.Star),
+          TypeExpr.Lambda(
+            TypeParameter.Create("entity_with_props", Kind.Star),
+            TypeExpr.Lambda(
+              TypeParameter.Create("entityId", Kind.Star),
+              TypeExpr.Arrow(
+                createSchemaEntityTypeApplication
+                  "schema"
+                  "entity"
+                  "entity_with_props"
+                  "entityId",
+                TypeExpr.Arrow(
+                  TypeExpr.Lookup(
+                    "entity_with_props" |> Identifier.LocalScope
+                  ),
+                  TypeExpr.Lookup("entity" |> Identifier.LocalScope)
+                )
+              )
+            )
+          )
+        )
+      )
+
+    let memoryDBStripPropsKind = standardSchemaOperationKind
+
+    let stripPropsOperation: OperationExtension<'runtimeContext, _, _> =
+      { PublicIdentifiers =
+          Some
+          <| (memoryDBStripPropsType,
+              memoryDBStripPropsKind,
+              DBValues.StripProps {| EntityRef = None |})
+        OperationsLens =
+          valueLens
+          |> PartialLens.BindGet (function
+            | DBValues.StripProps v -> Some(DBValues.StripProps v)
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (op, v) ->
+            reader {
+              let! op =
+                op
+                |> DBValues.AsStripProps
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              match op with
+              | None ->
+                let! v = extractEntityRefFromValue loc0 v valueLens
+
+                return
+                  (DBValues.StripProps({| EntityRef = Some v |})
+                   |> valueLens.Set,
+                   Some memoryDBStripPropsId)
+                  |> Ext
+              | Some entity_ref ->
+                return! stripProps db_ops v entity_ref
+            } }
+
+    memoryDBStripPropsId, stripPropsOperation

--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/Extension.fs
@@ -23,6 +23,12 @@ module CUD =
     let DBStripPropertyId, StripPropertyOperation, stripProps =
       DBStripPropertiesExtension listLens.Set valueLens
 
+    let DBCalculatePropsId, CalculatePropsOperation =
+      DBCalculatePropsPublicExtension db_ops calculateProps valueLens
+
+    let DBStripPropsId, StripPropsOperation =
+      DBStripPropsPublicExtension db_ops stripProps valueLens
+
     let DBCreateId, CreateOperation =
       DBCreateExtension db_ops calculateProps listLens.Set valueLens
 
@@ -67,6 +73,8 @@ module CUD =
           (DBGetManyId, GetManyOperation)
           (DBStripPropertyId, StripPropertyOperation)
           (DBCalculatePropertyId, CalculatePropertyOperation)
+          (DBCalculatePropsId, CalculatePropsOperation)
+          (DBStripPropsId, StripPropsOperation)
           (DBCreateId, CreateOperation)
           (DBUpdateId, UpdateOperation)
           (DBUpsertId, UpsertOperation)

--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/Model.fs
@@ -245,6 +245,8 @@ module Model =
     | Delete of {| EntityRef: Option<EntityRef<'db, 'ext>> |}
     | GetById of {| EntityRef: Option<EntityRef<'db, 'ext>> |}
     | GetMany of {| EntityRef: Option<EntityRef<'db, 'ext>> |}
+    | CalculateProps of {| EntityRef: Option<EntityRef<'db, 'ext>> |}
+    | StripProps of {| EntityRef: Option<EntityRef<'db, 'ext>> |}
     | Run
     | DBIO of DBIO<'runtimeContext, 'db, 'ext>
     | TypeAppliedRun of Schema<'ext> * 'db
@@ -332,6 +334,8 @@ module Model =
       | Delete _ -> "Delete"
       | GetById _ -> "GetById"
       | GetMany _ -> "GetMany"
+      | CalculateProps _ -> "CalculateProps"
+      | StripProps _ -> "StripProps"
       | Run -> "Run"
       | DBIO dbio -> $"DBIO({dbio})"
       | TypeAppliedRun(_schema, _) -> $"TypeAppliedRun"

--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/Patterns.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/Patterns.fs
@@ -122,6 +122,24 @@ module Patterns =
         Errors.Singleton () (fun () -> "Expected GetMany operation")
         |> sum.Throw
 
+    static member AsCalculateProps
+      (op: DBValues<'runtimeContext, 'db, 'ext>)
+      : Sum<Option<EntityRef<'db, 'ext>>, Errors<Unit>> =
+      match op with
+      | DBValues.CalculateProps v -> v.EntityRef |> sum.Return
+      | _ ->
+        Errors.Singleton () (fun () -> "Expected CalculateProps operation")
+        |> sum.Throw
+
+    static member AsStripProps
+      (op: DBValues<'runtimeContext, 'db, 'ext>)
+      : Sum<Option<EntityRef<'db, 'ext>>, Errors<Unit>> =
+      match op with
+      | DBValues.StripProps v -> v.EntityRef |> sum.Return
+      | _ ->
+        Errors.Singleton () (fun () -> "Expected StripProps operation")
+        |> sum.Throw
+
     static member AsEntityRef
       (op: DBValues<'runtimeContext, 'db, 'ext>)
       : Sum<EntityRef<'db, 'ext>, Errors<Unit>> =

--- a/samples/23-calculate-strip-props-integration.bl
+++ b/samples/23-calculate-strip-props-integration.bl
@@ -1,0 +1,72 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Ballerina Example 23: DB::calculateProps and DB::stripProps
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// This sample demonstrates the public DB::calculateProps and DB::stripProps
+// builtins. These allow users to manually add or remove computed properties
+// from entity values without going through create/update.
+
+type ItemId = { ItemId: guid };
+type Item = {
+  Name: string;
+  Price: int32;
+  Quantity: int32
+};
+
+type Shop = 
+  schema{
+    entity Items {
+      type Item ItemId
+      let property [] TotalValue : int32 = self.Price * self.Quantity
+      let property [] Label : string = self.Name
+    }
+  };
+
+DB::run [Shop] (fun (schema: Shop) ->
+  let item_id:ItemId = { ItemId = guid::v4() };
+  let item = {
+    Name = "Widget";
+    Price = 10;
+    Quantity = 5
+  };
+
+  // First, calculate properties on a raw item (never stored in DB)
+  let with_props = DB::calculateProps[Shop] (schema.Entities.Items) item;
+  do string::print ("calculateProps on raw item:", with_props);
+
+  // Strip the properties back off
+  let stripped = DB::stripProps[Shop] (schema.Entities.Items) with_props;
+  do string::print ("stripProps result:", stripped);
+
+  // Round-trip: calculate again on stripped value
+  let with_props_again = DB::calculateProps[Shop] (schema.Entities.Items) stripped;
+  do string::print ("calculateProps again:", with_props_again);
+
+  // Create the entity (this internally calculates props too)
+  let _ = DB::create[Shop] (schema.Entities.Items) (item_id, item);
+
+  // Fetch it back - should have properties from the DB
+  let fetched = DB::getById[Shop] (schema.Entities.Items) item_id;
+  do string::print ("After create, getById:", fetched);
+
+  // Strip the fetched entity's properties
+  let fetched_stripped = match fetched with
+    | 2Of2 v -> DB::stripProps[Shop] (schema.Entities.Items) v
+    | 1Of2 -> item
+  ;
+  do string::print ("Fetched then stripped:", fetched_stripped);
+
+  // Verify with a second item
+  let gadget = {
+    Name = "Gadget";
+    Price = 20;
+    Quantity = 3
+  };
+  let gadget_with_props = DB::calculateProps[Shop] (schema.Entities.Items) gadget;
+  do string::print ("Gadget with props:", gadget_with_props);
+
+  let gadget_stripped = DB::stripProps[Shop] (schema.Entities.Items) gadget_with_props;
+  do string::print ("Gadget stripped:", gadget_stripped);
+
+  string::print "Done!"
+)

--- a/samples/23-calculate-strip-props-integration.blproj
+++ b/samples/23-calculate-strip-props-integration.blproj
@@ -1,0 +1,5 @@
+{
+  "name": "calculate-strip-props-integration",
+  "sources": ["23-calculate-strip-props-integration.bl"],
+  "inputProjects": []
+}

--- a/vscode-bl-extension/package-lock.json
+++ b/vscode-bl-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bl-language-tools",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bl-language-tools",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.14.12",

--- a/vscode-bl-extension/package.json
+++ b/vscode-bl-extension/package.json
@@ -2,7 +2,7 @@
   "name": "bl-language-tools",
   "displayName": "Ballerina Language Tools",
   "description": "Syntax highlighting and diagnostics for .bl projects using bise-sql server mode",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "publisher": "GiuseppeMaggiore",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Expose `DB::calculateProps` and `DB::stripProps` as public builtins so that Ballerina users can manually add or remove computed properties from entity values without going through create/update.

## Changes

- **Model.fs**: Added `CalculateProps` and `StripProps` cases to the `DBValues` DU with `ToString()` overrides
- **Patterns.fs**: Added `AsCalculateProps` and `AsStripProps` pattern matchers
- **DBCalculateProps.fs**: Added `DBCalculatePropsPublicExtension` — type: `SchemaEntity → entity → entity_with_props`
- **DBStripProps.fs**: Added `DBStripPropsPublicExtension` — type: `SchemaEntity → entity_with_props → entity`
- **Extension.fs**: Wired both public operations into the `DBCUDExtension` operations map
- **Sample 23**: Test program demonstrating round-trip calculate/strip with integration expectations

## Testing

- All 25 integration samples pass
- Runtime verified with `bise-sql -r`: properties are correctly added (`TotalValue=50`, `Label="Widget"`) and removed