### PR TITLE
perf: memoize type instantiation and add schema unification shortcut

### DIFF
--- a/backend/libraries/ballerina-lang/Next/TypeChecker/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/Model.fs
@@ -94,7 +94,9 @@ module Model =
       InlayHints: Map<Location, InlayHint<'valueExt>>
       DotAccessHints: Map<Location, DotAccessHint<'valueExt>>
       ScopeAccessHints: Map<Location, ScopeAccessHint>
-      ScopePrefixHints: Map<string, Map<string, string>> }
+      ScopePrefixHints: Map<string, Map<string, string>>
+      VarsVersion: int
+      MemoInstantiateVar: Map<struct(TypeVar * int), TypeValue<'valueExt>> }
 
   type TypeValueKindEval<'valueExt when 'valueExt: comparison> =
     Option<ExprTypeLetBindingName>

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/Patterns.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/Patterns.fs
@@ -161,7 +161,9 @@ module Patterns =
         InlayHints = Map.empty
         DotAccessHints = Map.empty
         ScopeAccessHints = Map.empty
-        ScopePrefixHints = Map.empty }
+        ScopePrefixHints = Map.empty
+        VarsVersion = 0
+        MemoInstantiateVar = Map.empty }
 
     static member Create
       (bindings: TypeBindings<'valueExt>, symbols: TypeExprEvalSymbols)
@@ -320,7 +322,10 @@ module Patterns =
       {| Vars =
           fun
               (u: Updater<UnificationState<'valueExt>>)
-              (c: TypeCheckState<'valueExt>) -> { c with Vars = c.Vars |> u }
+              (c: TypeCheckState<'valueExt>) ->
+            { c with
+                Vars = c.Vars |> u
+                VarsVersion = c.VarsVersion + 1 }
          Bindings =
           fun u (c: TypeCheckState<'valueExt>) ->
             { c with Bindings = c.Bindings |> u }
@@ -380,7 +385,11 @@ module Patterns =
                 { c with
                     Symbols =
                       { c.Symbols with
-                          UnionCases = c.Symbols.UnionCases |> u } } |} |}
+                          UnionCases = c.Symbols.UnionCases |> u } } |}
+         MemoInstantiateVar =
+          fun u (c: TypeCheckState<'valueExt>) ->
+            { c with
+                MemoInstantiateVar = c.MemoInstantiateVar |> u } |}
 
     static member unbindType x =
       state {
@@ -624,6 +633,72 @@ module Patterns =
           fun f (ctx: TypeInstantiateContext<'valueExt>) ->
             { ctx with
                 PermissionHooksExtraScope = f ctx.PermissionHooksExtraScope } |}
+
+  type TypeValue<'valueExt> with
+    /// Returns true when a TypeValue has no free type variables, lookups, or
+    /// unevaluated applications — i.e. instantiation is guaranteed to be the
+    /// identity function. Schemas are checked entity-by-entity.
+    static member IsConcrete<'ve when 've: comparison>
+      (tv: TypeValue<'ve>)
+      : bool =
+      match tv with
+      | TypeValue.Var _ | TypeValue.Lookup _ | TypeValue.Application _ -> false
+      | TypeValue.Primitive _ | TypeValue.QueryTypeFunction -> true
+      | TypeValue.Arrow { value = l, r } ->
+        TypeValue.IsConcrete l && TypeValue.IsConcrete r
+      | TypeValue.Record { value = fields } ->
+        fields |> OrderedMap.toSeq |> Seq.forall (fun (_, (v, _)) -> TypeValue.IsConcrete v)
+      | TypeValue.Tuple { value = es } ->
+        es |> List.forall TypeValue.IsConcrete
+      | TypeValue.Union { value = es } ->
+        es |> OrderedMap.toSeq |> Seq.forall (fun (_, v) -> TypeValue.IsConcrete v)
+      | TypeValue.Sum { value = es } ->
+        es |> List.forall TypeValue.IsConcrete
+      | TypeValue.Set { value = v } -> TypeValue.IsConcrete v
+      | TypeValue.Imported { Arguments = args } ->
+        args |> List.forall TypeValue.IsConcrete
+      | TypeValue.Lambda _ -> false
+      | TypeValue.Schema s ->
+        s.Entities |> OrderedMap.toSeq |> Seq.forall (fun (_, e) ->
+          TypeValue.IsConcrete e.TypeOriginal
+          && TypeValue.IsConcrete e.TypeWithProps
+          && TypeValue.IsConcrete e.Id)
+      | TypeValue.Entities s | TypeValue.Relations s ->
+        s.Entities |> OrderedMap.toSeq |> Seq.forall (fun (_, e) ->
+          TypeValue.IsConcrete e.TypeOriginal
+          && TypeValue.IsConcrete e.TypeWithProps
+          && TypeValue.IsConcrete e.Id)
+      | TypeValue.Entity(s, e, e', eid) ->
+        TypeValue.IsConcrete(TypeValue.Schema s)
+        && TypeValue.IsConcrete e
+        && TypeValue.IsConcrete e'
+        && TypeValue.IsConcrete eid
+      | TypeValue.Relation(s, _, _, f, f', fid, t, t', tid) ->
+        TypeValue.IsConcrete(TypeValue.Schema s)
+        && TypeValue.IsConcrete f && TypeValue.IsConcrete f'
+        && TypeValue.IsConcrete fid
+        && TypeValue.IsConcrete t && TypeValue.IsConcrete t'
+        && TypeValue.IsConcrete tid
+      | TypeValue.ForeignKeyRelation(s, _, f, f', fid, t, t', tid) ->
+        TypeValue.IsConcrete(TypeValue.Schema s)
+        && TypeValue.IsConcrete f && TypeValue.IsConcrete f'
+        && TypeValue.IsConcrete fid
+        && TypeValue.IsConcrete t && TypeValue.IsConcrete t'
+        && TypeValue.IsConcrete tid
+      | TypeValue.RelationLookupOption(s, sid, t', tid)
+      | TypeValue.RelationLookupOne(s, sid, t', tid)
+      | TypeValue.RelationLookupMany(s, sid, t', tid) ->
+        TypeValue.IsConcrete(TypeValue.Schema s)
+        && TypeValue.IsConcrete sid
+        && TypeValue.IsConcrete t'
+        && TypeValue.IsConcrete tid
+      | TypeValue.QueryRow row ->
+        match row with
+        | TypeQueryRow.PrimaryKey t | TypeQueryRow.Json t -> TypeValue.IsConcrete t
+        | TypeQueryRow.PrimitiveType _ -> true
+        | TypeQueryRow.Tuple _ -> true
+        | TypeQueryRow.Record _ -> true
+        | TypeQueryRow.Array _ -> true
 
   type TypeCheckState<'valueExt when 'valueExt: comparison> with
     // static member ToInstantiationContext

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/Unification/Unification.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/Unification/Unification.fs
@@ -595,10 +595,17 @@ module Unification =
       let unifySchemas e1 e2 =
         state {
           if
+            e1.DeclaredAtForNominalEquality = e2.DeclaredAtForNominalEquality
+            && TypeValue.IsConcrete(TypeValue.Schema e1)
+            && TypeValue.IsConcrete(TypeValue.Schema e2)
+          then
+            // Same schema declaration and both fully concrete — entity types
+            // are identical so structural unification would be a no-op.
+            return ()
+          elif
             not (
               e1.Entities.Count = e2.Entities.Count
               && e1.Relations.Count = e2.Relations.Count
-            // && e1.DeclaredAtForNominalEquality = e2.DeclaredAtForNominalEquality
             )
           then
             return!
@@ -1084,6 +1091,10 @@ module Unification =
       =
       fun typeEval loc0 t ->
         state {
+          if TypeValue.IsConcrete t then
+            return t
+          else
+
           let error e = Errors.Singleton loc0 e
 
           let instantiateSchema schema =
@@ -1281,6 +1292,11 @@ module Unification =
               // return! Errors.Singleton $"Infinite type instantiation for variable {v}" |> state.Throw
               return t
             else
+              let memoKey = struct(v, s.VarsVersion)
+              match s.MemoInstantiateVar |> Map.tryFind memoKey with
+              | Some cached -> return cached
+              | None ->
+
               let localCtx =
                 { EvalState = s
                   Scope = ctx.Scope
@@ -1315,11 +1331,15 @@ module Unification =
 
               match vClass.Representative with
               | Some rep ->
-                return!
+                let! result =
                   TypeValue.Instantiate () typeEval loc0 rep
                   |> state.MapContext(
                     TypeInstantiateContext.Updaters.VisitedVars(Set.add v)
                   )
+                do! state.SetState(
+                      TypeCheckState.Updaters.MemoInstantiateVar(
+                        Map.add memoKey result))
+                return result
               | None ->
                 match
                   vClass.Variables
@@ -1339,7 +1359,12 @@ module Unification =
                       $"Variable {v} has no representative in the equivalence class")
                     |> error
                     |> state.Throw
-                | x :: xs -> return! NonEmptyList.OfList(x, xs) |> state.Any
+                | x :: xs ->
+                  let! result = NonEmptyList.OfList(x, xs) |> state.Any
+                  do! state.SetState(
+                        TypeCheckState.Updaters.MemoInstantiateVar(
+                          Map.add memoKey result))
+                  return result
           | TypeValue.Lookup l ->
             let! ctx = state.GetContext()
             let! s = state.GetState()


### PR DESCRIPTION
## Summary

Reduces typechecking time for `seed-uscreen-data.bl` from **~27s to ~10s** (63% improvement).

## Changes

### 1. `TypeValue.IsConcrete` (Patterns.fs)
Fast recursive check that returns `true` when a TypeValue has no free type variables, unresolved lookups, or unapplied type applications. Covers all DU cases including Schema (checks all entity TypeOriginal/TypeWithProps/Id).

### 2. Instantiate short-circuit for concrete types (Unification.fs)
At the top of `TypeValue.Instantiate`, if `IsConcrete(t)` returns true, the type is returned immediately — no state monad overhead, no equivalence class lookups, no recursive traversal.

### 3. TypeVar instantiation memoization (Unification.fs)
Adds `MemoInstantiateVar: Map<struct(TypeVar * int), TypeValue>` to `TypeCheckState`. The cache key is `(TypeVar, VarsVersion)` where `VarsVersion` is a monotonically increasing counter that increments on every equivalence class update. Cache hits skip the equivalence class lookup and recursive resolution.

### 4. VarsVersion counter (Model.fs, Patterns.fs)
Added `VarsVersion: int` field to `TypeCheckState`. The `Updaters.Vars` function now increments the version on every update. This provides a lightweight invalidation mechanism for the instantiation cache.

### 5. Schema unification shortcut (Unification.fs)
In `unifySchemas`, when both schemas have the same `DeclaredAtForNominalEquality` AND both are concrete (verified via `IsConcrete`), the per-entity structural comparison is skipped entirely. This is safe because identical concrete schemas produce no new type variable bindings.

## Testing

- All 25 sample integration tests pass (including fresh cache runs)
- All 8 webshop projects build successfully: stdlib, simple-test, uscreen, bise, ticketmaster, template, appointments, yeahgummy
- Performance benchmark: `seed-uscreen-data.bl` typechecking ~27s → ~10s