### PR TITLE
feat: incremental single-file typecheck for fast autocompletion

### DIFF
--- a/backend/libraries/ballerina-api/Common/OpenAPI/EndpointGeneration.fs
+++ b/backend/libraries/ballerina-api/Common/OpenAPI/EndpointGeneration.fs
@@ -90,6 +90,35 @@ module EndpointGeneration =
       else
         None)
 
+  type RelationDirection = FromTo | ToFrom
+
+  let collectFilterableRelations
+    (entityName: SchemaEntityName)
+    (schema: Schema<ValueExt<'runtimeContext, 'db, 'customExtension>>)
+    =
+    let entityNameStr = entityName.Name
+
+    schema.Relations
+    |> OrderedMap.toSeq
+    |> Seq.choose (fun (relationName, relation) ->
+      let fromName =
+        match relation.From with
+        | Identifier.LocalScope name -> name
+        | Identifier.FullyQualified(_, name) -> name
+
+      let toName =
+        match relation.To with
+        | Identifier.LocalScope name -> name
+        | Identifier.FullyQualified(_, name) -> name
+
+      if fromName = entityNameStr then
+        Some(relationName.Name, toName, FromTo)
+      elif toName = entityNameStr then
+        Some(relationName.Name, fromName, ToFrom)
+      else
+        None)
+    |> Seq.toList
+
   let generate_endpoints
     (tenantId: string)
     (schemaName: string)

--- a/backend/libraries/ballerina-api/Common/OpenAPI/FilterDataModelGeneration.fs
+++ b/backend/libraries/ballerina-api/Common/OpenAPI/FilterDataModelGeneration.fs
@@ -64,19 +64,55 @@ module FilterDataModelGeneration =
 
               do! state.SetState(Map.add predicateModelName predicateModel)
 
+              let filterableRelations = collectFilterableRelations entity_name schema
+
+              let relationExistsCases =
+                filterableRelations
+                |> List.map (fun (relationName, targetEntityName, _direction) ->
+                  let targetFilterTreeRef =
+                    { OpenAPIDataModelName.OpenAPIDataModelName = $"{targetEntityName}-FilterTree" }
+
+                  let existsModel =
+                    OpenAPIDataModel.Record
+                      [ ("RelationName" |> ResolvedIdentifier.Create,
+                         OpenAPIDataModel.Primitive PrimitiveType.String)
+                        ("TargetEntity" |> ResolvedIdentifier.Create,
+                         OpenAPIDataModel.Primitive PrimitiveType.String)
+                        ("SubFilter" |> ResolvedIdentifier.Create,
+                         OpenAPIDataModel.Ref targetFilterTreeRef) ]
+
+                  ($"{relationName}->{targetEntityName}" |> ResolvedIdentifier.Create,
+                   existsModel))
+
+              let relationPredicateModelName =
+                { OpenAPIDataModelName.OpenAPIDataModelName = $"{entity_name.Name}-RelationPredicate" }
+
+              if not (List.isEmpty relationExistsCases) then
+                let relationPredicateModel = OpenAPIDataModel.OneOf relationExistsCases
+                do! state.SetState(Map.add relationPredicateModelName relationPredicateModel)
+
               let filterTreeModelName =
                 { OpenAPIDataModelName.OpenAPIDataModelName = $"{entity_name.Name}-FilterTree" }
 
+              let baseCases =
+                [ ("And" |> ResolvedIdentifier.Create,
+                   OpenAPIDataModel.Array(OpenAPIDataModel.Ref filterTreeModelName))
+                  ("Or" |> ResolvedIdentifier.Create,
+                   OpenAPIDataModel.Array(OpenAPIDataModel.Ref filterTreeModelName))
+                  ("Not" |> ResolvedIdentifier.Create,
+                   OpenAPIDataModel.Ref filterTreeModelName)
+                  ("Predicate" |> ResolvedIdentifier.Create,
+                   OpenAPIDataModel.Ref predicateModelName) ]
+
+              let existsCase =
+                if not (List.isEmpty relationExistsCases) then
+                  [ ("Exists" |> ResolvedIdentifier.Create,
+                     OpenAPIDataModel.Ref relationPredicateModelName) ]
+                else
+                  []
+
               let filterTreeModel =
-                OpenAPIDataModel.OneOf
-                  [ ("And" |> ResolvedIdentifier.Create,
-                     OpenAPIDataModel.Array(OpenAPIDataModel.Ref filterTreeModelName))
-                    ("Or" |> ResolvedIdentifier.Create,
-                     OpenAPIDataModel.Array(OpenAPIDataModel.Ref filterTreeModelName))
-                    ("Not" |> ResolvedIdentifier.Create,
-                     OpenAPIDataModel.Ref filterTreeModelName)
-                    ("Predicate" |> ResolvedIdentifier.Create,
-                     OpenAPIDataModel.Ref predicateModelName) ]
+                OpenAPIDataModel.OneOf (baseCases @ existsCase)
 
               do! state.SetState(Map.add filterTreeModelName filterTreeModel)
 

--- a/backend/libraries/ballerina-lang-build/Caching.fs
+++ b/backend/libraries/ballerina-lang-build/Caching.fs
@@ -255,4 +255,8 @@ module Caching =
 
                 NonEmptyList.One exprWithType, [ file.Checksum ], ctx', st'
               })
-          |> sum.Map(fun (exprs, _, ctx, st) -> exprs, ctx, st) }
+          |> sum.Map(fun (exprs, _, ctx, st) -> exprs, ctx, st)
+      TryGetCachedState =
+        fun fileName ->
+          cache.TryGet fileName
+          |> Option.map (fun (_, _, _, _, ctx, st) -> ctx, st) }

--- a/backend/libraries/ballerina-lang-build/ProjectModel.fs
+++ b/backend/libraries/ballerina-lang-build/ProjectModel.fs
@@ -86,6 +86,12 @@ module ProjectModel =
             TypeCheckContext<'valueExt> *
             TypeCheckState<'valueExt>,
             Errors<Location>
+           >
+      TryGetCachedState:
+        FileName
+          -> Option<
+            TypeCheckContext<'valueExt> *
+            TypeCheckState<'valueExt>
            > }
 
   type InlayHint<'valueExt when 'valueExt: comparison> with
@@ -376,6 +382,89 @@ module ProjectModel =
 
         parserResult
       }
+
+    static member TypeCheckSingleFile<'valueExt when 'valueExt: comparison>
+      (config: TypeCheckingConfig<'valueExt>)
+      (cache: ProjectCache<'valueExt>)
+      (project: ProjectBuildConfiguration)
+      (targetFilePath: string)
+      (targetFileContent: string)
+      : Sum<
+          TypeCheckContext<'valueExt> *
+          TypeCheckState<'valueExt>,
+          Errors<Location>
+         >
+      =
+      let filesInOrder = project.Files |> NonEmptyList.ToList
+
+      let targetIndex =
+        filesInOrder
+        |> List.tryFindIndex (fun f -> f.FileName.Path = targetFilePath)
+
+      match targetIndex with
+      | None ->
+        Errors.Singleton Location.Unknown (fun () ->
+          $"File '{targetFilePath}' is not part of the project.")
+        |> Sum.Right
+      | Some idx ->
+        sum {
+          let! predecessorCtx, predecessorSt =
+            if idx = 0 then
+              match cache.TryGetCachedState { Path = targetFilePath } with
+              | Some(_ctx, _st) ->
+                // For the first file, we don't have a predecessor.
+                // We need the initial context. Try getting cached state of a
+                // "virtual" predecessor - but there is none for the first file.
+                // We must return an error indicating a full build is needed.
+                sum.Throw(
+                  Errors.Singleton Location.Unknown (fun () ->
+                    "Cannot incrementally typecheck the first file in a project. A full build is needed.")
+                )
+              | None ->
+                sum.Throw(
+                  Errors.Singleton Location.Unknown (fun () ->
+                    "No cached state available. A full build is needed first.")
+                )
+            else
+              let predecessorFile = filesInOrder.[idx - 1]
+
+              match cache.TryGetCachedState predecessorFile.FileName with
+              | Some(ctx, st) -> sum.Return(ctx, st)
+              | None ->
+                sum.Throw(
+                  Errors.Singleton Location.Unknown (fun () ->
+                    $"No cached state for predecessor file '{predecessorFile.FileName.Path}'. A full build is needed first.")
+                )
+
+          let targetFile =
+            FileBuildConfiguration.FromFile(targetFilePath, targetFileContent)
+
+          let! ParserResult(program, _) =
+            targetFile
+            |> ProjectBuildConfiguration.ParseFile
+            |> sum.WithErrorContext(fun () ->
+              $"...while parsing {targetFilePath}")
+
+          let scopePrefixHints =
+            TypeCheckState.ComputeScopePrefixHints predecessorCtx predecessorSt
+
+          let st =
+            { predecessorSt with
+                ScopePrefixHints = scopePrefixHints
+                DotAccessHints = Map.empty
+                ScopeAccessHints = Map.empty
+                InlayHints = Map.empty }
+
+          let! (_typeCheckedExpr, ctx'), st' =
+            Expr.TypeCheck config None program
+            |> State.Run(predecessorCtx, st)
+            |> sum.MapError fst
+            |> sum.WithErrorContext(fun () ->
+              $"...while typechecking {targetFilePath}")
+
+          let st' = st' |> Option.defaultValue st
+          return ctx', st'
+        }
 
     static member BuildCached<'valueExt when 'valueExt: comparison>
       (config: TypeCheckingConfig<'valueExt>)

--- a/backend/libraries/ballerina-language-server/LanguageServer.fs
+++ b/backend/libraries/ballerina-language-server/LanguageServer.fs
@@ -329,6 +329,11 @@ module BuildServer =
       string
         -> (FileBuiltEventDTO -> unit)
         -> Sum<InlayHintDTO[] * ScopeSymbolDTO[] * int * int, Errors<Location>>)
+    (typecheckSingleFile:
+      string
+        -> string
+        -> string
+        -> Sum<FileBuiltEventDTO, Errors<Location>>)
     : int =
     let jsonOptions =
       JsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
@@ -337,62 +342,120 @@ module BuildServer =
     let mutable line = Console.ReadLine()
 
     while not (isNull line) do
-      let projectPath = line.Trim()
+      let trimmed = line.Trim()
 
-      if projectPath.Length > 0 then
-        Console.SetOut(Console.Error)
+      if trimmed.Length > 0 then
+        if trimmed.StartsWith("TYPECHECK\t") then
+          let parts = trimmed.Split('\t')
 
-        try
-          let emitFileEvent (event: FileBuiltEventDTO) =
-            Console.SetOut(savedOut)
-            let json = JsonSerializer.Serialize(event, jsonOptions)
-            Console.WriteLine(json)
-            Console.Out.Flush()
+          if parts.Length >= 4 then
+            let projectPath = parts.[1]
+            let filePath = parts.[2]
+            let fileContent = parts.[3] |> Convert.FromBase64String |> Text.Encoding.UTF8.GetString
+
             Console.SetOut(Console.Error)
 
-          let buildResult =
-            buildProjectStreaming projectPath emitFileEvent
+            try
+              let result = typecheckSingleFile projectPath filePath fileContent
 
-          Console.SetOut(savedOut)
+              Console.SetOut(savedOut)
 
-          match buildResult with
-          | Left(inlayHints, scopeSymbols, totalFiles, totalErrors) ->
-            let completeEvent: ProjectCompleteEventDTO =
-              { EventType = "project-complete"
-                Project = projectPath
-                TotalFiles = totalFiles
-                TotalErrors = totalErrors
-                InlayHints = inlayHints
-                ScopeSymbols = scopeSymbols }
+              match result with
+              | Left event ->
+                let json = JsonSerializer.Serialize(event, jsonOptions)
+                Console.WriteLine(json)
+                Console.Out.Flush()
+              | Right errors ->
+                let errorDtos =
+                  (Errors<_>.FilterHighestPriorityOnly errors).Errors()
+                  |> NonEmptyList.ToList
+                  |> List.map (fun e ->
+                    { Message = e.Message
+                      File = e.Context.File
+                      Line = e.Context.Line
+                      Column = e.Context.Column })
+                  |> List.toArray
 
-            let json =
-              JsonSerializer.Serialize(completeEvent, jsonOptions)
+                let errorResult: BuildResultDTO =
+                  { Success = false
+                    Errors = errorDtos
+                    InlayHints = [||] }
 
-            Console.WriteLine(json)
-            Console.Out.Flush()
-          | Right errors ->
-            let errorDtos =
-              (Errors<_>.FilterHighestPriorityOnly errors).Errors()
-              |> NonEmptyList.ToList
-              |> List.map (fun e ->
-                { Message = e.Message
-                  File = e.Context.File
-                  Line = e.Context.Line
-                  Column = e.Context.Column })
-              |> List.toArray
+                let json = JsonSerializer.Serialize(errorResult, jsonOptions)
+                Console.WriteLine(json)
+                Console.Out.Flush()
+            finally
+              Console.SetOut(savedOut)
+          else
+            Console.SetOut(savedOut)
 
             let errorResult: BuildResultDTO =
               { Success = false
-                Errors = errorDtos
+                Errors =
+                  [| { Message = "TYPECHECK command requires: TYPECHECK\\tprojectPath\\tfilePath\\tbase64content"
+                       File = "unknown"
+                       Line = 1
+                       Column = 1 } |]
                 InlayHints = [||] }
 
-            let json =
-              JsonSerializer.Serialize(errorResult, jsonOptions)
-
+            let json = JsonSerializer.Serialize(errorResult, jsonOptions)
             Console.WriteLine(json)
             Console.Out.Flush()
-        finally
-          Console.SetOut(savedOut)
+        else
+          let projectPath = trimmed
+          Console.SetOut(Console.Error)
+
+          try
+            let emitFileEvent (event: FileBuiltEventDTO) =
+              Console.SetOut(savedOut)
+              let json = JsonSerializer.Serialize(event, jsonOptions)
+              Console.WriteLine(json)
+              Console.Out.Flush()
+              Console.SetOut(Console.Error)
+
+            let buildResult =
+              buildProjectStreaming projectPath emitFileEvent
+
+            Console.SetOut(savedOut)
+
+            match buildResult with
+            | Left(inlayHints, scopeSymbols, totalFiles, totalErrors) ->
+              let completeEvent: ProjectCompleteEventDTO =
+                { EventType = "project-complete"
+                  Project = projectPath
+                  TotalFiles = totalFiles
+                  TotalErrors = totalErrors
+                  InlayHints = inlayHints
+                  ScopeSymbols = scopeSymbols }
+
+              let json =
+                JsonSerializer.Serialize(completeEvent, jsonOptions)
+
+              Console.WriteLine(json)
+              Console.Out.Flush()
+            | Right errors ->
+              let errorDtos =
+                (Errors<_>.FilterHighestPriorityOnly errors).Errors()
+                |> NonEmptyList.ToList
+                |> List.map (fun e ->
+                  { Message = e.Message
+                    File = e.Context.File
+                    Line = e.Context.Line
+                    Column = e.Context.Column })
+                |> List.toArray
+
+              let errorResult: BuildResultDTO =
+                { Success = false
+                  Errors = errorDtos
+                  InlayHints = [||] }
+
+              let json =
+                JsonSerializer.Serialize(errorResult, jsonOptions)
+
+              Console.WriteLine(json)
+              Console.Out.Flush()
+          finally
+            Console.SetOut(savedOut)
 
       line <- Console.ReadLine()
 

--- a/ballerina/Program.fs
+++ b/ballerina/Program.fs
@@ -100,8 +100,73 @@ let buildProjectStreamingForPath
     | Right errors -> Right errors
   | Right errors -> Right errors
 
+let typecheckSingleFileForPath
+  (projectPath: string)
+  (filePath: string)
+  (fileContent: string)
+  : Sum<FileBuiltEventDTO, Errors<Location>> =
+  match BuildServer.projectFromPath projectPath with
+  | Left project ->
+    match
+      ProjectBuildConfiguration.TypeCheckSingleFile
+        typeCheckingConfig
+        buildCache
+        project
+        filePath
+        fileContent
+    with
+    | Left(ctx, st) ->
+      let inlayHints =
+        BuildServer.inlayHintDtosForFile st filePath
+
+      let identifierHints =
+        BuildServer.identifierHintDtosFromContext ctx
+
+      let dotAccessHints =
+        BuildServer.dotAccessHintDtosForFile st filePath
+
+      let scopeAccessHints =
+        BuildServer.scopeAccessHintDtosForFile st filePath
+
+      let event: FileBuiltEventDTO =
+        { EventType = "file-built"
+          File = filePath
+          Success = true
+          Errors = [||]
+          InlayHints = inlayHints
+          IdentifierHints = identifierHints
+          DotAccessHints = dotAccessHints
+          ScopeAccessHints = scopeAccessHints }
+
+      Left event
+    | Right errors ->
+      let errorDtos =
+        (Errors<_>.FilterHighestPriorityOnly errors).Errors()
+        |> NonEmptyList.ToList
+        |> List.map (fun e ->
+          { Message = e.Message
+            File = e.Context.File
+            Line = e.Context.Line
+            Column = e.Context.Column })
+        |> List.toArray
+
+      let event: FileBuiltEventDTO =
+        { EventType = "file-built"
+          File = filePath
+          Success = false
+          Errors = errorDtos
+          InlayHints = [||]
+          IdentifierHints = [||]
+          DotAccessHints = [||]
+          ScopeAccessHints = [||] }
+
+      Left event
+  | Right errors -> Right errors
+
 let runServerLoopStreaming () =
-  BuildServer.runServerLoopStreaming buildProjectStreamingForPath
+  BuildServer.runServerLoopStreaming
+    buildProjectStreamingForPath
+    typecheckSingleFileForPath
 
 [<EntryPoint>]
 let main (args: string array) =

--- a/vscode-bl-extension/src/extension.ts
+++ b/vscode-bl-extension/src/extension.ts
@@ -87,10 +87,12 @@ type StreamingBuildResult = {
 const LANGUAGE_ID = "bl";
 const DIAGNOSTIC_SOURCE = "ballerina-language-tools";
 const BUILD_DEBOUNCE_MS = 50;
+const TYPECHECK_DEBOUNCE_MS = 150;
 let buildRunSequence = 0;
 let buildServerClient: BuildServerClient | undefined;
 let buildServerClientKey: string | undefined;
 let completionHintStore: CompletionHintStore | undefined;
+let hasCompletedInitialBuild = false;
 
 export function activate(context: vscode.ExtensionContext): void {
   const output = getOutputChannel();
@@ -117,6 +119,9 @@ export function activate(context: vscode.ExtensionContext): void {
 
   const debouncedBuilder = createDebouncedBuildScheduler(diagnostics, inlayHints);
   context.subscriptions.push({ dispose: () => debouncedBuilder.dispose() });
+
+  const debouncedTypecheck = createDebouncedTypecheckScheduler();
+  context.subscriptions.push({ dispose: () => debouncedTypecheck.dispose() });
 
   const buildActiveDisposable = vscode.commands.registerCommand("bl.buildActiveProject", async () => {
     const doc = vscode.window.activeTextEditor?.document;
@@ -178,7 +183,7 @@ export function activate(context: vscode.ExtensionContext): void {
   });
 
   const changeDisposable = vscode.workspace.onDidChangeTextDocument(async (event: vscode.TextDocumentChangeEvent) => {
-    if (!isBlOrBlprojDocument(event.document)) {
+    if (!isBlDocument(event.document)) {
       return;
     }
 
@@ -186,7 +191,11 @@ export function activate(context: vscode.ExtensionContext): void {
       return;
     }
 
-    await debouncedBuilder.schedule(event.document, false);
+    if (!hasCompletedInitialBuild) {
+      return;
+    }
+
+    await debouncedTypecheck.schedule(event.document);
   });
 
   context.subscriptions.push(buildActiveDisposable, showOrderDisposable, saveDisposable, changeDisposable);
@@ -304,6 +313,7 @@ async function runBuildFromProjectPath(
   applyDiagnostics(issues, diagnostics, workspaceFolder.uri.fsPath);
 
   if (buildOutput.exitCode === 0) {
+    hasCompletedInitialBuild = true;
     if (notifyOnSuccess) {
       void vscode.window.showInformationMessage("BL build succeeded.");
     }
@@ -429,6 +439,99 @@ async function saveDirtyDocumentsForProject(projectPath: string, suppressedSaveU
     if (!saved) {
       suppressedSaveUris.delete(uri);
     }
+  }
+}
+
+function createDebouncedTypecheckScheduler(): {
+  schedule: (doc: vscode.TextDocument) => void;
+  dispose: () => void;
+} {
+  const timers = new Map<string, number>();
+  const generations = new Map<string, number>();
+  const timerApi = globalThis as unknown as {
+    setTimeout: (handler: () => void, timeoutMs: number) => number;
+    clearTimeout: (timerId: number) => void;
+  };
+
+  return {
+    schedule: (doc: vscode.TextDocument): void => {
+      const filePath = doc.uri.fsPath;
+      const key = normalizePathKey(filePath);
+      const gen = (generations.get(key) ?? 0) + 1;
+      generations.set(key, gen);
+
+      const existing = timers.get(key);
+      if (existing !== undefined) {
+        timerApi.clearTimeout(existing);
+      }
+
+      const timer = timerApi.setTimeout(() => {
+        timers.delete(key);
+        if (generations.get(key) !== gen) {
+          return;
+        }
+        void runIncrementalTypecheck(doc, gen, generations);
+      }, TYPECHECK_DEBOUNCE_MS);
+
+      timers.set(key, timer);
+    },
+    dispose: (): void => {
+      for (const timer of timers.values()) {
+        timerApi.clearTimeout(timer);
+      }
+      timers.clear();
+      generations.clear();
+    }
+  };
+}
+
+async function runIncrementalTypecheck(
+  doc: vscode.TextDocument,
+  generation: number,
+  generations: Map<string, number>
+): Promise<void> {
+  const filePath = doc.uri.fsPath;
+  const key = normalizePathKey(filePath);
+
+  const projectPath = await resolveProjectForDocument(filePath);
+  if (!projectPath) {
+    return;
+  }
+
+  if (generations.get(key) !== generation) {
+    return;
+  }
+
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(projectPath));
+  if (!workspaceFolder) {
+    return;
+  }
+
+  const output = getOutputChannel();
+  const serverClient = getBuildServerClient(workspaceFolder.uri.fsPath, output);
+
+  try {
+    const event = await serverClient.typecheckSingleFile(
+      projectPath,
+      filePath,
+      doc.getText()
+    );
+
+    if (generations.get(key) !== generation) {
+      return;
+    }
+
+    if (event) {
+      completionHintStore?.updateForFile(
+        projectPath,
+        event.file ?? "",
+        event.dotAccessHints ?? [],
+        event.scopeAccessHints ?? [],
+        event.identifierHints ?? []
+      );
+    }
+  } catch {
+    // Silently ignore incremental typecheck failures; the full build will catch errors.
   }
 }
 
@@ -1017,6 +1120,21 @@ class BuildServerClient {
     return promise;
   }
 
+  typecheckSingleFile(
+    projectFilePath: string,
+    filePath: string,
+    fileContent: string
+  ): Promise<FileBuiltEventDto | undefined> {
+    const work = async (): Promise<FileBuiltEventDto | undefined> => {
+      await this.ensureStarted();
+      return this.sendTypecheckRequest(projectFilePath, filePath, fileContent);
+    };
+
+    const promise = this.requestChain.then(work, work);
+    this.requestChain = promise.then(() => undefined, () => undefined);
+    return promise;
+  }
+
   dispose(): void {
     this.stdoutReader?.close();
     this.stdoutReader = undefined;
@@ -1151,6 +1269,72 @@ class BuildServerClient {
       child.once("error", onError);
 
       child.stdin.write(`${projectFilePath}\n`, (err?: Error | null) => {
+        if (err) {
+          cleanup();
+          reject(err);
+        }
+      });
+    });
+  }
+
+  private async sendTypecheckRequest(
+    projectFilePath: string,
+    filePath: string,
+    fileContent: string
+  ): Promise<FileBuiltEventDto | undefined> {
+    const child = this.child;
+    const stdoutReader = this.stdoutReader;
+
+    if (!child || !stdoutReader || child.killed) {
+      throw new Error("Build server is not running.");
+    }
+
+    const base64Content = Buffer.from(fileContent, "utf-8").toString("base64");
+
+    return new Promise<FileBuiltEventDto | undefined>((resolve, reject) => {
+      const onLine = (line: string): void => {
+        const trimmed = line.trim();
+        if (trimmed.length === 0) {
+          return;
+        }
+
+        cleanup();
+
+        try {
+          const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+          const eventType = parsed.eventType as string | undefined;
+          if (eventType === "file-built") {
+            resolve(parsed as unknown as FileBuiltEventDto);
+          } else {
+            resolve(undefined);
+          }
+        } catch {
+          resolve(undefined);
+        }
+      };
+
+      const onClose = (): void => {
+        cleanup();
+        const stderrTail = this.stderrLines.join("").trim();
+        reject(new Error(stderrTail.length > 0 ? stderrTail : "Build server exited before responding."));
+      };
+
+      const onError = (err: unknown): void => {
+        cleanup();
+        reject(err instanceof Error ? err : new Error(String(err)));
+      };
+
+      const cleanup = (): void => {
+        stdoutReader.off("line", onLine);
+        child.off("close", onClose);
+        child.off("error", onError);
+      };
+
+      stdoutReader.on("line", onLine);
+      child.once("close", onClose);
+      child.once("error", onError);
+
+      child.stdin.write(`TYPECHECK\t${projectFilePath}\t${filePath}\t${base64Content}\n`, (err?: Error | null) => {
         if (err) {
           cleanup();
           reject(err);


### PR DESCRIPTION
## Summary

Adds incremental single-file typechecking to dramatically speed up autocompletion in the VSCode extension.

### Problem
Every keystroke (after 50ms debounce) triggered a full project rebuild via `server-streaming`. Even with caching, this iterated all files per request, creating noticeable latency for autocompletion.

### Solution
Add a `TYPECHECK` protocol command that reuses cached predecessor state and only parses + typechecks the changed file.

### Backend changes
- **ProjectModel.fs**: Added `TryGetCachedState` field to `ProjectCache` and `TypeCheckSingleFile` static method to `ProjectBuildConfiguration`
- **Caching.fs**: Implemented `TryGetCachedState` on the build cache
- **LanguageServer.fs**: Extended `runServerLoopStreaming` to handle `TYPECHECK\t{project}\t{file}\t{base64content}` requests
- **Program.fs**: Added `typecheckSingleFileForPath` that builds `FileBuiltEventDTO` with completion hints

### Extension changes
- After initial build completes, keystrokes trigger a 150ms-debounced single-file typecheck instead of a full rebuild
- Generation tracking cancels stale typecheck requests
- `BuildServerClient.typecheckSingleFile()` sends the TYPECHECK protocol and reads a single JSON response

### Testing
- All 25 integration tests pass
- uscreen.blproj builds successfully
- Extension compiles cleanly