### PR TITLE
feat: add lookup-not-connected-many endpoint for relations

### DIFF
--- a/backend/libraries/ballerina-api/Common/OpenAPI/EndpointGeneration.fs
+++ b/backend/libraries/ballerina-api/Common/OpenAPI/EndpointGeneration.fs
@@ -558,6 +558,65 @@ module EndpointGeneration =
 
             do! add_lookup_endpoint_from cardinality.To
             do! add_lookup_endpoint_to cardinality.From
+
+            if cardinality.To = Cardinality.Many then
+              do!
+                state {
+                  let lookup_path =
+                    sprintf "%s/%s/lookup-not-connected-many/From" routePrefix relation_name.Name
+
+                  let request_model = OpenAPIDataModel.Ref from_id_name
+
+                  let response_model =
+                    (OpenAPIDataModel.Tuple
+                      [ OpenAPIDataModel.Ref to_id_name; OpenAPIDataModel.Ref to_with_props_name ])
+                    |> listToOpenApi
+
+                  let query_params =
+                    [ { Name = "offset" |> ResolvedIdentifier.Create
+                        Type = PrimitiveType.Int32 }
+                      { Name = "limit" |> ResolvedIdentifier.Create
+                        Type = PrimitiveType.Int32 } ]
+
+                  let endpoint =
+                    { Path = lookup_path
+                      Method = OpenAPIEndpointModel.Post
+                      QueryParameters = draftQueryParam :: query_params
+                      RequestModel = Some request_model
+                      ResponseModel = Some response_model }
+
+                  do! state.SetState(fun l -> endpoint :: l)
+                }
+
+            if cardinality.From = Cardinality.Many then
+              do!
+                state {
+                  let lookup_path =
+                    sprintf "%s/%s/lookup-not-connected-many/To" routePrefix relation_name.Name
+
+                  let request_model = OpenAPIDataModel.Ref to_id_name
+
+                  let response_model =
+                    (OpenAPIDataModel.Tuple
+                      [ OpenAPIDataModel.Ref from_id_name; OpenAPIDataModel.Ref from_with_props_name ])
+                    |> listToOpenApi
+
+                  let query_params =
+                    [ { Name = "offset" |> ResolvedIdentifier.Create
+                        Type = PrimitiveType.Int32 }
+                      { Name = "limit" |> ResolvedIdentifier.Create
+                        Type = PrimitiveType.Int32 } ]
+
+                  let endpoint =
+                    { Path = lookup_path
+                      Method = OpenAPIEndpointModel.Post
+                      QueryParameters = draftQueryParam :: query_params
+                      RequestModel = Some request_model
+                      ResponseModel = Some response_model }
+
+                  do! state.SetState(fun l -> endpoint :: l)
+                }
+
             return ()
           })
         |> state.All

--- a/backend/libraries/ballerina-api/Endpoints/Read.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Read.fs
@@ -355,6 +355,77 @@ module Read =
     |> ignore
 
     app.MapPost(
+      "/{tenantId}/{schemaName}/{relationName}/lookup-not-connected-many/{direction}",
+      Func<HttpContext, 'tenantId, 'schemaName, string, string, bool, int, int, ValueDTO<ValueExtDTO>, IResult>
+        (fun httpContext tenantId schemaName relationName direction draft offset limit fromId ->
+
+          let result =
+            sum {
+
+              let! dbio, languageContext, evalContext, typeCheckContext, typeCheckState =
+                getDbDescriptor tenantId schemaName draft context
+
+              let! idValue =
+                valueFromDTO >> runDTOConverter languageContext <| fromId
+                |> sum.MapError APIError<'runtimeContext, 'db, 'customExtension, Location>.Create
+
+              do!
+                checkRelatedEntityId
+                  relationName
+                  direction
+                  idValue
+                  dbio
+                  languageContext
+                  typeCheckContext
+                  typeCheckState
+
+              let! lookupDescriptor =
+                lookupDescriptorFromDb dbio relationName direction
+                |> sum.MapError(
+                  Errors.MapContext(replaceWith Location.Unknown)
+                  >> APIError<'runtimeContext, 'db, 'customExtension, Location>.Create
+                )
+
+              let doLookupExpr: RunnableExpr<ValueExt<'runtimeContext, 'db, 'customExtension>> =
+                RunnableExpr.UnsafeApplyForUntypedEval(
+                  RunnableExpr.UnsafeApplyForUntypedEval(
+                    RunnableExpr.UnsafeApplyForUntypedEval(
+                      RunnableExpr.UnsafeLookupForUntypedEval(
+                        Identifier.FullyQualified([ "DB" ], $"lookupNotConnectedMany")
+                        |> ResolvedIdentifier.FromIdentifier
+                      ),
+                      RunnableExpr.FromValue(
+                        lookupDescriptor,
+                        TypeValue.CreatePrimitive PrimitiveType.Unit,
+                        Kind.Star
+                      )
+                    ),
+                    RunnableExpr.FromValue(idValue, TypeValue.CreatePrimitive PrimitiveType.Unit, Kind.Star)
+                  ),
+                  RunnableExpr.UnsafeTupleConsForUntypedEval
+                    [ RunnableExpr.UnsafePrimitiveForUntypedEval(PrimitiveValue.Int32(offset))
+                      RunnableExpr.UnsafePrimitiveForUntypedEval(PrimitiveValue.Int32(limit)) ]
+                )
+
+              let! evalResult =
+                Expr.Eval(
+                  NonEmptyList.prependList languageContext.TypeCheckedPreludes (NonEmptyList.OfList(doLookupExpr, []))
+                )
+                |> Reader.Run(evalContext |> context.PermissionHookInjector httpContext)
+                |> sum.MapError APIError<'runtimeContext, 'db, 'customExtension, Location>.Create
+
+              let! resultDTO =
+                valueToDTO >> runDTOConverter languageContext <| evalResult
+                |> sum.MapError APIError<'runtimeContext, 'db, 'customExtension, Location>.Create
+
+              return resultDTO
+            }
+
+          apiResponseFromSum result id)
+    )
+    |> ignore
+
+    app.MapPost(
       "/{tenantId}/{schemaName}/{relationName}/lookup-option/{direction}",
       Func<HttpContext, 'tenantId, 'schemaName, string, string, bool, ValueDTO<ValueExtDTO>, IResult>
         (fun httpContext tenantId schemaName relationName direction draft fromId ->

--- a/backend/libraries/ballerina-filedb/FileDB.fs
+++ b/backend/libraries/ballerina-filedb/FileDB.fs
@@ -485,6 +485,36 @@ module FileDB =
         fun relation_ref (source, dir, skip, truncate) ->
           dbTypeClass.LookupMany relation_ref source dir (skip, truncate))
 
+  let private lookupNotConnectedMany<'customExt when 'customExt: comparison>
+    directory
+    extension
+    (memoryDbOps:
+      DBTypeClass<
+        FileDBRuntimeContext,
+        MutableMemoryDB<FileDBRuntimeContext, 'customExt>,
+        ValueExt<
+          FileDBRuntimeContext,
+          MutableMemoryDB<FileDBRuntimeContext, 'customExt>,
+          'customExt
+         >
+       >)
+    relation_ref
+    source
+    dir
+    (skip, truncate)
+    =
+    runDbOpWithFileManager
+      relation_ref
+      (source, dir, skip, truncate)
+      directory
+      extension
+      memoryDbOps
+      false
+      relationRefUpdater
+      (fun dbTypeClass ->
+        fun relation_ref (source, dir, skip, truncate) ->
+          dbTypeClass.LookupNotConnectedMany relation_ref source dir (skip, truncate))
+
   let updateFromFileSystem
     { DbDirectory = directory
       DbExtension = extension }
@@ -545,6 +575,8 @@ module FileDB =
       LookupMaybe = lookupMaybe directory extension memoryDbOps
       LookupOne = lookupOne directory extension memoryDbOps
       LookupMany = lookupMany directory extension memoryDbOps
+      LookupNotConnectedMany =
+        lookupNotConnectedMany directory extension memoryDbOps
       RunQuery =
         fun query range ->
           reader {

--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/Lookups.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/Lookups.fs
@@ -454,6 +454,174 @@ module Lookups =
 
             } }
 
+    let memoryDBLookupNotConnectedManyId =
+      Identifier.FullyQualified([ "DB" ], "lookupNotConnectedMany")
+      |> TypeCheckScope.Empty.Resolve
+
+    let memoryDBLookupNotConnectedManyType =
+      TypeValue.CreateLambda(
+        TypeParameter.Create("schema", Kind.Schema),
+        TypeExpr.Lambda(
+          TypeParameter.Create("from_id", Kind.Star),
+          TypeExpr.Lambda(
+            TypeParameter.Create("to_id", Kind.Star),
+            TypeExpr.Lambda(
+              TypeParameter.Create("to_with_props", Kind.Star),
+              TypeExpr.Arrow(
+                TypeExpr.Apply(
+                  TypeExpr.Apply(
+                    TypeExpr.Apply(
+                      TypeExpr.Apply(
+                        TypeExpr.Lookup(
+                          "SchemaLookupMany" |> Identifier.LocalScope
+                        ),
+                        TypeExpr.Lookup("schema" |> Identifier.LocalScope)
+                      ),
+                      TypeExpr.Lookup("from_id" |> Identifier.LocalScope)
+                    ),
+                    TypeExpr.Lookup("to_id" |> Identifier.LocalScope)
+                  ),
+                  TypeExpr.Lookup("to_with_props" |> Identifier.LocalScope)
+                ),
+                TypeExpr.Arrow(
+                  TypeExpr.Lookup("from_id" |> Identifier.LocalScope),
+                  TypeExpr.Arrow(
+                    TypeExpr.Tuple
+                      [ TypeExpr.Primitive PrimitiveType.Int32
+                        TypeExpr.Primitive PrimitiveType.Int32 ],
+                    TypeExpr.Sum
+                      [ TypeExpr.Primitive PrimitiveType.Unit
+                        TypeExpr.Apply(
+                          TypeExpr.Lookup("List" |> Identifier.LocalScope),
+                          TypeExpr.Tuple[TypeExpr.Lookup(
+                                           "to_id" |> Identifier.LocalScope
+                                         )
+
+                                         TypeExpr.Lookup(
+                                           "to_with_props"
+                                           |> Identifier.LocalScope
+                                         )]
+                        ) ]
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+
+    let memoryDBLookupNotConnectedManyKind =
+      Kind.Arrow(
+        Kind.Schema,
+        Kind.Arrow(
+          Kind.Star,
+          Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+        )
+      )
+
+    let LookupNotConnectedManyOperation: OperationExtension<'runtimeContext, _, _> =
+      { PublicIdentifiers =
+          Some
+          <| (memoryDBLookupNotConnectedManyType,
+              memoryDBLookupNotConnectedManyKind,
+              DBValues.LookupNotConnectedMany
+                {| RelationRef = None
+                   EntityId = None |})
+        OperationsLens =
+          valueLens
+          |> PartialLens.BindGet (function
+            | DBValues.LookupNotConnectedMany v -> Some(DBValues.LookupNotConnectedMany v)
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (op, v) ->
+            reader {
+              let! op =
+                op
+                |> DBValues.AsLookupNotConnectedMany
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              match op.RelationRef with
+              | None ->
+                let! v, _ =
+                  v
+                  |> Value.AsExt
+                  |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                  |> reader.OfSum
+
+                let! v =
+                  v
+                  |> valueLens.Get
+                  |> sum.OfOption(
+                    Errors.Singleton loc0 (fun () ->
+                      "Cannot get value from extension")
+                  )
+                  |> reader.OfSum
+
+                let! v =
+                  v
+                  |> DBValues.AsRelationLookupRef
+                  |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                  |> reader.OfSum
+
+                return
+                  (DBValues.LookupNotConnectedMany
+                    {| RelationRef = Some v
+                       EntityId = None |}
+                   |> valueLens.Set,
+                   Some memoryDBLookupNotConnectedManyId)
+                  |> Ext
+              | Some(relation_ref, direction) ->
+                match op.EntityId with
+                | None ->
+                  return
+                    (DBValues.LookupNotConnectedMany
+                      {| RelationRef = Some(relation_ref, direction)
+                         EntityId = Some v |}
+                     |> valueLens.Set,
+                     Some memoryDBLookupNotConnectedManyId)
+                    |> Ext
+                | Some entityId ->
+                  let! v =
+                    v
+                    |> Value.AsTuple
+                    |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                    |> reader.OfSum
+
+                  match v with
+                  | [ Value.Primitive(PrimitiveValue.Int32 _offset)
+                      Value.Primitive(PrimitiveValue.Int32 _limit) ] ->
+                    let! target_values =
+                      db_ops.LookupNotConnectedMany
+                        relation_ref
+                        entityId
+                        direction
+                        (_offset, _limit)
+                      |> reader.MapError(Errors.MapContext(replaceWith loc0))
+                      |> reader.Catch
+
+                    match target_values with
+                    | Right(_e: Errors<_>) ->
+                      return
+                        Value.Sum(
+                          { Case = 1; Count = 2 },
+                          Value.Primitive PrimitiveValue.Unit
+                        )
+                    | Left target_values ->
+                      return
+                        Value.Sum(
+                          { Case = 2; Count = 2 },
+                          (target_values |> listSet, None) |> Ext
+                        )
+                  | _ ->
+                    return!
+                      Errors.Singleton loc0 (fun () ->
+                        "Expected a tuple of two Int32 values for offset and limit")
+                      |> reader.Throw
+
+            } }
+
     [ (memoryDBLookupOptionId, LookupOptionOperation)
       (memoryDBLookupOneId, LookupOneOperation)
-      (memoryDBLookupManyId, LookupManyOperation) ]
+      (memoryDBLookupManyId, LookupManyOperation)
+      (memoryDBLookupNotConnectedManyId, LookupNotConnectedManyOperation) ]

--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/Model.fs
@@ -176,6 +176,16 @@ module Model =
             List<Value<TypeValue<'ext>, 'ext>>,
             ExprEvalContext<'runtimeContext, 'ext>,
             Errors<Unit>
+           >
+      LookupNotConnectedMany:
+        RelationRef<'db, 'ext>
+          -> Value<TypeValue<'ext>, 'ext>
+          -> RelationLookupDirection
+          -> int * int
+          -> Reader<
+            List<Value<TypeValue<'ext>, 'ext>>,
+            ExprEvalContext<'runtimeContext, 'ext>,
+            Errors<Unit>
            > }
 
   let db_nonsense () =
@@ -205,7 +215,8 @@ module Model =
       LookupOne =
         fun _ _ _ ->
           reader.Throw <| Errors.Singleton () (fun () -> "No such relation")
-      LookupMany = fun _ _ _ _ -> reader.Return [] }
+      LookupMany = fun _ _ _ _ -> reader.Return []
+      LookupNotConnectedMany = fun _ _ _ _ -> reader.Return [] }
 
   type DBEvalProperty<'ext> =
     { PropertyName: LocalIdentifier
@@ -260,6 +271,9 @@ module Model =
     | LookupOption of
       {| RelationRef: Option<RelationRef<'db, 'ext> * RelationLookupDirection> |}
     | LookupMany of
+      {| RelationRef: Option<RelationRef<'db, 'ext> * RelationLookupDirection>
+         EntityId: Option<Value<TypeValue<'ext>, 'ext>> |}
+    | LookupNotConnectedMany of
       {| RelationRef: Option<RelationRef<'db, 'ext> * RelationLookupDirection>
          EntityId: Option<Value<TypeValue<'ext>, 'ext>> |}
     | RelationLookupRef of RelationRef<'db, 'ext> * RelationLookupDirection
@@ -382,6 +396,14 @@ module Model =
           | None -> "None"
 
         $"LookupMany(Relation: {relationStr})"
+      | LookupNotConnectedMany lookupNotConnectedMany ->
+        let relationStr =
+          match lookupNotConnectedMany.RelationRef with
+          | Some((_, _, relation, fromEntity, toEntity, _), _) ->
+            $"RelationRef({relation.Name}, from: {fromEntity.Name}, to: {toEntity.Name})"
+          | None -> "None"
+
+        $"LookupNotConnectedMany(Relation: {relationStr})"
       | RelationLookupRef((_, _, relation, _fromEntity, _toEntity, _), direction) ->
         $"{relation.Name}[{direction}]"
       | EvalProperty prop -> $"EvalProperty({prop.PropertyName})"

--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/Patterns.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/Patterns.fs
@@ -291,6 +291,21 @@ module Patterns =
         Errors.Singleton () (fun () -> "Expected LookupMany operation")
         |> sum.Throw
 
+    static member AsLookupNotConnectedMany
+      (op: DBValues<'runtimeContext, 'db, 'ext>)
+      : Sum<
+          {| RelationRef:
+               Option<RelationRef<'db, 'ext> * RelationLookupDirection>
+             EntityId: Option<_> |},
+          Errors<Unit>
+         >
+      =
+      match op with
+      | DBValues.LookupNotConnectedMany v -> v |> sum.Return
+      | _ ->
+        Errors.Singleton () (fun () -> "Expected LookupNotConnectedMany operation")
+        |> sum.Throw
+
     static member AsDBIO
       (op: DBValues<'runtimeContext, 'db, 'ext>)
       : Sum<DBIO<'runtimeContext, 'db, 'ext>, Errors<Unit>> =

--- a/backend/libraries/ballerina-memorydb/MemoryDB.fs
+++ b/backend/libraries/ballerina-memorydb/MemoryDB.fs
@@ -1126,4 +1126,40 @@ module MutableMemoryDB =
 
             return
               results |> Seq.skip skip |> Seq.truncate truncate |> Seq.toList
+          }
+      LookupNotConnectedMany =
+        fun relation_ref source dir (skip, truncate) ->
+          reader {
+            let schema, db, relation, from, to_, schema_value = relation_ref
+
+            let! relation_data =
+              db.relations
+              |> Map.tryFind relation.Name
+              |> reader.OfOption(
+                Errors.Singleton () (fun () -> "Relation not found")
+              )
+
+            let _source_entity_ref, target_entity_ref, source_to_targets =
+              match dir with
+              | FromTo -> from, to_, relation_data.FromTo
+              | ToFrom -> to_, from, relation_data.ToFrom
+
+            let! targets =
+              entity_values_restricted_by_can_read
+                (schema, db, target_entity_ref, schema_value)
+                queryRunAdapter
+
+            let connected_ids =
+              source_to_targets
+              |> Map.tryFind source
+              |> Option.defaultValue Set.empty
+
+            return
+              targets
+              |> Map.toSeq
+              |> Seq.filter (fun (id, _) -> not (Set.contains id connected_ids))
+              |> Seq.skip skip
+              |> Seq.truncate truncate
+              |> Seq.map (fun (id, value) -> Value.Tuple [ id; value ])
+              |> Seq.toList
           } }


### PR DESCRIPTION
Adds `lookup-not-connected-many/From` and `lookup-not-connected-many/To` endpoints for many-to-many relations.

These return all items on the "other side" of a relation that are NOT currently linked to the given source entity — the complement of `lookup-many`. Useful for multiselect dropdowns showing connected (checked) vs. disconnected (unchecked) items.

### Changes
- **OpenAPI spec generation** (`EndpointGeneration.fs`): generates routes for many-cardinality relations
- **HTTP endpoint** (`Read.fs`): POST handler calling `DB::lookupNotConnectedMany`
- **Stdlib** (`Lookups.fs`, `Model.fs`, `Patterns.fs`): operation definition and pattern matching
- **PostgreSQL** (`simple_queries.fs`, `db_ops.fs`): anti-join SQL query
- **MemoryDB/FileDB**: in-memory implementation

### SQL Pattern
```sql
SELECT e."Id", e."Value"
FROM {schema}.{targetEntity} AS e
LEFT JOIN {schema}.{relation} AS r ON e."Id" = r."{targetCol}" AND r."{sourceCol}" = @sourceId
WHERE r."{targetCol}" IS NULL
ORDER BY e."Id" OFFSET ... LIMIT ...
```