### PR TITLE
perf: replace parser.Any with token-based dispatch for simple expressions

### DIFF
--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Expr.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Expr.fs
@@ -974,48 +974,34 @@ module Expr =
       | Token.Operator Operator.Bang -> true
       | _ -> false
 
-    let simpleShapes =
-      [ stringLiteral ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu1"))
-        intLiteral ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu2"))
-        int64Literal ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu3"))
-        caseLiteral () |> parser.Map Expr.SumCons
-        // |> parser.MapError(Errors.Map((+) "bubububububu4"))
-        decimalLiteral ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu5"))
-        float32Literal ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu6"))
-        float64Literal ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu7"))
-        boolLiteral ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu8"))
-        unitLiteral ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu9"))
-        exprLambda ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu10"))
-        exprConditional ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu11"))
-        recordCons ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu12"))
-        betweenBrackets (fun () -> expr parseAllComplexShapes)
-        // |> parser.MapError(Errors.Map((+) "bubububububu13"))
-        typeLet ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu14"))
-        matchWith ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu15"))
-        query (fun () -> expr parseAllComplexShapes) ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu16"))
-        identifierLookup ()
-        // |> parser.MapError(Errors.Map(replaceWith "bubububububu17"))
-        unaryOperatorIdentifier ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu18"))
-        exprLet ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu19"))
-        exprDo ()
-        // |> parser.MapError(Errors.Map((+) "bubububububu20"))
-        ]
+    let simpleShapesByToken (t: LocalizedToken) =
+      match t.Token with
+      | Token.StringLiteral _ -> [ stringLiteral () ]
+      | Token.IntLiteral _ -> [ intLiteral () ]
+      | Token.Int64Literal _ -> [ int64Literal () ]
+      | Token.CaseLiteral _ -> [ caseLiteral () |> parser.Map Expr.SumCons ]
+      | Token.DecimalLiteral _ -> [ decimalLiteral () ]
+      | Token.Float32Literal _ -> [ float32Literal () ]
+      | Token.Float64Literal _ -> [ float64Literal () ]
+      | Token.BoolLiteral _ -> [ boolLiteral () ]
+      | Token.Operator(Operator.RoundBracket Bracket.Open) ->
+        [ unitLiteral ()
+          betweenBrackets (fun () -> expr parseAllComplexShapes) ]
+      | Token.Keyword Keyword.Fun -> [ exprLambda () ]
+      | Token.Keyword Keyword.If -> [ exprConditional () ]
+      | Token.Operator(Operator.CurlyBracket Bracket.Open) -> [ recordCons () ]
+      | Token.Keyword Keyword.Type -> [ typeLet () ]
+      | Token.Keyword Keyword.Match -> [ matchWith () ]
+      | Token.Keyword Keyword.Query ->
+        [ query (fun () -> expr parseAllComplexShapes) () ]
+      | Token.Identifier _
+      | Token.Keyword Keyword.Schema
+      | Token.Keyword Keyword.Entity
+      | Token.Keyword Keyword.Relation -> [ identifierLookup () ]
+      | Token.Operator Operator.Bang -> [ unaryOperatorIdentifier () ]
+      | Token.Keyword Keyword.Let -> [ exprLet () ]
+      | Token.Keyword Keyword.Do -> [ exprDo () ]
+      | _ -> []
 
     parser {
       // let! s = parser.Stream
@@ -1028,10 +1014,28 @@ module Expr =
       // do Console.ReadLine() |> ignore
 
       if parseComplexShapes |> Set.isEmpty then
-        return!
-          simpleShapes
-          |> parser.Any
-          |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
+        let! stream = parser.Stream
+        match stream with
+        | t :: _ ->
+          match simpleShapesByToken t with
+          | [ single ] -> return! single
+          | multiple when multiple.Length > 0 ->
+            return!
+              multiple
+              |> parser.Any
+              |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
+          | _ ->
+            let! loc = parser.Location
+            return!
+              (fun () -> $"Unexpected symbol: `{t.Token}`")
+              |> Errors.Singleton loc
+              |> parser.Throw
+        | [] ->
+          let! loc = parser.Location
+          return!
+            (fun () -> "Unexpected end of input")
+            |> Errors.Singleton loc
+            |> parser.Throw
       else
         // let! s = parser.Stream
 


### PR DESCRIPTION
## Summary

Replace the sequential `parser.Any` over all 20 simple expression parsers with a token-based dispatch that peeks at the first token and directly selects the matching parser(s).

## Motivation

`parser.Any` tries each parser in order, saving/restoring state on each failure. For simple expressions, this means up to 19 failed-and-backtracked attempts before finding the right parser. Since `expr()` is called recursively for every sub-expression in the AST, this backtracking cost is significant.

## Approach

Added a `simpleShapesByToken` function that maps the first token to the relevant parser(s):

| Token | Parser(s) |
|-------|-----------|
| `StringLiteral` | `stringLiteral()` |
| `IntLiteral` | `intLiteral()` |
| `Int64Literal` | `int64Literal()` |
| `CaseLiteral` | `caseLiteral()` |
| `DecimalLiteral` | `decimalLiteral()` |
| `Float32Literal` | `float32Literal()` |
| `Float64Literal` | `float64Literal()` |
| `BoolLiteral` | `boolLiteral()` |
| `RoundBracket Open` | `unitLiteral()` or `betweenBrackets(...)` |
| `Keyword Fun` | `exprLambda()` |
| `Keyword If` | `exprConditional()` |
| `CurlyBracket Open` | `recordCons()` |
| `Keyword Type` | `typeLet()` |
| `Keyword Match` | `matchWith()` |
| `Keyword Query` | `query(...)()` |
| `Identifier`/`Schema`/`Entity`/`Relation` | `identifierLookup()` |
| `Bang` | `unaryOperatorIdentifier()` |
| `Keyword Let` | `exprLet()` |
| `Keyword Do` | `exprDo()` |
| Unknown | immediate error (no backtracking) |

When a token maps to a single parser, that parser is called directly (no `parser.Any` overhead). When mapped to multiple alternatives (only `(` currently), a small `parser.Any` runs over just those 2 options.

## Testing

- All 25 sample integration tests pass (fresh cache)
- All 8 webshop projects build successfully (fresh cache)