### PR TITLE
chore: enable WarningLevel 5, fix all FS1178/FS0052 errors

### DIFF
--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -16,7 +16,6 @@
         <NuGetAudit>true</NuGetAudit>
         <NuGetAuditMode>all</NuGetAuditMode>
         <NuGetAuditLevel>critical</NuGetAuditLevel>
-        <!-- TODO: enable -->
-        <!-- <WarningLevel>5</WarningLevel> -->
+        <WarningLevel>5</WarningLevel>
     </PropertyGroup>
 </Project>

--- a/backend/libraries/ballerina-api-filedb-factory/Models/CompilationCache.fs
+++ b/backend/libraries/ballerina-api-filedb-factory/Models/CompilationCache.fs
@@ -13,6 +13,7 @@ module CacheCompilation =
       Schema: string
       IsDraft: bool }
 
+  [<NoComparison; NoEquality>]
   type CompilationContext<'runtimeContext, 'valueExt when 'valueExt: comparison>
     =
     { TypeCheckContext: TypeCheckContext<'valueExt>
@@ -20,6 +21,7 @@ module CacheCompilation =
       EvalContext: ExprEvalContext<'runtimeContext, 'valueExt>
       EvalResult: Value<TypeValue<'valueExt>, 'valueExt> }
 
+  [<NoComparison; NoEquality>]
   type CompilationCache<'runtimeContext, 'valueExt when 'valueExt: comparison> =
     { mutable Cache:
         Map<TenantData, CompilationContext<'runtimeContext, 'valueExt>> }

--- a/backend/libraries/ballerina-api/Endpoints/Create.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Create.fs
@@ -24,6 +24,7 @@ module Create =
   open Ballerina.DSL.Next.Types.TypeChecker.Value
   open Ballerina.DSL.Next.StdLib.DB
 
+  [<NoComparison; NoEquality>]
   type CreatePayload =
     { Id: ValueDTO<ValueExtDTO>
       Entity: ValueDTO<ValueExtDTO> }

--- a/backend/libraries/ballerina-api/Endpoints/Filter.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Filter.fs
@@ -14,6 +14,7 @@ module Filter =
   open Microsoft.AspNetCore.Http
   open System.Text.Json
 
+  [<NoComparison; NoEquality>]
   type EntityFilterResult =
     { EntityId: string
       JsonValue: ValueDTO<ValueExtDTO> }

--- a/backend/libraries/ballerina-api/Endpoints/Linking.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Linking.fs
@@ -22,10 +22,12 @@ module Linking =
   open Microsoft.AspNetCore.Http
   open Ballerina.DSL.Next.Serialization.ValueSerializer
 
+  [<NoComparison; NoEquality>]
   type LinkPayload =
     { FromId: ValueDTO<ValueExtDTO>
       ToId: ValueDTO<ValueExtDTO> }
 
+  [<NoComparison; NoEquality>]
   type MovePayload =
     { FromId: ValueDTO<ValueExtDTO>
       SourceId: ValueDTO<ValueExtDTO>

--- a/backend/libraries/ballerina-api/Endpoints/Read.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Read.fs
@@ -23,6 +23,7 @@ module Read =
   open Ballerina.DSL.Next.Serialization.ValueSerializer
   open Ballerina.DSL.Next.StdLib.DB
 
+  [<NoComparison; NoEquality>]
   type GetManyResponseItem =
     { Key: ValueDTO<ValueExtDTO>
       Value: ValueDTO<ValueExtDTO> }

--- a/backend/libraries/ballerina-api/Endpoints/Update.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Update.fs
@@ -29,6 +29,7 @@ module Update =
   open Ballerina.Data.Delta
   open Ballerina.DSL.Next.StdLib.Updater.Model
 
+  [<NoComparison; NoEquality>]
   type UpdateDeltaWithId =
     { Id: ValueDTO<ValueExtDTO>
       Delta: DeltaDTO<ValueExtDTO, DeltaExtDTO> }

--- a/backend/libraries/ballerina-api/Endpoints/Upsert.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Upsert.fs
@@ -25,6 +25,7 @@ module Upsert =
   open Ballerina.Data.Delta.Serialization.DeltaDTO
   open Ballerina.Data.Delta.Serialization.DeltaDeserializer
 
+  [<NoComparison; NoEquality>]
   type EntityWithId =
     { Id: ValueDTO<ValueExtDTO>
       Entity: ValueDTO<ValueExtDTO>

--- a/backend/libraries/ballerina-api/Model/Model.fs
+++ b/backend/libraries/ballerina-api/Model/Model.fs
@@ -14,6 +14,7 @@ open Ballerina.DSL.Next.StdLib.DB
 open Ballerina.Fun
 open Microsoft.AspNetCore.Http
 
+[<NoComparison; NoEquality>]
 type APITypeError<'runtimeContext, 'db, 'customExtension
   when 'customExtension: comparison and 'db: comparison> =
   { ExpectedType: TypeValue<ValueExt<'runtimeContext, 'db, 'customExtension>>
@@ -30,6 +31,7 @@ type APITypeError<'runtimeContext, 'db, 'customExtension
         DeltaExtDTO
        > }
 
+[<NoComparison; NoEquality>]
 type APIError<'runtimeContext, 'db, 'customExtension, 'context
   when 'customExtension: comparison and 'context: comparison and 'db: comparison>
   =
@@ -39,10 +41,12 @@ type APIError<'runtimeContext, 'db, 'customExtension, 'context
   static member Create(errors: Errors<'context>) =
     { Errors = errors; TypeError = None }
 
+[<NoComparison; NoEquality>]
 type APIErrorResponse =
   { Errors: string[]
     Examples: ValueDTO<ValueExtDTO>[] }
 
+[<NoComparison; NoEquality>]
 type DbDescriptor<'runtimeContext, 'db, 'customExtension
   when 'customExtension: comparison and 'db: comparison> =
   { TypeCheckContext:
@@ -73,6 +77,7 @@ type TenantDescriptor<'tenantId, 'schemaName> =
   { TenantId: 'tenantId
     SchemaName: 'schemaName }
 
+[<NoComparison; NoEquality>]
 type APIRegistrationFactory<'runtimeContext, 'db, 'customExtension, 'tenantId, 'schemaName
   when 'customExtension: comparison and 'db: comparison> =
   { DbDescriptorFetcher:

--- a/backend/libraries/ballerina-cat/Coroutine/Model.fs
+++ b/backend/libraries/ballerina-cat/Coroutine/Model.fs
@@ -10,6 +10,7 @@ module Model =
 
   type DeltaT = TimeSpan
 
+  [<NoComparison; NoEquality>]
   type Coroutine<'a, 's, 'c, 'event, 'err> =
     | Co of
       ('s * 'c * OrderedMap<Guid, 'event> * DeltaT
@@ -29,7 +30,7 @@ module Model =
         |> Sum.map (fun (p_result, s_updater, e_updater) ->
           (CoroutineResult.map f p_result, s_updater, e_updater)))
 
-  and CoroutineResult<'a, 's, 'c, 'event, 'err> =
+  and [<NoComparison; NoEquality>] CoroutineResult<'a, 's, 'c, 'event, 'err> =
     | Return of 'a
     | Any of List<Coroutine<'a, 's, 'c, 'event, 'err>>
     // | All of List<Coroutine<'a, 's, 'c, 'event, 'err>>
@@ -212,10 +213,12 @@ module Model =
 
   let co = CoroutineBuilder()
 
+  [<NoComparison; NoEquality>]
   type WaitingCoroutine<'a, 's, 'c, 'event, 'err> =
     { P: Coroutine<'a, 's, 'c, 'event, 'err>
       Until: DateTime }
 
+  [<NoComparison; NoEquality>]
   type EvaluatedCoroutine<'a, 's, 'c, 'event, 'err> =
     | Done of 'a * Option<U<'s>> * Option<U<OrderedMap<Guid, 'event>>>
     | Spawned of
@@ -252,6 +255,7 @@ module Model =
         WaitingOrListening(x, u_s >>? u_s', u_e >>? u_e')
       | Error err -> Error err
 
+  [<NoComparison; NoEquality>]
   type EvaluatedCoroutines<'s, 'c, 'event, 'err> =
     { active: Map<Guid, Coroutine<Unit, 's, 'c, 'event, 'err>>
       stopped: Set<Guid>

--- a/backend/libraries/ballerina-cat/Lenses/Model.fs
+++ b/backend/libraries/ballerina-cat/Lenses/Model.fs
@@ -4,6 +4,7 @@ namespace Ballerina.Lenses
 module Partial =
   open Ballerina.Collections.Option
 
+  [<NoComparison; NoEquality>]
   type PartialLens<'a, 'b> =
     { Get: 'a -> Option<'b>; Set: 'b -> 'a }
 

--- a/backend/libraries/ballerina-cat/Parser/Model.fs
+++ b/backend/libraries/ballerina-cat/Parser/Model.fs
@@ -33,6 +33,7 @@ module Model =
       ParserResult(f a, rest)
 
 
+  [<NoComparison; NoEquality>]
   type Parser<'a, 'sym, 'loc, 'err> =
     | Parser of FreeNode<'a, unit, List<'sym> * 'loc, 'err>
 

--- a/backend/libraries/ballerina-cat/Reader/WithError/Model.fs
+++ b/backend/libraries/ballerina-cat/Reader/WithError/Model.fs
@@ -5,6 +5,7 @@ module WithError =
   open Ballerina.Collections.Sum
   open Ballerina.Collections.NonEmptyList
 
+  [<NoComparison; NoEquality>]
   type Reader<'a, 'c, 'e> =
     | Reader of ('c -> Sum<'a, 'e>)
 

--- a/backend/libraries/ballerina-cat/Stackless/State/WithError/Model.fs
+++ b/backend/libraries/ballerina-cat/Stackless/State/WithError/Model.fs
@@ -8,6 +8,7 @@ module StacklessStateWithError =
   // models a state monad: type State<'a, 'c, 's, 'e> = State of ('c * 's -> Sum<'a * Option<'s>, 'e * Option<'s>>)
   type private MonadResult<'a, 's, 'e> = Sum<'a * Option<'s>, 'e * Option<'s>>
 
+  [<NoComparison; NoEquality>]
   type Node<'c, 's, 'e> =
     | Ret of ('c * 's -> MonadResult<Existential, 's, 'e>)
     | Bind of Node<'c, 's, 'e> * SuccessContinuation<'c, 's, 'e>
@@ -21,6 +22,7 @@ module StacklessStateWithError =
   type BindScope = int
 
   // needed for typing (Node cannot have the value type info because it's existential)
+  [<NoComparison; NoEquality>]
   type FreeNode<'a, 'c, 's, 'e> =
     | FreeNodeCons of Node<'c, 's, 'e>
 

--- a/backend/libraries/ballerina-cat/State/Model.fs
+++ b/backend/libraries/ballerina-cat/State/Model.fs
@@ -3,6 +3,7 @@ namespace Ballerina.State
 module Simple =
   open Ballerina.Fun
 
+  [<NoComparison; NoEquality>]
   type State<'a, 'c, 's> =
     | State of ('c * 's -> 'a * Option<'s>)
 

--- a/backend/libraries/ballerina-cat/State/WithError/Model.fs
+++ b/backend/libraries/ballerina-cat/State/WithError/Model.fs
@@ -10,6 +10,7 @@ module WithError =
 
   open Ballerina.Stackless.State.WithError.StacklessStateWithError
 
+  [<NoComparison; NoEquality>]
   type State<'a, 'c, 's, 'e> =
     | State of FreeNode<'a, 'c, 's, 'e>
 

--- a/backend/libraries/ballerina-cat/State/WithError/Seq/Model.fs
+++ b/backend/libraries/ballerina-cat/State/WithError/Seq/Model.fs
@@ -6,6 +6,7 @@ module Seq =
   open Ballerina
   open Ballerina.Collections.Sum
 
+  [<NoComparison; NoEquality>]
   type SeqState<'a, 'c, 's, 'e> =
     | State of ('c * 's -> Sum<seq<'a> * Option<'s>, 'e * Option<'s>>)
 

--- a/backend/libraries/ballerina-lang-build/Caching.fs
+++ b/backend/libraries/ballerina-lang-build/Caching.fs
@@ -14,6 +14,7 @@ module Caching =
 
   type Fun<'a, 'b> = 'a -> 'b
 
+  [<NoComparison; NoEquality>]
   type BuildCache<'valueExt when 'valueExt: comparison> =
     { TryGet:
         ProjectModel.FileName

--- a/backend/libraries/ballerina-lang-build/ProjectModel.fs
+++ b/backend/libraries/ballerina-lang-build/ProjectModel.fs
@@ -21,10 +21,11 @@ module ProjectModel =
   open System.Text.Json.Serialization
   open Ballerina.Collections.NonEmptyList
 
+  [<NoComparison; NoEquality>]
   type ProjectBuildConfiguration =
     { Files: NonEmptyList<FileBuildConfiguration> }
 
-  and FileTypeCheckedOutput<'valueExt when 'valueExt: comparison> =
+  and [<NoComparison; NoEquality>] FileTypeCheckedOutput<'valueExt when 'valueExt: comparison> =
     { File: FileBuildConfiguration
       Expr: TypeCheckedExpr<'valueExt>
       TypeValue: TypeValue<'valueExt> }
@@ -42,7 +43,7 @@ module ProjectModel =
             md5.ComputeHash(System.Text.Encoding.UTF8.GetBytes(s))
           ) }
 
-  and FileBuildConfiguration =
+  and [<NoComparison; NoEquality>] FileBuildConfiguration =
     { FileName: FileName
       Content: Unit -> string
       Checksum: Checksum }
@@ -52,7 +53,7 @@ module ProjectModel =
         Content = fun () -> fileContent
         Checksum = Checksum.Compute fileContent }
 
-  and ProjectCache<'valueExt when 'valueExt: comparison> =
+  and [<NoComparison; NoEquality>] ProjectCache<'valueExt when 'valueExt: comparison> =
     { Fold:
         NonEmptyList<FileBuildConfiguration>
           -> (FileBuildConfiguration * int

--- a/backend/libraries/ballerina-lang/Next/DeltaSerialization/Models/Context.fs
+++ b/backend/libraries/ballerina-lang/Next/DeltaSerialization/Models/Context.fs
@@ -6,6 +6,7 @@ open Ballerina.Data.Delta
 open Ballerina.Errors
 open DeltaDTO
 
+[<NoComparison; NoEquality>]
 type DeltaSerializationContext<'valueExtension, 'valueExtensionDTO, 'deltaExtension, 'deltaExtensionDTO
   when 'valueExtensionDTO: not null
   and 'valueExtensionDTO: not struct

--- a/backend/libraries/ballerina-lang/Next/DeltaSerialization/Models/PocoObjects.fs
+++ b/backend/libraries/ballerina-lang/Next/DeltaSerialization/Models/PocoObjects.fs
@@ -4,6 +4,7 @@ module DeltaDTO =
   open Ballerina.DSL.Next.Serialization.PocoObjects
   open System.Collections.Generic
 
+  [<NoComparison; NoEquality>]
   type RecordDeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO
     when 'valueExtensionDTO: not null
     and 'valueExtensionDTO: not struct
@@ -12,7 +13,7 @@ module DeltaDTO =
     { Field: string
       Delta: DeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO> }
 
-  and UnionDeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO
+  and [<NoComparison; NoEquality>] UnionDeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO
     when 'valueExtensionDTO: not null
     and 'valueExtensionDTO: not struct
     and 'deltaExtensionDTO: not null
@@ -20,7 +21,7 @@ module DeltaDTO =
     { Case: string
       Delta: DeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO> }
 
-  and TupleDeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO
+  and [<NoComparison; NoEquality>] TupleDeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO
     when 'valueExtensionDTO: not null
     and 'valueExtensionDTO: not struct
     and 'deltaExtensionDTO: not null
@@ -28,7 +29,7 @@ module DeltaDTO =
     { Position: int
       Delta: DeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO> }
 
-  and SumDeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO
+  and [<NoComparison; NoEquality>] SumDeltaDTO<'valueExtensionDTO, 'deltaExtensionDTO
     when 'valueExtensionDTO: not null
     and 'valueExtensionDTO: not struct
     and 'deltaExtensionDTO: not null

--- a/backend/libraries/ballerina-lang/Next/Eval/Expr_FastEval.fs
+++ b/backend/libraries/ballerina-lang/Next/Eval/Expr_FastEval.fs
@@ -59,6 +59,7 @@ module FastEval =
          >
       Symbols: ExprEvalContextSymbols }
 
+  [<NoComparison; NoEquality>]
   type ExprEvalContext<'runtimeContext, 'valueExtension> =
     { Scope: ExprEvalContextScope<'valueExtension>
       /// Stack of scope frames pushed during evaluation.
@@ -84,7 +85,7 @@ module FastEval =
         Value<TypeValue<'valueExtension>, 'valueExtension>
        >)
 
-  and ExtEvalResult<'runtimeContext, 'valueExtension> =
+  and [<NoComparison; NoEquality>] ExtEvalResult<'runtimeContext, 'valueExtension> =
     | Result of Value<TypeValue<'valueExtension>, 'valueExtension>
     | Async of
       Coroutine<
@@ -134,7 +135,7 @@ module FastEval =
       -> Value<TypeValue<'valueExtension>, 'valueExtension>
       -> Value<TypeValue<'valueExtension>, 'valueExtension>
 
-  and ValueExtensionOps<'runtimeContext, 'valueExtension> =
+  and [<NoComparison; NoEquality>] ValueExtensionOps<'runtimeContext, 'valueExtension> =
     { Eval: ExtensionEvaluator<'runtimeContext, 'valueExtension>
       Applicables:
         Map<

--- a/backend/libraries/ballerina-lang/Next/Serialization/Models/Context.fs
+++ b/backend/libraries/ballerina-lang/Next/Serialization/Models/Context.fs
@@ -4,6 +4,7 @@ open Ballerina.Reader.WithError
 open PocoObjects
 open Ballerina.DSL.Next.Types
 
+[<NoComparison; NoEquality>]
 type SerializationContext<'ext, 'extDTO
   when 'extDTO: not null and 'extDTO: not struct> =
   { ToDTO:

--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/DBRun.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/DBRun.fs
@@ -1,6 +1,7 @@
 namespace Ballerina.DSL.Next.StdLib.DB.Extension
 
 #nowarn "0040"
+#nowarn "21"
 
 [<AutoOpen>]
 module DBRun =

--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/Model.fs
@@ -68,6 +68,7 @@ module Model =
       SourceId: Value<TypeValue<'ext>, 'ext>
       TargetId: Value<TypeValue<'ext>, 'ext> }
 
+  [<NoComparison; NoEquality>]
   type DBTypeClass<'runtimeContext, 'db, 'ext when 'ext: comparison> =
     { DB: 'db
       BeginTransaction: 'db -> Sum<Guid, Errors<Unit>>

--- a/backend/libraries/ballerina-lang/Next/Stdlib/Email/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Email/Extension.fs
@@ -14,6 +14,7 @@ module Extension =
   open Ballerina.Lenses
   open Ballerina.DSL.Next.Extensions
 
+  [<NoComparison; NoEquality>]
   type EmailTypeClass<'runtimeContext> =
     { send: 'runtimeContext -> string -> string -> string -> unit }
 

--- a/backend/libraries/ballerina-lang/Next/Stdlib/Extensions/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Extensions/Model.fs
@@ -18,6 +18,7 @@ module Model =
   open Ballerina.Fun
 
 
+  [<NoComparison; NoEquality>]
   type LanguageContext<'runtimeContext, 'ext, 'extDTO, 'deltaExt, 'deltaExtDTO
     when 'ext: comparison
     and 'extDTO: not null
@@ -32,6 +33,7 @@ module Model =
         DeltaSerializationContext<'ext, 'extDTO, 'deltaExt, 'deltaExtDTO>
       ExtTypeChecker: Option<IsExtInstanceOf<'ext>> }
 
+  [<NoComparison; NoEquality>]
   type OperationsExtension<'runtimeContext, 'ext, 'extOperations> =
     { TypeVars: List<TypeVar * Kind> // example: [ ("a", Star) ]
       // WrapTypeVars: TypeExpr -> TypeValue
@@ -41,7 +43,7 @@ module Model =
           OperationExtension<'runtimeContext, 'ext, 'extOperations>
          > }
 
-  and OperationExtension<'runtimeContext, 'ext, 'extOperations> =
+  and [<NoComparison; NoEquality>] OperationExtension<'runtimeContext, 'ext, 'extOperations> =
     { PublicIdentifiers: Option<TypeValue<'ext> * Kind * 'extOperations>
       OperationsLens: PartialLens<'ext, 'extOperations> // lens to access the value inside the extension value
       Apply:
@@ -50,7 +52,7 @@ module Model =
           -> 'extOperations * Value<TypeValue<'ext>, 'ext>
           -> ExprEvaluator<'runtimeContext, 'ext, Value<TypeValue<'ext>, 'ext>> }
 
-  and TypeExtension<'runtimeContext, 'ext, 'extDTO, 'deltaExt, 'deltaExtDTO, 'extConstructors, 'extValues, 'extOperations
+  and [<NoComparison; NoEquality>] TypeExtension<'runtimeContext, 'ext, 'extDTO, 'deltaExt, 'deltaExtDTO, 'extConstructors, 'extValues, 'extOperations
     when 'ext: comparison
     and 'extDTO: not struct
     and 'extDTO: not null
@@ -99,7 +101,7 @@ module Model =
           |> List.map (fun (tv, k) -> TypeParameter.Create(tv.Name, k))
         Arguments = [] }
 
-  and TypeOperationExtension<'runtimeContext, 'ext, 'extConstructors, 'extValues, 'extOperations>
+  and [<NoComparison; NoEquality>] TypeOperationExtension<'runtimeContext, 'ext, 'extConstructors, 'extValues, 'extOperations>
     =
     { Type: TypeValue<'ext> // "a => b => (a -> b) -> Option a -> Option b"
       Kind: Kind // * => * => *
@@ -111,7 +113,7 @@ module Model =
           -> 'extOperations * Value<TypeValue<'ext>, 'ext>
           -> ExprEvaluator<'runtimeContext, 'ext, Value<TypeValue<'ext>, 'ext>> }
 
-  and TypeCaseExtension<'runtimeContext, 'ext, 'extConstructors, 'extValues> =
+  and [<NoComparison; NoEquality>] TypeCaseExtension<'runtimeContext, 'ext, 'extConstructors, 'extValues> =
     { CaseType: TypeExpr<'ext> // "a"
       ConstructorType: TypeValue<'ext> // "a => Option a"
       Constructor: 'extConstructors
@@ -123,7 +125,7 @@ module Model =
           -> 'extConstructors * Value<TypeValue<'ext>, 'ext>
           -> ExprEvaluator<'runtimeContext, 'ext, Value<TypeValue<'ext>, 'ext>> }
 
-  and TypeLambdaExtension<'runtimeContext, 'ext, 'extDTO, 'extTypeLambda
+  and [<NoComparison; NoEquality>] TypeLambdaExtension<'runtimeContext, 'ext, 'extDTO, 'extTypeLambda
     when 'extDTO: not null and 'extDTO: not struct> =
     { ExtensionType: ResolvedIdentifier * TypeValue<'ext> * Kind
       ExtraBindings: Map<ResolvedIdentifier, TypeValue<'ext> * Kind>

--- a/backend/libraries/ballerina-lang/Next/Stdlib/List/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/List/Model.fs
@@ -65,6 +65,7 @@ module Model =
     | RemoveAllElements
     | MoveElement of fromIndex: int * toIndex: int
 
+  [<NoComparison; NoEquality>]
   type UpdateElementDTO<'extDTO, 'deltaExtDTO
     when 'extDTO: not null
     and 'extDTO: not struct
@@ -73,6 +74,7 @@ module Model =
     { Index: int
       Value: DeltaDTO<'extDTO, 'deltaExtDTO> }
 
+  [<NoComparison; NoEquality>]
   type InsertElementDTO<'extDTO when 'extDTO: not null and 'extDTO: not struct>
     =
     { Index: int; Value: ValueDTO<'extDTO> }
@@ -83,6 +85,7 @@ module Model =
   type MoveElementDTO<'extDTO when 'extDTO: not null and 'extDTO: not struct> =
     { From: int; To: int }
 
+  [<NoComparison; NoEquality>]
   type ListDeltaExtDTO<'extDTO, 'deltaExtDTO
     when 'extDTO: not null
     and 'extDTO: not struct

--- a/backend/libraries/ballerina-lang/Next/Stdlib/Map/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Map/Model.fs
@@ -50,10 +50,12 @@ module Model =
       value: Model.Value<Model.TypeValue<'valueExt>, 'valueExt>
     | RemoveItem of key: Model.Value<Model.TypeValue<'valueExt>, 'valueExt>
 
+  [<NoComparison; NoEquality>]
   type UpdateMapKeyDTO<'extDTO when 'extDTO: not null and 'extDTO: not struct> =
     { OldKey: ValueDTO<'extDTO>
       NewKey: ValueDTO<'extDTO> }
 
+  [<NoComparison; NoEquality>]
   type UpdateMapValueDTO<'extDTO, 'deltaExtDTO
     when 'extDTO: not null
     and 'extDTO: not struct
@@ -62,10 +64,12 @@ module Model =
     { Key: ValueDTO<'extDTO>
       Value: DeltaDTO<'extDTO, 'deltaExtDTO> }
 
+  [<NoComparison; NoEquality>]
   type AddMapItemDTO<'extDTO when 'extDTO: not null and 'extDTO: not struct> =
     { Key: ValueDTO<'extDTO>
       Value: ValueDTO<'extDTO> }
 
+  [<NoComparison; NoEquality>]
   type MapDeltaExtDTO<'extDTO, 'deltaExtDTO
     when 'extDTO: not null
     and 'extDTO: not struct

--- a/backend/libraries/ballerina-lang/Next/Stdlib/SmartComponents/SmartComponents.LocalEmbeddings/EmbeddingF32.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/SmartComponents/SmartComponents.LocalEmbeddings/EmbeddingF32.fs
@@ -23,7 +23,7 @@ type internal Utils private () =
       MemoryMarshal.Cast<byte, sbyte>(fromMemory.Span).ToArray()
     )
 
-[<Struct; JsonConverter(typeof<FloatEmbeddingJsonConverter>)>]
+[<Struct; NoComparison; NoEquality; JsonConverter(typeof<FloatEmbeddingJsonConverter>)>]
 type EmbeddingF32 =
   val private buffer: ReadOnlyMemory<byte>
   val private values: ReadOnlyMemory<single>

--- a/backend/libraries/ballerina-lang/Next/Stdlib/SmartComponents/SmartComponents.LocalEmbeddings/EmbeddingI1.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/SmartComponents/SmartComponents.LocalEmbeddings/EmbeddingI1.fs
@@ -5,7 +5,7 @@ open System.Numerics
 open System.Text.Json
 open System.Text.Json.Serialization
 
-[<Struct; JsonConverter(typeof<BitEmbeddingJsonConverter>)>]
+[<Struct; NoComparison; NoEquality; JsonConverter(typeof<BitEmbeddingJsonConverter>)>]
 type EmbeddingI1 =
   val private buffer: ReadOnlyMemory<byte>
 

--- a/backend/libraries/ballerina-lang/Next/Stdlib/SmartComponents/SmartComponents.LocalEmbeddings/EmbeddingI8.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/SmartComponents/SmartComponents.LocalEmbeddings/EmbeddingI8.fs
@@ -6,7 +6,7 @@ open System.Runtime.InteropServices
 open System.Text.Json
 open System.Text.Json.Serialization
 
-[<Struct; JsonConverter(typeof<ByteEmbeddingJsonConverter>)>]
+[<Struct; NoComparison; NoEquality; JsonConverter(typeof<ByteEmbeddingJsonConverter>)>]
 type EmbeddingI8 =
   val private buffer: ReadOnlyMemory<byte>
   val private values: ReadOnlyMemory<sbyte>

--- a/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
@@ -46,7 +46,7 @@ type ValueExt<'runtimeContext, 'db, 'customExtension
 
   static member Updaters = {| ValueExt = fun u (ValueExt e) -> ValueExt(u e) |}
 
-and ValueExtDTO =
+and [<NoComparison; NoEquality>] ValueExtDTO =
   { List: List.Model.ListValueDTO<ValueExtDTO>
     Map: Map.Model.MapValueDTO<ValueExtDTO> }
 
@@ -553,12 +553,13 @@ and TupleDeltaExt<'runtimeContext, 'db, 'customExtension
 
 and OptionDeltaExt = OptionDeltaExt
 
-and DeltaExtDTO =
+and [<NoComparison; NoEquality>] DeltaExtDTO =
   { ListDelta: ListDeltaExtDTO<ValueExtDTO, DeltaExtDTO> | null
     MapDelta: Map.Model.MapDeltaExtDTO<ValueExtDTO, DeltaExtDTO> | null }
 
   static member Empty = { ListDelta = null; MapDelta = null }
 
+[<NoComparison; NoEquality>]
 type StdExtensions<'runtimeContext, 'valueExt, 'valueExtDTO, 'deltaExt, 'deltaExtDTO
   when 'valueExt: comparison
   and 'deltaExt: comparison

--- a/backend/libraries/ballerina-lang/Next/Stdlib/String/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/String/Extension.fs
@@ -15,6 +15,7 @@ module Extension =
   open Ballerina.DSL.Next.Extensions
   open Ballerina
 
+  [<NoComparison; NoEquality>]
   type StringTypeClass<'ext> =
     { print: Value<TypeValue<'ext>, 'ext> -> unit }
 

--- a/backend/libraries/ballerina-lang/Next/Stdlib/Updater/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Updater/Model.fs
@@ -7,11 +7,12 @@ module Model =
   open Ballerina.Errors
   open PolyType
 
+  [<NoComparison; NoEquality>]
   type UpdaterType<'ext> =
     Value<TypeValue<'ext>, 'ext>
       -> Sum<Value<TypeValue<'ext>, 'ext>, Errors<unit>>
 
-  [<TypeShape(Kind = TypeShapeKind.None)>]
+  [<TypeShape(Kind = TypeShapeKind.None); NoComparison; NoEquality>]
   type UpdaterFunction<'ext> = { Updater: UpdaterType<'ext> }
 
   [<CustomEquality; CustomComparison>]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Lexer.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Lexer.fs
@@ -183,9 +183,9 @@ module Lexer =
       | CaseLiteral(i, n) -> $"{i}Of{n}"
       | BoolLiteral b -> if b then "true" else "false"
       | IntLiteral i -> i.ToString()
-      | Int64Literal i -> $"{i.ToString()}" + longSuffixString.ToString()
-      | Float32Literal f -> $"{f.ToString()}" + floatSuffixString.ToString()
-      | Float64Literal f -> $"{f.ToString()}" + doubleSuffixString.ToString()
+      | Int64Literal i -> $"{i.ToString()}" + (string longSuffixString)
+      | Float32Literal f -> $"{f.ToString()}" + (string floatSuffixString)
+      | Float64Literal f -> $"{f.ToString()}" + (string doubleSuffixString)
       | DecimalLiteral d -> d.ToString()
 
   type LocalizedToken =

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Precedence.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Precedence.fs
@@ -23,6 +23,7 @@ module Precedence =
     | Operand of 'operand * OperandMergeability
     | Operator of 'operator
 
+  [<NoComparison; NoEquality>]
   type BinaryOperatorsOperations<'operand, 'operator, 'expr> =
     { Compose:
         'operand *

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/Model.fs
@@ -168,6 +168,7 @@ module Model =
       PermissionHooksExtraScope:
         Map<ResolvedIdentifier, (TypeValue<'valueExt> * Kind)> }
 
+  [<NoComparison; NoEquality>]
   type TypeCheckingConfig<'valueExt when 'valueExt: comparison> =
     { QueryTypeSymbol: TypeSymbol
       ListTypeSymbol: TypeSymbol

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/TypeExtractionExpr.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/TypeExtractionExpr.fs
@@ -15,6 +15,7 @@ module TypeExtractionExpr =
 
   type MapOps = { MapToList: ResolvedIdentifier }
 
+  [<NoComparison; NoEquality>]
   type private CompileContext<'valueExt> =
     { ListOps: ListOps
       MapOps: MapOps

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/Unification/EquivalenceClass.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/Unification/EquivalenceClass.fs
@@ -56,7 +56,7 @@ module EquivalenceClasses =
         { Representative = rep
           Variables = vars }
 
-  and EquivalenceClassValueOperations<'var, 'value, 'context
+  and [<NoComparison; NoEquality>] EquivalenceClassValueOperations<'var, 'value, 'context
     when 'var: comparison and 'value: comparison and 'context: comparison> =
     { equalize:
         'value * 'value

--- a/backend/libraries/ballerina-memorydb/MemoryDB.fs
+++ b/backend/libraries/ballerina-memorydb/MemoryDB.fs
@@ -128,6 +128,7 @@ module MutableMemoryDB =
   // type EvalQueryContext<'ext when 'ext: comparison> =
   //   { Bindings: Map<ResolvedIdentifier, Value<TypeValue<'ext>, 'ext>> }
 
+  [<NoComparison; NoEquality>]
   type MemoryDBQueryRunAdapter<'db, 'ext when 'ext: comparison> =
     { GetDbFromEntityRef: EntityRef<'db, 'ext> -> 'db
       GetDbFromRelationRef: RelationRef<'db, 'ext> -> 'db }

--- a/backend/libraries/ballerina-stdlib/Core/String/Model.fs
+++ b/backend/libraries/ballerina-stdlib/Core/String/Model.fs
@@ -34,7 +34,10 @@ module String =
       if self |> String.IsNullOrEmpty then
         self
       else
-        String.Concat(self[0].ToString().ToUpper(), self.AsSpan(1))
+        let c = Char.ToUpper(self.[0])
+        let first = string c
+        let rest = self.Substring(1)
+        String.Concat(first, rest)
 
     static member ToFirstUpper(self: String) = self.ToFirstUpper
 

--- a/backend/libraries/ballerina-stdlib/Core/StringBuilder/Model.fs
+++ b/backend/libraries/ballerina-stdlib/Core/StringBuilder/Model.fs
@@ -5,6 +5,7 @@ module StringBuilder =
   open System
   open System.Text.RegularExpressions
 
+  [<NoComparison; NoEquality>]
   type StringBuilder =
     | One of string
     | Many of seq<StringBuilder>

--- a/backend/libraries/ballerina-stdlib/Errors/Model.fs
+++ b/backend/libraries/ballerina-stdlib/Errors/Model.fs
@@ -37,6 +37,7 @@ module Errors =
 
     static member MapPriority f e = { e with Priority = f e.Priority }
 
+  [<NoComparison; NoEquality>]
   type Errors<'context when 'context: comparison> =
     { Errors: unit -> NonEmptyList<Error<'context>> }
 


### PR DESCRIPTION
## Summary

- Enable `WarningLevel 5` in `Directory.Build.props` (was a TODO comment)
- Add `[<NoComparison; NoEquality>]` to all types containing function fields/cases across:
  - `ballerina-cat` (Lenses, State, Reader, Coroutine, Parser)
  - `ballerina-stdlib` (StringBuilder, Errors)
  - `ballerina-lang-parser` (Precedence)
  - `ballerina-lang-typecheck` (EquivalenceClass, Model, TypeExtractionExpr)
  - `ballerina-lang-eval` (ExprEvalContext, ExtEvalResult, ValueExtensionOps)
  - `ballerina-lang-serialization` (SerializationContext)
  - `ballerina-delta-serialization` (DeltaSerializationContext, DTOs)
  - `ballerina-lang-stdlib` (Extensions, DB, Email, String, Updater, StdExtensions, List, Map)
  - `ballerina-lang-build` (ProjectModel, Caching)
  - `ballerina-api` (Model, Endpoints)
  - `ballerina-memorydb` (MemoryDB)
  - `ballerina-api-filedb-factory` (CompilationCache)
  - SmartComponents (EmbeddingF32, EmbeddingI1, EmbeddingI8)
- Fix `FS0052` struct copy warnings in `String/Model.fs` and `Lexer.fs`
- Add `#nowarn "21"` for safe recursive initialization in `DBRun.fs`

## Testing

- `dotnet build backend.sln` → 0 warnings, 0 errors
- All 26 sample integration tests pass