### PR TITLE
perf: fast extension applicables, scope chain variable lookup, EvalApply fast path

### DIFF
--- a/backend/libraries/ballerina-lang/Next/Eval/Expr_Eval.fs
+++ b/backend/libraries/ballerina-lang/Next/Eval/Expr_Eval.fs
@@ -36,7 +36,8 @@ module Eval =
                   (fun () -> $"Error: cannot evaluate empty extension")
                   |> Errors.Singleton loc0
                   |> reader.Throw
-              Applicables = Map.empty } }
+              Applicables = Map.empty
+              FastApplicables = Map.empty } }
 
     static member WithTypeCheckingSymbols<'valueExtension>
       (ctx: ExprEvalContext<'runtimeContext, 'valueExtension>)
@@ -85,44 +86,19 @@ module Eval =
 
   type Expr<'T, 'Id, 'valueExt when 'Id: comparison> with
     static member EvalApply (loc0: Location) (rest: List<_>) (fV, argV) =
-      reader {
-        let! fVVar, fvBody, closure, _scope =
-          fV
-          |> Value.AsLambda
-          |> sum.MapError(Errors.MapContext(replaceWith loc0))
-          |> reader.OfSum
-
-        return!
-          reader {
-            let closure =
-              closure
-              |> Map.add
-                (fVVar.Name
-                 |> Identifier.LocalScope
-                 |> TypeCheckScope.Empty.Resolve)
-                argV
-
-            let! res =
-              NonEmptyList.OfList(fvBody, rest)
-              |> Expr.Eval
-              |> reader.MapContext(
-                ExprEvalContext.Updaters.Values(Map.merge (fun _ -> id) closure)
-              )
-              |> reader.Catch
-
-            match res with
-            | Left res -> return res
-            | Right err ->
-              // do Console.WriteLine($"Warning: error during function application {fV} {argV} ({fvBody})")
-              // do Console.ReadLine() |> ignore
-              // do closure |> Map.iter (fun k v -> Console.WriteLine($"  {k} = {v}"))
-              // do Console.ReadLine() |> ignore
-              return! err |> reader.Throw
-          }
-          |> reader.MapError(
-            Errors<Location>.MapPriority(replaceWith ErrorPriority.High)
+      Reader(fun (ctx: ExprEvalContext<'runtimeContext, 'valueExtension>) ->
+        try
+          Left(
+            fastApply<'runtimeContext, 'valueExtension>
+              loc0
+              TypeCheckScope.Empty
+              rest
+              ctx
+              fV
+              argV
           )
-      }
+        with :? EvalException as ex ->
+          Right ex.Errors)
 
     // NOTE: expressions are concatenated in the order of the input (the returned value is of the type of the last expression)
     static member Eval<'runtimeContext, 'valueExtension>

--- a/backend/libraries/ballerina-lang/Next/Eval/Expr_Eval.fs
+++ b/backend/libraries/ballerina-lang/Next/Eval/Expr_Eval.fs
@@ -27,6 +27,7 @@ module Eval =
       fun runtimeContext ->
         { RootLevelEval = true
           RuntimeContext = runtimeContext
+          ValueOverlays = []
           Scope =
             { Values = Map.empty
               Symbols = ExprEvalContextSymbols.Empty }

--- a/backend/libraries/ballerina-lang/Next/Eval/Expr_FastEval.fs
+++ b/backend/libraries/ballerina-lang/Next/Eval/Expr_FastEval.fs
@@ -118,12 +118,25 @@ module FastEval =
         ExtEvalResult<'runtimeContext, 'valueExtension>
        >
 
+  and FastApplicable<'runtimeContext, 'valueExtension> =
+    Location
+      -> List<RunnableExpr<'valueExtension>>
+      -> ExprEvalContext<'runtimeContext, 'valueExtension>
+      -> 'valueExtension
+      -> Value<TypeValue<'valueExtension>, 'valueExtension>
+      -> Value<TypeValue<'valueExtension>, 'valueExtension>
+
   and ValueExtensionOps<'runtimeContext, 'valueExtension> =
     { Eval: ExtensionEvaluator<'runtimeContext, 'valueExtension>
       Applicables:
         Map<
           ResolvedIdentifier,
           ApplicableExtEvalResult<'runtimeContext, 'valueExtension>
+         >
+      FastApplicables:
+        Map<
+          ResolvedIdentifier,
+          FastApplicable<'runtimeContext, 'valueExtension>
          > }
 
   and ExprEvaluator<'runtimeContext, 'valueExtension, 'res> =
@@ -308,6 +321,31 @@ module FastEval =
 
   let private compilationCache =
     ConditionalWeakTable<obj, obj>()
+
+  // Cache for closure-context merges in Lambda application.
+  // When the same Lambda is applied to many values (e.g. List.map),
+  // the expensive closure-into-context fold is computed once and reused.
+  // Key: closure Map reference. Value: obj[2] = [| ctxRef; mergedMap |].
+  let private closureMergeCache =
+    ConditionalWeakTable<obj, obj[]>()
+
+  let inline private getCachedMerge
+    (closure: Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>>)
+    (ctxValues: Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>>)
+    : Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>> =
+    let closureObj = closure :> obj
+    match closureMergeCache.TryGetValue(closureObj) with
+    | true, entry ->
+      if System.Object.ReferenceEquals(entry[0], ctxValues :> obj) then
+        entry[1] :?> Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>>
+      else
+        let merged = closure |> Map.fold (fun acc k v -> Map.add k v acc) ctxValues
+        closureMergeCache.AddOrUpdate(closureObj, [| ctxValues :> obj; merged :> obj |])
+        merged
+    | false, _ ->
+      let merged = closure |> Map.fold (fun acc k v -> Map.add k v acc) ctxValues
+      closureMergeCache.AddOrUpdate(closureObj, [| ctxValues :> obj; merged :> obj |])
+      merged
 
   // Helper to extend context with additional values (avoids record disambiguation issues)
   let inline extendValues
@@ -906,12 +944,12 @@ module FastEval =
         |> Identifier.LocalScope
         |> TypeCheckScope.Empty.Resolve
 
-      let closure = closure |> Map.add resolvedParam argV
-
       let compiledBody = compileSequence<'rc, 'ext> (NonEmptyList.OfList(body, rest))
 
-      let mergedValues =
-        Map.merge (fun _ -> id) closure ctx.Scope.Values
+      // Cache the closure-context merge: when the same Lambda is applied to many values
+      // (List.map pattern), the expensive fold is computed once and reused.
+      let mergedBase = getCachedMerge closure ctx.Scope.Values
+      let mergedValues = mergedBase |> Map.add resolvedParam argV
 
       compiledBody (ctx |> extendValues (fun _ -> mergedValues))
 
@@ -949,6 +987,11 @@ module FastEval =
     | Value.Ext(fExt, appId) ->
       match appId with
       | Some appId ->
+        // Fast path: pre-compiled applicable (no Reader overhead)
+        match ctx.ExtensionOps.FastApplicables |> Map.tryFind appId with
+        | Some f -> f loc0 rest ctx fExt argV
+        | None ->
+        // Fallback: Reader-based applicable
         match ctx.ExtensionOps.Applicables |> Map.tryFind appId with
         | Some f -> runReader loc0 (f loc0 rest fExt argV) ctx
         | None ->

--- a/backend/libraries/ballerina-lang/Next/Eval/Expr_FastEval.fs
+++ b/backend/libraries/ballerina-lang/Next/Eval/Expr_FastEval.fs
@@ -61,6 +61,14 @@ module FastEval =
 
   type ExprEvalContext<'runtimeContext, 'valueExtension> =
     { Scope: ExprEvalContextScope<'valueExtension>
+      /// Stack of scope frames pushed during evaluation.
+      /// Lookup traverses frames top-to-bottom, then falls back to Scope.Values.
+      /// Empty outside the JIT fast path; flushed before bridging to Reader-based code.
+      ValueOverlays:
+        Map<
+          ResolvedIdentifier,
+          Value<TypeValue<'valueExtension>, 'valueExtension>
+         > list
       ExtensionOps: ValueExtensionOps<'runtimeContext, 'valueExtension>
       RuntimeContext: 'runtimeContext
       RootLevelEval: bool }
@@ -301,17 +309,109 @@ module FastEval =
       )
 
   // ── Bridge: run Reader-based extension code from fast eval ─────────────
+  // Flushes overlays into Scope.Values so Reader-based code sees a flat scope.
+
+  // Cache for flattenScope: avoids re-merging when the same overlay list + base are flattened
+  // repeatedly (e.g., multiple Lambda creations inside the same let-binding body).
+  let private flattenCache =
+    ConditionalWeakTable<obj, obj[]>()
+
+  let flattenScope
+    (ctx: ExprEvalContext<'rc, 'ext>)
+    : Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>> =
+    match ctx.ValueOverlays with
+    | [] -> ctx.Scope.Values
+    | overlays ->
+      // Cache: if the same overlay list (by reference) is flattened with the same base,
+      // return the cached result. Common in Lambda creation inside let-heavy bodies.
+      let key = overlays :> obj
+      match flattenCache.TryGetValue(key) with
+      | true, entry ->
+        if System.Object.ReferenceEquals(entry[0], ctx.Scope.Values :> obj) then
+          entry[1] :?> Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>>
+        else
+          let result =
+            overlays
+            |> List.foldBack
+              (fun frame acc -> frame |> Map.fold (fun a k v -> Map.add k v a) acc)
+              <| ctx.Scope.Values
+          flattenCache.AddOrUpdate(key, [| ctx.Scope.Values :> obj; result :> obj |])
+          result
+      | false, _ ->
+        let result =
+          overlays
+          |> List.foldBack
+            (fun frame acc -> frame |> Map.fold (fun a k v -> Map.add k v a) acc)
+            <| ctx.Scope.Values
+        flattenCache.AddOrUpdate(key, [| ctx.Scope.Values :> obj; result :> obj |])
+        result
+
+  let inline flushOverlays
+    (ctx: ExprEvalContext<'rc, 'ext>)
+    : ExprEvalContext<'rc, 'ext> =
+    match ctx.ValueOverlays with
+    | [] -> ctx
+    | _ ->
+      { ctx with
+          Scope = { ctx.Scope with Values = flattenScope ctx }
+          ValueOverlays = [] }
 
   let inline runReader
     (_loc: Location)
     (r: Reader<'a, ExprEvalContext<'rc, 'ext>, Errors<Location>>)
     (ctx: ExprEvalContext<'rc, 'ext>)
     : 'a =
+    let ctx = flushOverlays ctx
     match Reader.Run ctx r with
     | Left v -> v
     | Right errors -> raise (EvalException(errors))
 
-  // ── Memoization cache ──────────────────────────────────────────────────
+  // ── Scope chain helpers ────────────────────────────────────────────────
+  // Instead of merging closures/bindings into Scope.Values (expensive Map merge),
+  // we push lightweight frames onto ValueOverlays and traverse top-to-bottom on lookup.
+  // Lambda application becomes O(1) push instead of O(|closure| * log |ctx|) merge.
+
+  let inline lookupValue
+    (id: ResolvedIdentifier)
+    (ctx: ExprEvalContext<'rc, 'ext>)
+    : Value<TypeValue<'ext>, 'ext> voption =
+    let rec search frames =
+      match frames with
+      | [] -> Map.tryFind id ctx.Scope.Values |> ValueOption.ofOption
+      | frame :: rest ->
+        match Map.tryFind id frame with
+        | Some v -> ValueSome v
+        | None -> search rest
+    search ctx.ValueOverlays
+
+  let inline pushBinding
+    (id: ResolvedIdentifier)
+    (value: Value<TypeValue<'ext>, 'ext>)
+    (ctx: ExprEvalContext<'rc, 'ext>)
+    : ExprEvalContext<'rc, 'ext> =
+    match ctx.ValueOverlays with
+    | top :: rest ->
+      { ctx with ValueOverlays = (Map.add id value top) :: rest }
+    | [] ->
+      { ctx with ValueOverlays = [ Map.ofList [ id, value ] ] }
+
+  let inline pushFrame
+    (frame: Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>>)
+    (ctx: ExprEvalContext<'rc, 'ext>)
+    : ExprEvalContext<'rc, 'ext> =
+    { ctx with ValueOverlays = frame :: ctx.ValueOverlays }
+
+  // Legacy helper — still used by some external callers through Updaters.Values
+  let inline extendValues
+    (updater: Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>> -> Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>>)
+    (ctx: ExprEvalContext<'rc, 'ext>)
+    : ExprEvalContext<'rc, 'ext> =
+    { ctx with
+        Scope =
+          { ctx.Scope with
+              Values = updater ctx.Scope.Values } }
+
+  // ── Memoization caches ──────────────────────────────────────────────────
   // ConditionalWeakTable: keys are held weakly. When a RunnableExpr is GC'd
   // (e.g. schema reload), the compiled lambda is collected automatically.
   // Thread-safe by default.
@@ -321,41 +421,6 @@ module FastEval =
 
   let private compilationCache =
     ConditionalWeakTable<obj, obj>()
-
-  // Cache for closure-context merges in Lambda application.
-  // When the same Lambda is applied to many values (e.g. List.map),
-  // the expensive closure-into-context fold is computed once and reused.
-  // Key: closure Map reference. Value: obj[2] = [| ctxRef; mergedMap |].
-  let private closureMergeCache =
-    ConditionalWeakTable<obj, obj[]>()
-
-  let inline private getCachedMerge
-    (closure: Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>>)
-    (ctxValues: Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>>)
-    : Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>> =
-    let closureObj = closure :> obj
-    match closureMergeCache.TryGetValue(closureObj) with
-    | true, entry ->
-      if System.Object.ReferenceEquals(entry[0], ctxValues :> obj) then
-        entry[1] :?> Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>>
-      else
-        let merged = closure |> Map.fold (fun acc k v -> Map.add k v acc) ctxValues
-        closureMergeCache.AddOrUpdate(closureObj, [| ctxValues :> obj; merged :> obj |])
-        merged
-    | false, _ ->
-      let merged = closure |> Map.fold (fun acc k v -> Map.add k v acc) ctxValues
-      closureMergeCache.AddOrUpdate(closureObj, [| ctxValues :> obj; merged :> obj |])
-      merged
-
-  // Helper to extend context with additional values (avoids record disambiguation issues)
-  let inline extendValues
-    (updater: Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>> -> Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>>)
-    (ctx: ExprEvalContext<'rc, 'ext>)
-    : ExprEvalContext<'rc, 'ext> =
-    { ctx with
-        Scope =
-          { ctx.Scope with
-              Values = updater ctx.Scope.Values } }
 
   // ── Core JIT compiler ──────────────────────────────────────────────────
 
@@ -426,7 +491,7 @@ module FastEval =
 
       fun ctx ->
         let value = compiledVal ctx
-        let ctx' = ctx |> extendValues (Map.add resolvedId value)
+        let ctx' = pushBinding resolvedId value ctx
         compiledBody ctx'
 
     // ── Do (sequence, discard first) ──────────────────────────────
@@ -441,12 +506,16 @@ module FastEval =
     // ── Lookup ────────────────────────────────────────────────────
     | RunnableExprRec.Lookup({ Id = id }) ->
       fun ctx ->
-        fastMapFind
-          loc0
-          "variables"
-          (fun () -> id.AsFSharpString)
-          id
-          ctx.Scope.Values
+        match lookupValue id ctx with
+        | ValueSome v -> v
+        | ValueNone ->
+          raise (
+            EvalException(
+              Errors.Singleton
+                loc0
+                (fun () -> $"Cannot find variables '{id.AsFSharpString}'")
+            )
+          )
 
     // ── Record construction ───────────────────────────────────────
     | RunnableExprRec.RecordCons { Fields = fields } ->
@@ -576,7 +645,7 @@ module FastEval =
                 let resolvedId =
                   caseVar.Name |> Identifier.LocalScope |> e.Scope.Resolve
 
-                ctx |> extendValues (Map.add resolvedId innerV)
+                pushBinding resolvedId innerV ctx
 
             compiledBody ctx'
           | None ->
@@ -650,7 +719,7 @@ module FastEval =
             let resolvedId =
               caseVar.Name |> Identifier.LocalScope |> e.Scope.Resolve
 
-            ctx |> extendValues (Map.add resolvedId innerV)
+            pushBinding resolvedId innerV ctx
 
         compiledBody ctx'
 
@@ -672,7 +741,7 @@ module FastEval =
     // ── Lambda ────────────────────────────────────────────────────
     | RunnableExprRec.Lambda { RunnableExprLambda.Param = var
                                RunnableExprLambda.Body = body } ->
-      fun ctx -> Value.Lambda(var, body, ctx.Scope.Values, e.Scope)
+      fun ctx -> Value.Lambda(var, body, flattenScope ctx, e.Scope)
 
     // ── TypeLambda (type params erased at runtime) ────────────────
     | RunnableExprRec.TypeLambda({ Param = _; Body = body }) ->
@@ -738,14 +807,11 @@ module FastEval =
         | Right _ -> []
 
       let allBindings = unionBindings @ recordBindings
+      let bindingsFrame = allBindings |> Map.ofList
       let compiledBody = compileWithRest<'rc, 'ext> body rest
 
       fun ctx ->
-        let values =
-          allBindings
-          |> List.fold (fun acc (k, v) -> Map.add k v acc) ctx.Scope.Values
-
-        compiledBody (ctx |> extendValues (fun _ -> values))
+        compiledBody (pushFrame bindingsFrame ctx)
 
     // ── EntitiesDes ───────────────────────────────────────────────
     | RunnableExprRec.EntitiesDes({ Expr = s }) ->
@@ -869,9 +935,10 @@ module FastEval =
               VarType = it.VarType
               Source = compiledSource ctx })
 
-        // Build closure map
+        // Build closure map (flatten overlays to get full scope)
+        let allValues = flattenScope ctx
         let closure =
-          ctx.Scope.Values
+          allValues
           |> Map.filter (fun k _ -> q.Closure |> Map.containsKey k)
           |> Map.map (fun k v -> v, q.Closure.[k])
 
@@ -946,12 +1013,10 @@ module FastEval =
 
       let compiledBody = compileSequence<'rc, 'ext> (NonEmptyList.OfList(body, rest))
 
-      // Cache the closure-context merge: when the same Lambda is applied to many values
-      // (List.map pattern), the expensive fold is computed once and reused.
-      let mergedBase = getCachedMerge closure ctx.Scope.Values
-      let mergedValues = mergedBase |> Map.add resolvedParam argV
-
-      compiledBody (ctx |> extendValues (fun _ -> mergedValues))
+      // O(1) push: closure + param as a single frame on the overlay stack.
+      // No Map merge — lookups traverse frames top-to-bottom.
+      let frame = closure |> Map.add resolvedParam argV
+      compiledBody (pushFrame frame ctx)
 
     // ── UnionCons application ─────────────────────────────────────
     | Value.UnionCons id -> Value.UnionCase(id, argV)

--- a/backend/libraries/ballerina-lang/Next/Runners/BackgroundJob.fs
+++ b/backend/libraries/ballerina-lang/Next/Runners/BackgroundJob.fs
@@ -58,6 +58,7 @@ let executeBackgroundJob
       |> Reader.mapContext injectBackgroundContext
       |> Reader.Run
         { Scope = dbio.EvalContext
+          ValueOverlays = []
           ExtensionOps = evalContext
           RuntimeContext = runtimeContext
           RootLevelEval = true }

--- a/backend/libraries/ballerina-lang/Next/Stdlib/Extensions/Operations.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Extensions/Operations.fs
@@ -15,6 +15,7 @@ module Operations =
   open Ballerina.DSL.Next.Extensions
   open Ballerina.DSL.Next.Types
   open Ballerina.DSL.Next.Terms
+  open Ballerina.DSL.Next.Terms.FastEval
   open Ballerina.DSL.Next.Serialization
 
   type OperationsExtension<'rtc, 'e, 'extOperations> with
@@ -133,13 +134,46 @@ module Operations =
             evalContext.ExtensionOps.Applicables
             applicables
 
+        let fastApplicables
+          : Map<
+              ResolvedIdentifier,
+              FastApplicable<'runtimeContext, 'ext>
+             > =
+          opsExt.Operations
+          |> Map.map
+            (fun
+                 (_k: ResolvedIdentifier)
+                 (op: OperationExtension<'runtimeContext, 'ext, 'extOperations>) ->
+              fun loc0 rest ctx f v ->
+                match op.OperationsLens.Get f with
+                | Some opVal ->
+                  match Reader.Run ctx (op.Apply loc0 rest (opVal, v)) with
+                  | Left result -> result
+                  | Right errors -> raise (EvalException(errors))
+                | None ->
+                  raise (
+                    EvalException(
+                      Errors.Singleton
+                        loc0
+                        (fun () ->
+                          $"Error: cannot extract operation from extension")
+                    )
+                  ))
+
+        let fastApplicables =
+          Map.merge
+            (fun _ -> id)
+            evalContext.ExtensionOps.FastApplicables
+            fastApplicables
+
         { evalContext with
             Scope =
               { evalContext.Scope with
                   Values = values }
             ExtensionOps =
               { Eval = ops
-                Applicables = applicables } }
+                Applicables = applicables
+                FastApplicables = fastApplicables } }
 
     static member RegisterLanguageContext
       (opsExt: OperationsExtension<'runtimeContext, 'ext, 'extOperations>)

--- a/backend/libraries/ballerina-lang/Next/Stdlib/Extensions/TypeLambdas.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Extensions/TypeLambdas.fs
@@ -68,7 +68,8 @@ module TypeLambdas =
                       evalContext.Scope.Values }
             ExtensionOps =
               { Eval = ops
-                Applicables = evalContext.ExtensionOps.Applicables } }
+                Applicables = evalContext.ExtensionOps.Applicables
+                FastApplicables = evalContext.ExtensionOps.FastApplicables } }
 
     static member RegisterLanguageContext<'runtimeContext, 'ext, 'extDTO, 'deltaExt, 'deltaExtDTO
       when 'ext: comparison

--- a/backend/libraries/ballerina-lang/Next/Stdlib/Extensions/Types.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Extensions/Types.fs
@@ -15,6 +15,7 @@ module Types =
   open Ballerina.DSL.Next.Types.TypeChecker
   open Ballerina.DSL.Next.Extensions
   open Ballerina.DSL.Next.Terms
+  open Ballerina.DSL.Next.Terms.FastEval
   open Ballerina.Collections.NonEmptyList
   open Ballerina.DSL.Next.Serialization
   open Ballerina.Data.Delta.Serialization
@@ -277,13 +278,53 @@ module Types =
             evalContext.ExtensionOps.Applicables
             applicables
 
+        let fastApplicables
+          : Map<
+              ResolvedIdentifier,
+              FastApplicable<'runtimeContext, 'ext>
+             > =
+          typeExt.Operations
+          |> Map.map
+            (fun
+                 (_k: ResolvedIdentifier)
+                 (op:
+                   TypeOperationExtension<
+                     'runtimeContext,
+                     'ext,
+                     'extConstructors,
+                     'extValues,
+                     'extOperations
+                    >) ->
+              fun loc0 rest ctx f v ->
+                match op.OperationsLens.Get f with
+                | Some opVal ->
+                  match Reader.Run ctx (op.Apply loc0 rest (opVal, v)) with
+                  | Left result -> result
+                  | Right errors -> raise (EvalException(errors))
+                | None ->
+                  raise (
+                    EvalException(
+                      Errors.Singleton
+                        loc0
+                        (fun () ->
+                          $"Error: cannot extract operation from extension")
+                    )
+                  ))
+
+        let fastApplicables =
+          Map.merge
+            (fun _ -> id)
+            evalContext.ExtensionOps.FastApplicables
+            fastApplicables
+
         { evalContext with
             Scope =
               { evalContext.Scope with
                   Values = values }
             ExtensionOps =
               { Eval = ops
-                Applicables = applicables } }
+                Applicables = applicables
+                FastApplicables = fastApplicables } }
 
     static member RegisterSerializationContext<'runtimeContext, 'ext
       when 'ext: comparison>


### PR DESCRIPTION
## Phase 2 Eval Performance Optimizations

Builds on the Phase 1 JIT compiler (PR #26) with optimizations targeting extension dispatch, Lambda application overhead, and variable lookup.

### Changes

#### Commit 1: Fast extension applicables + EvalApply fast path

1. **FastApplicables** — New `FastApplicables` field on `ValueExtensionOps`. Pre-compiled extension applicables that bypass Reader allocation for lens extraction. Registered at extension setup time in `Operations.fs` and `Types.fs`.

2. **EvalApply to fastApply** — Replaced `Expr.EvalApply` Reader chain with a direct call to `fastApply`. All extension callbacks (List.map/filter/fold per-element calls) now use the fast JIT path instead of building 5+ Reader allocations per invocation.

#### Commit 2: Scope chain for variable lookup

3. **Overlay frame stack** — Added `ValueOverlays: Map list` to `ExprEvalContext`. Lambda application is now O(1) push of a closure frame instead of O(|closure| x log |ctx|) Map merge. Let bindings, union/sum case vars add to the top overlay frame.

4. **Lookup traversal** — Variable lookup traverses overlay frames top-to-bottom, then falls back to `Scope.Values` base. Recent bindings hit the top frame immediately.

5. **Flatten cache** — Lambda creation calls `flattenScope` to capture a closure Map. Cached via `ConditionalWeakTable` keyed by overlay list reference to avoid repeated merges in let-heavy bodies.

6. **Reader bridge** — `runReader` flushes overlays before entering Reader-based extension code, ensuring backward compat with `ExprEvalContext.Updaters.Values` callers.

### Benchmark Results (50 warm iterations, 19 samples)

| Metric | Phase 1 (baseline) | Phase 2 | Improvement |
|--------|-------------------|---------|-------------|
| Warm total | 58.24ms | **50.27ms** | **-13.7%** |
| Cold total | 196.32ms | 189.05ms | ~same |

Key per-sample improvements (warm avg, Phase 1 to Phase 2):
- **11-records-and-unions**: 0.75 to 0.22ms (**3.41x**)
- **09-language-fundamentals**: 0.64 to 0.22ms (**2.91x**)
- **04-functions-and-type-inference**: 5.23 to 3.26ms (**1.60x**)
- **16-type-hints-and-type-lambdas**: 3.37 to 2.47ms (**1.36x**)
- **02-list-manipulation**: 13.81 to 11.54ms (**1.20x**)
- **15-patterns-and-arrows**: 2.98 to 2.50ms (**1.19x**)

### Testing
- All 25 sample projects pass
- UScreen webshop builds successfully

### Files changed
- `Expr_FastEval.fs` — Scope chain (ValueOverlays, lookupValue, pushBinding, pushFrame, flattenScope with cache), FastApplicable type, FastApplicables in fastApply
- `Expr_Eval.fs` — EvalApply body replaced with fastApply, ExprEvalContext.Empty with ValueOverlays + FastApplicables
- `BackgroundJob.fs` — ValueOverlays field in ExprEvalContext construction
- `Operations.fs` — FastApplicables registration for operation extensions
- `Types.fs` — FastApplicables registration for type extensions
- `TypeLambdas.fs` — Pass through FastApplicables field
