### PR TITLE
perf: make sum.Any, state.Any, reader.Any lazy and short-circuiting

### DIFF
--- a/backend/libraries/ballerina-cat/Collections/Sum/Model.fs
+++ b/backend/libraries/ballerina-cat/Collections/Sum/Model.fs
@@ -114,17 +114,56 @@ module Model =
         if not (obj.ReferenceEquals(box disposable, null)) then
           disposable.Dispose()
 
-    member inline _.Any<'a, 'b when 'b: (static member Concat: 'b * 'b -> 'b)>(ps: NonEmptyList<Sum<'a, 'b>>) =
-      let merge: Sum<'a, 'b> -> Sum<'a, 'b> -> Sum<'a, 'b> =
-        function
-        | Left a -> fun _ -> Left a
-        | Right b1 ->
-          function
-          | Left a -> Left a
-          | Right b2 -> Right('b.Concat(b1, b2))
+    // Core: seq with explicit empty error, short-circuiting mutable loop
+    member inline _.Any<'a, 'b when 'b: (static member Concat: 'b * 'b -> 'b)>
+      (emptyError: 'b, ps: seq<Sum<'a, 'b>>)
+      : Sum<'a, 'b> =
+      use e = ps.GetEnumerator()
+      let mutable error = emptyError
+      let mutable result = Unchecked.defaultof<'a>
+      let mutable found = false
 
-      match ps with
-      | NonEmptyList(p, ps) -> ps |> Seq.fold merge p
+      while not found && e.MoveNext() do
+        match e.Current with
+        | Left a ->
+          result <- a
+          found <- true
+        | Right b -> error <- 'b.Concat(error, b)
+
+      if found then Left result else Right error
+
+    // seq with SRTP Default constraint for empty case
+    member inline sum.Any<'a, 'b
+      when 'b: (static member Concat: 'b * 'b -> 'b)
+      and 'b: (static member Default: 'b)>
+      (ps: seq<Sum<'a, 'b>>)
+      : Sum<'a, 'b> =
+      sum.Any('b.Default, ps)
+
+    // NonEmptyList: mutable loop with short-circuit
+    member inline _.Any<'a, 'b when 'b: (static member Concat: 'b * 'b -> 'b)>
+      (ps: NonEmptyList<Sum<'a, 'b>>)
+      : Sum<'a, 'b> =
+      let (NonEmptyList(first, rest)) = ps
+
+      match first with
+      | Left a -> Left a
+      | Right firstError ->
+        let mutable e = rest
+        let mutable error = firstError
+        let mutable result = Unchecked.defaultof<'a>
+        let mutable found = false
+
+        while not found && not e.IsEmpty do
+          match e.Head with
+          | Left a ->
+            result <- a
+            found <- true
+          | Right b -> error <- 'b.Concat(error, b)
+
+          e <- e.Tail
+
+        if found then Left result else Right error
 
     member inline sum.Any<'a, 'b when 'b: (static member Concat: 'b * 'b -> 'b)>
       (p: Sum<'a, 'b>, ps: List<Sum<'a, 'b>>)
@@ -133,7 +172,7 @@ module Model =
 
     member inline _.Any2<'a, 'b when 'b: (static member Concat: 'b * 'b -> 'b)> (p1: Sum<'a, 'b>) (p2: Sum<'a, 'b>) =
       match p1, p2 with
-      | Left v, _
+      | Left v, _ -> Left v
       | _, Left v -> Left v
       | Right e1, Right e2 -> Right('b.Concat(e1, e2))
 

--- a/backend/libraries/ballerina-cat/Reader/WithError/Model.fs
+++ b/backend/libraries/ballerina-cat/Reader/WithError/Model.fs
@@ -84,7 +84,14 @@ module WithError =
       when 'e: (static member Concat: 'e * 'e -> 'e)>
       (Reader r1: Reader<'a, 'c, 'e>)
       : Reader<'a, 'c, 'e> -> Reader<'a, 'c, 'e> =
-      fun (Reader r2) -> Reader(fun (c: 'c) -> sum.Any2 (r1 c) (r2 c))
+      fun (Reader r2) ->
+        Reader(fun (c: 'c) ->
+          match r1 c with
+          | Left a -> Left a
+          | Right e1 ->
+            match r2 c with
+            | Left a -> Left a
+            | Right e2 -> Right('e.Concat(e1, e2)))
 
     member inline _.All<'c, 'a, 'e
       when 'e: (static member Concat: 'e * 'e -> 'e)>
@@ -99,12 +106,33 @@ module WithError =
       Reader(fun (c: 'c) ->
         sum.AllNonEmpty(readers |> NonEmptyList.map (fun (Reader r) -> r c)))
 
+    // Core: seq with explicit empty error, lazy evaluation via Seq.map + sum.Any short-circuit
+    member inline _.Any<'c, 'a, 'e
+      when 'e: (static member Concat: 'e * 'e -> 'e)>
+      (emptyError: 'e, readers: seq<Reader<'a, 'c, 'e>>)
+      : Reader<'a, 'c, 'e> =
+      Reader(fun (c: 'c) ->
+        sum.Any(emptyError, readers |> Seq.map (fun (Reader r) -> r c)))
+
+    // seq with SRTP Default constraint for empty case
+    member inline reader.Any<'c, 'a, 'e
+      when 'e: (static member Concat: 'e * 'e -> 'e)
+      and 'e: (static member Default: 'e)>
+      (readers: seq<Reader<'a, 'c, 'e>>)
+      : Reader<'a, 'c, 'e> =
+      reader.Any('e.Default, readers)
+
+    // NonEmptyList: evaluate first eagerly, rest lazily
     member inline _.Any<'c, 'a, 'e
       when 'e: (static member Concat: 'e * 'e -> 'e)>
       (readers: NonEmptyList<Reader<'a, 'c, 'e>>)
       : Reader<'a, 'c, 'e> =
+      let (NonEmptyList(Reader first, rest)) = readers
+
       Reader(fun (c: 'c) ->
-        sum.Any(readers |> NonEmptyList.map (fun (Reader r) -> r c)))
+        match first c with
+        | Left a -> Left a
+        | Right e -> sum.Any(e, rest |> Seq.map (fun (Reader r) -> r c)))
 
     member inline reader.Any<'c, 'a, 'e
       when 'e: (static member Concat: 'e * 'e -> 'e)>

--- a/backend/libraries/ballerina-cat/Stackless/State/WithError/Model.fs
+++ b/backend/libraries/ballerina-cat/Stackless/State/WithError/Model.fs
@@ -174,35 +174,36 @@ module StacklessStateWithError =
 
     static member any
       (concat: 'e * 'e -> 'e)
-      (ps: List<FreeNode<'a, 'c, 's, 'e>>)
+      (ps: seq<FreeNode<'a, 'c, 's, 'e>>)
       : FreeNode<'a, 'c, 's, 'e> =
-      let mutable acc: FreeNode<Sum<'a, 'e> option * 'e option, 'c, 's, 'e> =
-        FreeNode.Return(None, None)
+      // Wrap in a bind so the enumerator is created at run time (safe for multiple runs)
+      FreeNode.bind (FreeNode.Return()) (fun () ->
+        let e = ps.GetEnumerator()
 
-      for p in ps do
-        acc <-
-          FreeNode.bind acc (fun (current, errors) ->
-            match current with
-            | Some(Left v) -> FreeNode.Return(Some(Left v), errors) // Already have success, short-circuit
-            | _ ->
-              FreeNode.bind (FreeNode.catch p) (fun res ->
-                match res with
-                | Left v -> FreeNode.Return(Some(Left v), errors)
-                | Right err ->
-                  let newErrors =
-                    match errors with
-                    | Some errs -> Some(concat (errs, err))
-                    | None -> Some err
+        let rec tryNext (errors: 'e option) : FreeNode<'a, 'c, 's, 'e> =
+          if e.MoveNext() then
+            let p = e.Current
 
-                  FreeNode.Return(None, newErrors)))
+            FreeNode.bind (FreeNode.catch p) (fun res ->
+              match res with
+              | Left v ->
+                e.Dispose()
+                FreeNode.Return v
+              | Right err ->
+                let newErrors =
+                  match errors with
+                  | Some errs -> Some(concat (errs, err))
+                  | None -> Some err
 
-      FreeNode.bind acc (fun (result, errors) ->
-        match result with
-        | Some(Left v) -> FreeNode.Return v
-        | _ ->
-          match errors with
-          | Some err -> FreeNode.throw err
-          | None -> failwith "Unreachable: Any requires at least one element")
+                tryNext newErrors)
+          else
+            e.Dispose()
+
+            match errors with
+            | Some err -> FreeNode.throw err
+            | None -> failwith "Unreachable: Any requires at least one element"
+
+        tryNext None)
 
     static member all
       (ps: List<FreeNode<'a, 'c, 's, 'e>>)

--- a/backend/libraries/ballerina-cat/State/WithError/Model.fs
+++ b/backend/libraries/ballerina-cat/State/WithError/Model.fs
@@ -140,14 +140,13 @@ module WithError =
       }
 
     member state.Any<'a, 'c, 's, 'e>
-      (e: {| concat: 'e * 'e -> 'e |}, ps: NonEmptyList<State<'a, 'c, 's, 'e>>)
+      (e: {| concat: 'e * 'e -> 'e |}, ps: seq<State<'a, 'c, 's, 'e>>)
       : State<'a, 'c, 's, 'e> =
-      let ps = ps |> NonEmptyList.ToList |> List.map (fun (State p) -> p)
-      State(FreeNode.any e.concat ps)
+      State(FreeNode.any e.concat (ps |> Seq.map (fun (State p) -> p)))
 
     member inline state.Any<'a, 'c, 's, 'b
       when 'b: (static member Concat: 'b * 'b -> 'b)>
-      (ps: NonEmptyList<State<'a, 'c, 's, 'b>>)
+      (ps: seq<State<'a, 'c, 's, 'b>>)
       =
       state.Any({| concat = 'b.Concat |}, ps)
 
@@ -155,7 +154,11 @@ module WithError =
       when 'b: (static member Concat: 'b * 'b -> 'b)>
       (p: State<'a, 'c, 's, 'b>, ps: List<State<'a, 'c, 's, 'b>>)
       =
-      NonEmptyList.OfList(p, ps) |> state.Any
+      seq {
+        yield p
+        yield! ps
+      }
+      |> state.Any
 
     member state.All<'a, 'c, 's, 'e>
       (_e: {| concat: 'e * 'e -> 'e |}, ps: List<State<'a, 'c, 's, 'e>>)
@@ -249,7 +252,7 @@ module WithError =
       (p1: State<'a, 'c, 's, 'e>)
       (p2: State<'a, 'c, 's, 'e>)
       =
-      state.Any({| concat = 'e.Concat |}, NonEmptyList.OfList(p1, [ p2 ]))
+      state.Any({| concat = 'e.Concat |}, [| p1; p2 |] :> seq<_>)
 
     member inline state.Either3
       (p1: State<'a, 'c, 's, 'e>)


### PR DESCRIPTION
## Summary

Make sum.Any, state.Any, reader.Any lazy and short-circuiting.

### Changes

**sum.Any** (Collections/Sum/Model.fs)
- NonEmptyList overload: mutable loop with early exit (was Seq.fold that could not break)
- New overload: Any(emptyError, ps: seq) - explicit empty error for seq input
- New overload: Any(ps: seq) - with SRTP Default constraint for empty case
- Any2: explicit pattern match instead of tuple match (short-circuits on first Left)

**FreeNode.any** (Stackless/State/WithError/Model.fs)
- Accepts seq instead of List
- Builds bind nodes lazily via enumerator inside bind continuation
- Enumerator created at run time (safe for multiple runs of same node)
- Only fetches next alternative when current one fails

**state.Any** (State/WithError/Model.fs)
- Primary overload accepts seq instead of NonEmptyList
- Inline SRTP overload accepts seq
- Convenience (p, ps) overload builds lazy seq

**reader.Any** (Reader/WithError/Model.fs)
- NonEmptyList overload: evaluates first reader eagerly, rest lazily via Seq.map
- New overload: Any(emptyError, readers: seq) for seq input
- New overload: Any(readers: seq) with SRTP Default constraint
- Any2: short-circuits without evaluating second reader on success

### Verification
- dotnet build backend.sln: 0 errors, 0 warnings
- 36/36 ballerina-cat unit tests pass
- 25/25 integration samples pass
- UScreen .blproj compiles successfully
- bise.slnx builds successfully

4 files changed, 117 insertions, 46 deletions
