### PR TITLE
feat: preserve partial typecheck state for Intellisense hints on broken files

### DIFF
--- a/backend/libraries/ballerina-cat/Stackless/State/WithError/Model.fs
+++ b/backend/libraries/ballerina-cat/Stackless/State/WithError/Model.fs
@@ -143,7 +143,7 @@ module StacklessStateWithError =
             | None -> ()
 
             match catchStack with
-            | [] -> Right(e, s')
+            | [] -> Right(e, Some s)
             | (err_k, savedBinds, savedS, savedLatestState, savedScope) :: rest ->
               catchStack <- rest // pop off current err handler
               bindStack <- savedBinds // restore the program to where it was before the current subroutine was started

--- a/backend/libraries/ballerina-lang-build/ProjectModel.fs
+++ b/backend/libraries/ballerina-lang-build/ProjectModel.fs
@@ -392,79 +392,88 @@ module ProjectModel =
       : Sum<
           TypeCheckContext<'valueExt> *
           TypeCheckState<'valueExt>,
-          Errors<Location>
+          Errors<Location> *
+          Option<TypeCheckState<'valueExt>>
          >
       =
       let filesInOrder = project.Files |> NonEmptyList.ToList
 
+      let targetFileName = Path.GetFileName targetFilePath
+
       let targetIndex =
         filesInOrder
-        |> List.tryFindIndex (fun f -> f.FileName.Path = targetFilePath)
+        |> List.tryFindIndex (fun f ->
+          Path.GetFileName(f.FileName.Path) = targetFileName)
 
       match targetIndex with
       | None ->
-        Errors.Singleton Location.Unknown (fun () ->
-          $"File '{targetFilePath}' is not part of the project.")
+        (Errors.Singleton Location.Unknown (fun () ->
+          $"File '{targetFilePath}' is not part of the project."),
+         None)
         |> Sum.Right
       | Some idx ->
-        sum {
-          let! predecessorCtx, predecessorSt =
-            if idx = 0 then
-              match cache.TryGetCachedState { Path = targetFilePath } with
-              | Some(_ctx, _st) ->
-                // For the first file, we don't have a predecessor.
-                // We need the initial context. Try getting cached state of a
-                // "virtual" predecessor - but there is none for the first file.
-                // We must return an error indicating a full build is needed.
-                sum.Throw(
-                  Errors.Singleton Location.Unknown (fun () ->
-                    "Cannot incrementally typecheck the first file in a project. A full build is needed.")
-                )
-              | None ->
-                sum.Throw(
-                  Errors.Singleton Location.Unknown (fun () ->
-                    "No cached state available. A full build is needed first.")
-                )
-            else
-              let predecessorFile = filesInOrder.[idx - 1]
+        let setupResult =
+          sum {
+            let! predecessorCtx, predecessorSt =
+              if idx = 0 then
+                match cache.TryGetCachedState { Path = targetFilePath } with
+                | Some(_ctx, _st) ->
+                  sum.Throw(
+                    Errors.Singleton Location.Unknown (fun () ->
+                      "Cannot incrementally typecheck the first file in a project. A full build is needed.")
+                  )
+                | None ->
+                  sum.Throw(
+                    Errors.Singleton Location.Unknown (fun () ->
+                      "No cached state available. A full build is needed first.")
+                  )
+              else
+                let predecessorFile = filesInOrder.[idx - 1]
 
-              match cache.TryGetCachedState predecessorFile.FileName with
-              | Some(ctx, st) -> sum.Return(ctx, st)
-              | None ->
-                sum.Throw(
-                  Errors.Singleton Location.Unknown (fun () ->
-                    $"No cached state for predecessor file '{predecessorFile.FileName.Path}'. A full build is needed first.")
-                )
+                match cache.TryGetCachedState predecessorFile.FileName with
+                | Some(ctx, st) -> sum.Return(ctx, st)
+                | None ->
+                  sum.Throw(
+                    Errors.Singleton Location.Unknown (fun () ->
+                      $"No cached state for predecessor file '{predecessorFile.FileName.Path}'. A full build is needed first.")
+                  )
 
-          let targetFile =
-            FileBuildConfiguration.FromFile(targetFilePath, targetFileContent)
+            let targetFile =
+              FileBuildConfiguration.FromFile(targetFilePath, targetFileContent)
 
-          let! ParserResult(program, _) =
-            targetFile
-            |> ProjectBuildConfiguration.ParseFile
-            |> sum.WithErrorContext(fun () ->
-              $"...while parsing {targetFilePath}")
+            let! ParserResult(program, _) =
+              targetFile
+              |> ProjectBuildConfiguration.ParseFile
+              |> sum.WithErrorContext(fun () ->
+                $"...while parsing {targetFilePath}")
 
-          let scopePrefixHints =
-            TypeCheckState.ComputeScopePrefixHints predecessorCtx predecessorSt
+            let scopePrefixHints =
+              TypeCheckState.ComputeScopePrefixHints predecessorCtx predecessorSt
 
-          let st =
-            { predecessorSt with
-                ScopePrefixHints = scopePrefixHints
-                DotAccessHints = Map.empty
-                ScopeAccessHints = Map.empty
-                InlayHints = Map.empty }
+            let st =
+              { predecessorSt with
+                  ScopePrefixHints = scopePrefixHints
+                  DotAccessHints = Map.empty
+                  ScopeAccessHints = Map.empty
+                  InlayHints = Map.empty }
 
-          let! (_typeCheckedExpr, ctx'), st' =
+            return predecessorCtx, st, program
+          }
+
+        match setupResult with
+        | Right errors -> Right(errors, None)
+        | Left(predecessorCtx, st, program) ->
+          let typecheckResult =
             Expr.TypeCheck config None program
             |> State.Run(predecessorCtx, st)
-            |> sum.MapError fst
-            |> sum.WithErrorContext(fun () ->
-              $"...while typechecking {targetFilePath}")
 
-          let st' = st' |> Option.defaultValue st
-          return ctx', st'
-        }
+          match typecheckResult with
+          | Left((_typeCheckedExpr, ctx'), stOpt) ->
+            let st' = stOpt |> Option.defaultValue st
+            Left(ctx', st')
+          | Right(errors, partialStOpt) ->
+            let partialSt = partialStOpt |> Option.defaultValue st
+            Right(errors, Some partialSt)
 
     static member BuildCached<'valueExt when 'valueExt: comparison>
       (config: TypeCheckingConfig<'valueExt>)

--- a/ballerina/Program.fs
+++ b/ballerina/Program.fs
@@ -139,7 +139,7 @@ let typecheckSingleFileForPath
           ScopeAccessHints = scopeAccessHints }
 
       Left event
-    | Right errors ->
+    | Right(errors, partialStOpt) ->
       let errorDtos =
         (Errors<_>.FilterHighestPriorityOnly errors).Errors()
         |> NonEmptyList.ToList
@@ -150,15 +150,30 @@ let typecheckSingleFileForPath
             Column = e.Context.Column })
         |> List.toArray
 
+      let dotAccessHints =
+        partialStOpt
+        |> Option.map (fun st -> BuildServer.dotAccessHintDtosForFile st filePath)
+        |> Option.defaultValue [||]
+
+      let scopeAccessHints =
+        partialStOpt
+        |> Option.map (fun st -> BuildServer.scopeAccessHintDtosForFile st filePath)
+        |> Option.defaultValue [||]
+
+      let inlayHints =
+        partialStOpt
+        |> Option.map (fun st -> BuildServer.inlayHintDtosForFile st filePath)
+        |> Option.defaultValue [||]
+
       let event: FileBuiltEventDTO =
         { EventType = "file-built"
           File = filePath
           Success = false
           Errors = errorDtos
-          InlayHints = [||]
+          InlayHints = inlayHints
           IdentifierHints = [||]
-          DotAccessHints = [||]
-          ScopeAccessHints = [||] }
+          DotAccessHints = dotAccessHints
+          ScopeAccessHints = scopeAccessHints }
 
       Left event
   | Right errors -> Right errors


### PR DESCRIPTION
## Summary

When a file has a type error (e.g., the user types `.` or `::` triggering autocompletion), the typechecker now preserves accumulated state so that dot-access hints, scope-access hints, and inlay hints are still returned to the editor.

Previously, `FreeNode.run` would discard all accumulated state when an unhandled error occurred (via `state.Throw` returning `None`), meaning no hints were available for broken files.

## Changes

- **`Model.fs` (ballerina-cat)**: `FreeNode.run` error path returns `Some s` (the mutable accumulated state) instead of the potentially-`None` value from `state.Throw`
- **`ProjectModel.fs` (ballerina-lang-build)**: `TypeCheckSingleFile` return type includes `Option<TypeCheckState>` on the error path. Also fixed file path comparison to use `Path.GetFileName` for consistent matching
- **`Program.fs` (ballerina)**: `typecheckSingleFileForPath` error path now extracts `dotAccessHints`, `scopeAccessHints`, and `inlayHints` from partial state instead of returning empty arrays

## Testing

- All 25 sample integration tests pass
- UScreen webshop builds successfully
- Protocol tests verified: dangling dot at EOF, dangling dot mid-file, and dangling dot + type mismatch all correctly return hints