### PR TITLE
Fix: standardize delta field names to fully qualified ResolvedIdentifiers

### DIFF
--- a/backend/libraries/ballerina-delta/Model.fs
+++ b/backend/libraries/ballerina-delta/Model.fs
@@ -10,8 +10,8 @@ module Model =
   type Delta<'valueExtension, 'deltaExtension> =
     | Multiple of List<Delta<'valueExtension, 'deltaExtension>>
     | Replace of Value<TypeValue<'valueExtension>, 'valueExtension>
-    | Record of string * Delta<'valueExtension, 'deltaExtension>
-    | Union of string * Delta<'valueExtension, 'deltaExtension>
+    | Record of ResolvedIdentifier * Delta<'valueExtension, 'deltaExtension>
+    | Union of ResolvedIdentifier * Delta<'valueExtension, 'deltaExtension>
     | Tuple of int * Delta<'valueExtension, 'deltaExtension>
     | Sum of int * Delta<'valueExtension, 'deltaExtension>
     | Ext of 'deltaExtension

--- a/backend/libraries/ballerina-delta/Patterns.fs
+++ b/backend/libraries/ballerina-delta/Patterns.fs
@@ -33,7 +33,7 @@ module Patterns =
 
     static member AsRecord
       (delta: Delta<'valueExtension, 'deltaExtension>)
-      : Sum<string * Delta<'valueExtension, 'deltaExtension>, Errors<unit>> =
+      : Sum<ResolvedIdentifier * Delta<'valueExtension, 'deltaExtension>, Errors<unit>> =
       match delta with
       | Delta.Record(fieldName, fieldDelta) -> sum.Return(fieldName, fieldDelta)
       | other ->
@@ -44,7 +44,7 @@ module Patterns =
 
     static member AsUnion
       (delta: Delta<'valueExtension, 'deltaExtension>)
-      : Sum<string * Delta<'valueExtension, 'deltaExtension>, Errors<unit>> =
+      : Sum<ResolvedIdentifier * Delta<'valueExtension, 'deltaExtension>, Errors<unit>> =
       match delta with
       | Delta.Union(caseName, caseDelta) -> sum.Return(caseName, caseDelta)
       | other ->

--- a/backend/libraries/ballerina-delta/ToUpdater.fs
+++ b/backend/libraries/ballerina-delta/ToUpdater.fs
@@ -46,28 +46,23 @@ module ToUpdater =
         | Delta.Record(fieldName, fieldDelta) ->
           let! fieldUpdater = Delta.ToUpdater deltaExtensionHandler fieldDelta
 
-          (*
-            IMPROVEMENT: the delta should take resolved identifiers and not just field names so that we can do a lookup in the map 
-            instead of a linear search.
-          *)
           return
             fun (v: Value<TypeValue<'valueExtension>, 'valueExtension>) ->
               sum {
                 let! fieldValues = Value.AsRecord v
 
-                let! targetSymbol, currentValue =
+                let! currentValue =
                   fieldValues
-                  |> Map.tryFindByWithError
-                    (fun (ts, _) -> ts.Name = fieldName)
-                    "field values"
-                    (fun () -> fieldName)
-                    ()
+                  |> Map.tryFind fieldName
+                  |> Sum.fromOption (fun () ->
+                    Errors.Singleton () (fun () ->
+                      $"Cannot find field values '{fieldName}'"))
 
                 let! updatedValue = fieldUpdater currentValue
 
                 return
                   fieldValues
-                  |> Map.add targetSymbol updatedValue
+                  |> Map.add fieldName updatedValue
                   |> Value.Record
               }
 
@@ -79,7 +74,7 @@ module ToUpdater =
               sum {
                 let! valueCaseName, caseValue = v |> Value.AsUnion
 
-                if caseName <> valueCaseName.Name then
+                if caseName <> valueCaseName then
                   return v
                 else
                   let! caseValue = caseUpdater caseValue

--- a/backend/libraries/ballerina-lang/Next/DeltaSerialization/Serializer/DeltaDeserializer.fs
+++ b/backend/libraries/ballerina-lang/Next/DeltaSerialization/Serializer/DeltaDeserializer.fs
@@ -1,7 +1,7 @@
 namespace Ballerina.Data.Delta.Serialization
 
 module DeltaDeserializer =
-  open Ballerina.Data.Delta
+  open Ballerina.DSL.Next.Types.Model
   open Ballerina.Reader.WithError
   open DeltaDTO
   open Ballerina.Errors
@@ -9,6 +9,12 @@ module DeltaDeserializer =
   open Ballerina.Collections.NonEmptyList
   open System.Text.Json
   open Ballerina.DSL.Next.Serialization.SerializerConfig
+  open Ballerina.Data.Delta
+
+  module private ResolvedIdentifierParsing =
+    open Ballerina.DSL.Next.Serialization.PocoObjects
+
+    let tryParse (s: string) = ResolvedIdentifier.TryParse s
 
   let rec multipleFromDTO
     (deltaDTO: DeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO>)
@@ -75,8 +81,12 @@ module DeltaDeserializer =
       let! field, deltaDTO =
         assertSingleElementDictionary recordDTO "record delta"
 
+      let! fieldIdentifier =
+        ResolvedIdentifierParsing.tryParse field
+        |> reader.OfSum
+
       let! delta = deltaFromDTO deltaDTO
-      return Record(field, delta)
+      return Record(fieldIdentifier, delta)
     }
 
   and unionFromDTO
@@ -95,8 +105,13 @@ module DeltaDeserializer =
     reader {
       let! unionDTO = assertValue deltaDTO.Union "union delta"
       let! case, deltaDTO = assertSingleElementDictionary unionDTO "union delta"
+
+      let! caseIdentifier =
+        ResolvedIdentifierParsing.tryParse case
+        |> reader.OfSum
+
       let! delta = deltaFromDTO deltaDTO
-      return Union(case, delta)
+      return Union(caseIdentifier, delta)
     }
 
   and tupleFromDTO

--- a/backend/libraries/ballerina-lang/Next/DeltaSerialization/Serializer/DeltaSerializer.fs
+++ b/backend/libraries/ballerina-lang/Next/DeltaSerialization/Serializer/DeltaSerializer.fs
@@ -1,7 +1,7 @@
 namespace Ballerina.Data.Delta.Serialization
 
 module DeltaSerializer =
-  open Ballerina.Data.Delta
+  open Ballerina.DSL.Next.Types.Model
   open Ballerina.Reader.WithError
   open Ballerina.DSL.Next.Serialization
   open DeltaDTO
@@ -10,6 +10,7 @@ module DeltaSerializer =
   open Ballerina.DSL.Next.Serialization.PocoObjects
   open System.Text.Json
   open Ballerina.DSL.Next.Serialization.SerializerConfig
+  open Ballerina.Data.Delta
 
   let rec multipleToDTO
     (deltas: List<Delta<'valueExtension, 'deltaExtension>>)
@@ -46,7 +47,7 @@ module DeltaSerializer =
       new DeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO>(replace))
 
   and recordToDTO
-    (field: string)
+    (field: ResolvedIdentifier)
     (delta: Delta<'valueExtension, 'deltaExtension>)
     =
     reader {
@@ -58,12 +59,12 @@ module DeltaSerializer =
           DeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO>
          >()
 
-      record.Add(field, deltaDTO)
+      record.Add(field.ToDTO, deltaDTO)
       return new DeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO>(record, true)
     }
 
   and unionToDTO
-    (case: string)
+    (case: ResolvedIdentifier)
     (delta: Delta<'valueExtension, 'deltaExtension>)
     =
     reader {
@@ -75,7 +76,7 @@ module DeltaSerializer =
           DeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO>
          >()
 
-      union.Add(case, deltaDTO)
+      union.Add(case.ToDTO, deltaDTO)
       return new DeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO>(union, false)
     }
 


### PR DESCRIPTION
## Summary

Standardize delta field names to fully qualified ResolvedIdentifiers throughout the delta pipeline. This ensures consistent representation at the model, serialization, and backend layers.

## Changes Made

1. **Model.fs**: Changed `Delta.Record` and `Delta.Union` discriminators to use `ResolvedIdentifier` instead of `string`
   - Ensures field names are fully qualified from the model layer

2. **Patterns.fs**: Updated `AsRecord` and `AsUnion` active patterns to return `ResolvedIdentifier`
   - Maintains consistency for pattern matching

3. **DeltaDeserializer.fs**: Added parsing of incoming DTO dictionary keys
   - Created `ResolvedIdentifierParsing` module to avoid import shadowing
   - Both Record and Union cases now parse FQ field names from wire format

4. **DeltaSerializer.fs**: Updated serialization to call `.ToDTO` on `ResolvedIdentifier` fields
   - Converts back to wire format (`"Type::FieldName"`) for JSON payload
   - Reordered imports to prevent Record pattern shadowing

5. **ToUpdater.fs**: Replaced linear scan with direct map lookup
   - Changed from O(n) predicate-based search to O(log n) `Map.tryFind`
   - Eliminates inefficient string-to-name comparison

## Impact

- Full architectural consistency in delta pipeline
- Type-safe field name handling at all boundaries
- Performance improvement: O(log n) instead of O(n) for field lookups