### PR TITLE
feat: View/Coroutine parser and typechecker extensions

### DIFF
--- a/backend/libraries/ballerina-lang-build/HddCache.fs
+++ b/backend/libraries/ballerina-lang-build/HddCache.fs
@@ -46,7 +46,10 @@ module HddCache =
   type BuildCacheContainerDto<'valueExt when 'valueExt: comparison> =
     { Entries: (string * byte array) array
       QueryTypeSymbol: Option<TypeSymbol>
-      ListTypeSymbol: Option<TypeSymbol> }
+      ListTypeSymbol: Option<TypeSymbol>
+      ViewTypeSymbol: Option<TypeSymbol>
+      ViewPropsTypeSymbol: Option<TypeSymbol>
+      CoTypeSymbol: Option<TypeSymbol> }
 
   type PersistedCacheData<'valueExt when 'valueExt: comparison> =
     Map<
@@ -58,6 +61,9 @@ module HddCache =
       TypeCheckContext<'valueExt> *
       TypeCheckState<'valueExt>
      > *
+    Option<TypeSymbol> *
+    Option<TypeSymbol> *
+    Option<TypeSymbol> *
     Option<TypeSymbol> *
     Option<TypeSymbol>
 
@@ -89,15 +95,18 @@ module HddCache =
         | Left container ->
           decodeEntries container.Entries,
           container.QueryTypeSymbol,
-          container.ListTypeSymbol
+          container.ListTypeSymbol,
+          container.ViewTypeSymbol,
+          container.ViewPropsTypeSymbol,
+          container.CoTypeSymbol
         | Right _ ->
           // Legacy cache format has no TypeCheckingConfig and can lead to symbol mismatches.
           // Force a clean rebuild so the next persisted cache includes the config.
-          Map.empty, None, None
+          Map.empty, None, None, None, None, None
       else
-        Map.empty, None, None
+        Map.empty, None, None, None, None, None
     with _ ->
-      Map.empty, None, None
+      Map.empty, None, None, None, None, None
 
   let private tryDeleteCacheFile (cacheFilePath: string) =
     try
@@ -111,18 +120,24 @@ module HddCache =
     : Option<TypeCheckingConfig<'valueExt>> =
     let serializer = MessagePackSerializerAdapter()
 
-    let _, queryTypeSymbol, listTypeSymbol =
+    let _, queryTypeSymbol, listTypeSymbol, viewTypeSymbol, viewPropsTypeSymbol, coTypeSymbol =
       loadPersistedCacheData<'valueExt> serializer cacheFilePath
 
     let dbQueryId = Identifier.FullyQualified([ "DB" ], "Query")
     let dbQueryResolvedId = dbQueryId |> TypeCheckScope.Empty.Resolve
     let listId = Identifier.LocalScope "List" |> TypeCheckScope.Empty.Resolve
+    let viewId = Identifier.FullyQualified([ "Frontend" ], "View") |> TypeCheckScope.Empty.Resolve
+    let viewPropsId = Identifier.FullyQualified([ "View" ], "Props") |> TypeCheckScope.Empty.Resolve
+    let coId = Identifier.LocalScope "Co" |> TypeCheckScope.Empty.Resolve
 
-    match queryTypeSymbol, listTypeSymbol with
-    | Some queryTypeSymbol, Some listTypeSymbol ->
+    match queryTypeSymbol, listTypeSymbol, viewTypeSymbol, viewPropsTypeSymbol, coTypeSymbol with
+    | Some queryTypeSymbol, Some listTypeSymbol, Some viewTypeSymbol, Some viewPropsTypeSymbol, Some coTypeSymbol ->
       Some
         { QueryTypeSymbol = queryTypeSymbol
           ListTypeSymbol = listTypeSymbol
+          ViewTypeSymbol = viewTypeSymbol
+          ViewPropsTypeSymbol = viewPropsTypeSymbol
+          CoTypeSymbol = coTypeSymbol
           // This config is only used to bootstrap stdExtensions with stable symbols.
           MkQueryType =
             fun s qr ->
@@ -137,7 +152,28 @@ module HddCache =
                 { Id = listId
                   Sym = listTypeSymbol
                   Parameters = []
-                  Arguments = [ inner ] } }
+                  Arguments = [ inner ] }
+          MkViewType =
+            fun schema ctx st ->
+              TypeValue.Imported
+                { Id = viewId
+                  Sym = viewTypeSymbol
+                  Parameters = []
+                  Arguments = [ schema; ctx; st ] }
+          MkViewPropsType =
+            fun schema ctx st ->
+              TypeValue.Imported
+                { Id = viewPropsId
+                  Sym = viewPropsTypeSymbol
+                  Parameters = []
+                  Arguments = [ schema; ctx; st ] }
+          MkCoType =
+            fun schema ctx st res ->
+              TypeValue.Imported
+                { Id = coId
+                  Sym = coTypeSymbol
+                  Parameters = []
+                  Arguments = [ schema; ctx; st; res ] } }
     | _ ->
       // If symbols are missing while cache file exists, assume format mismatch and invalidate.
       tryDeleteCacheFile cacheFilePath
@@ -153,7 +189,7 @@ module HddCache =
     let cacheFilePath = Path.Combine(cacheFolder, "build-cache.msgpack")
 
     let loadCache () =
-      let cache, _, _ =
+      let cache, _, _, _, _, _ =
         loadPersistedCacheData<'valueExt> serializer cacheFilePath
 
       cache
@@ -176,7 +212,13 @@ module HddCache =
             QueryTypeSymbol =
               typeCheckingConfig |> Option.map (fun cfg -> cfg.QueryTypeSymbol)
             ListTypeSymbol =
-              typeCheckingConfig |> Option.map (fun cfg -> cfg.ListTypeSymbol) }
+              typeCheckingConfig |> Option.map (fun cfg -> cfg.ListTypeSymbol)
+            ViewTypeSymbol =
+              typeCheckingConfig |> Option.map (fun cfg -> cfg.ViewTypeSymbol)
+            ViewPropsTypeSymbol =
+              typeCheckingConfig |> Option.map (fun cfg -> cfg.ViewPropsTypeSymbol)
+            CoTypeSymbol =
+              typeCheckingConfig |> Option.map (fun cfg -> cfg.CoTypeSymbol) }
 
         match serializer.Serialize(container) with
         | Left bytes ->

--- a/backend/libraries/ballerina-lang/Next/Eval/Expr_TypeEval.fs
+++ b/backend/libraries/ballerina-lang/Next/Eval/Expr_TypeEval.fs
@@ -241,6 +241,18 @@ module TypeEval =
                 $"Error (typecheck): not yet implemented expression pattern query")
               |> state.Throw
 
+          | ExprRec.View _ ->
+            return!
+              Errors.Singleton expr.Location (fun () ->
+                $"Error (typecheck): not yet implemented expression pattern view")
+              |> state.Throw
+
+          | ExprRec.Co _ ->
+            return!
+              Errors.Singleton expr.Location (fun () ->
+                $"Error (typecheck): not yet implemented expression pattern co")
+              |> state.Throw
+
           | ExprRec.RecoveredSyntaxError err ->
             return!
               Errors.Singleton err.ErrorLocation (fun () -> err.ErrorMessage)

--- a/backend/libraries/ballerina-lang/Next/Models/Types.fs
+++ b/backend/libraries/ballerina-lang/Next/Models/Types.fs
@@ -2142,6 +2142,96 @@ module Model =
 
     override self.ToString() = $"{self.Param} -> {self.Body}"
 
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Type-checked View AST types
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  and [<RequireQualifiedAccess>] TypeCheckedExprView<'valueExt> =
+    { Param: Var
+      ParamType: TypeValue<'valueExt>
+      Body: TypeCheckedViewNode<'valueExt>
+      Location: Location }
+
+    override self.ToString() =
+      $"view ({self.Param}: {self.ParamType}) -> {self.Body}"
+
+  and [<RequireQualifiedAccess>] TypeCheckedViewNode<'valueExt> =
+    { Location: Location
+      Node: TypeCheckedViewNodeRec<'valueExt> }
+
+    override self.ToString() = self.Node.ToString()
+
+  and [<RequireQualifiedAccess>] TypeCheckedViewNodeRec<'valueExt> =
+    | ViewElement of TypeCheckedViewElement<'valueExt>
+    | ViewFragment of List<TypeCheckedViewNode<'valueExt>>
+    | ViewExprContainer of TypeCheckedExpr<'valueExt>
+    | ViewText of string
+
+    override self.ToString() =
+      match self with
+      | ViewElement el -> el.ToString()
+      | ViewFragment children ->
+        let childStrs = children |> List.map string |> String.concat " "
+        $"<>{childStrs}</>"
+      | ViewExprContainer e -> $"{{{e}}}"
+      | ViewText t -> t
+
+  and [<RequireQualifiedAccess>] TypeCheckedViewElement<'valueExt> =
+    { Tag: string
+      Attributes: List<TypeCheckedViewAttribute<'valueExt>>
+      Children: List<TypeCheckedViewNode<'valueExt>>
+      SelfClosing: bool }
+
+    override self.ToString() =
+      let attrStr =
+        self.Attributes |> List.map string |> String.concat " "
+
+      if self.SelfClosing then
+        $"<{self.Tag} {attrStr} />"
+      else
+        let childStr =
+          self.Children |> List.map string |> String.concat ""
+
+        $"<{self.Tag} {attrStr}>{childStr}</{self.Tag}>"
+
+  and [<RequireQualifiedAccess>] TypeCheckedViewAttribute<'valueExt> =
+    | ViewAttrStringValue of Name: string * Value: string
+    | ViewAttrExprValue of Name: string * Value: TypeCheckedExpr<'valueExt>
+
+    override self.ToString() =
+      match self with
+      | ViewAttrStringValue(name, value) -> $"{name}=\"{value}\""
+      | ViewAttrExprValue(name, _) -> $"{name}={{...}}"
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Type-checked Coroutine AST types
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  and [<RequireQualifiedAccess>] TypeCheckedExprCo<'valueExt> =
+    { Body: TypeCheckedCoStep<'valueExt>
+      Location: Location }
+
+    override self.ToString() = $"co {{ {self.Body} }}"
+
+  and [<RequireQualifiedAccess>] TypeCheckedCoStep<'valueExt> =
+    { Location: Location
+      Step: TypeCheckedCoStepRec<'valueExt> }
+
+    override self.ToString() = self.Step.ToString()
+
+  and [<RequireQualifiedAccess>] TypeCheckedCoStepRec<'valueExt> =
+    | CoLetBang of Var: Var * Value: TypeCheckedExpr<'valueExt> * Rest: TypeCheckedCoStep<'valueExt>
+    | CoDoBang of Value: TypeCheckedExpr<'valueExt> * Rest: TypeCheckedCoStep<'valueExt>
+    | CoReturn of TypeCheckedExpr<'valueExt>
+    | CoReturnBang of TypeCheckedExpr<'valueExt>
+
+    override self.ToString() =
+      match self with
+      | CoLetBang(var, value, rest) -> $"let! {var} = {value}; {rest}"
+      | CoDoBang(value, rest) -> $"do! {value}; {rest}"
+      | CoReturn e -> $"return {e}"
+      | CoReturnBang e -> $"return! {e}"
+
   and [<RequireQualifiedAccess>] TypeCheckedExprRecoveredSyntaxError =
     { ErrorMessage: string
       ErrorLocation: Location
@@ -2198,8 +2288,8 @@ module Model =
     | TupleDes of TypeCheckedExprTupleDes<'valueExt>
     | SumDes of TypeCheckedExprSumDes<'valueExt>
     | Query of TypeCheckedExprQuery<'valueExt>
-    | View of ExprView<TypeValue<'valueExt>, ResolvedIdentifier, 'valueExt>
-    | Co of ExprCo<TypeValue<'valueExt>, ResolvedIdentifier, 'valueExt>
+    | View of TypeCheckedExprView<'valueExt>
+    | Co of TypeCheckedExprCo<'valueExt>
     | RecoveredSyntaxError of TypeCheckedExprRecoveredSyntaxError
     | ErrorDanglingRecordDes of TypeCheckedExprErrorDanglingRecordDes<'valueExt>
     | ErrorDanglingScopedIdentifier of TypeCheckedExprErrorDanglingScopedIdentifier

--- a/backend/libraries/ballerina-lang/Next/Models/Types.fs
+++ b/backend/libraries/ballerina-lang/Next/Models/Types.fs
@@ -1496,6 +1496,99 @@ module Model =
       | Some t -> $"{self.Var}: {t} in {self.Source}"
       | None -> $"{self.Var} in {self.Source}"
 
+  // ═══════════════════════════════════════════════════════════════════════════
+  // View AST types (JSX-like syntax)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  and ExprView<'T, 'Id, 'valueExt when 'Id: comparison> =
+    { Param: Var
+      ParamType: Option<'T>
+      Body: ExprViewNode<'T, 'Id, 'valueExt>
+      Location: Location }
+
+    override self.ToString() =
+      match self.ParamType with
+      | Some t -> $"view ({self.Param}: {t}) -> {self.Body}"
+      | None -> $"view {self.Param} -> {self.Body}"
+
+  and ExprViewNode<'T, 'Id, 'valueExt when 'Id: comparison> =
+    { Location: Location
+      Node: ExprViewNodeRec<'T, 'Id, 'valueExt> }
+
+    override self.ToString() = self.Node.ToString()
+
+  and ExprViewNodeRec<'T, 'Id, 'valueExt when 'Id: comparison> =
+    | ViewElement of ExprViewElement<'T, 'Id, 'valueExt>
+    | ViewFragment of List<ExprViewNode<'T, 'Id, 'valueExt>>
+    | ViewExprContainer of Expr<'T, 'Id, 'valueExt>
+    | ViewText of string
+
+    override self.ToString() =
+      match self with
+      | ViewElement el -> el.ToString()
+      | ViewFragment children ->
+        let childStrs = children |> List.map (fun c -> c.ToString()) |> String.concat " "
+        $"<>{childStrs}</>"
+      | ViewExprContainer e -> $"{{{e}}}"
+      | ViewText t -> t
+
+  and ExprViewElement<'T, 'Id, 'valueExt when 'Id: comparison> =
+    { Tag: string
+      Attributes: List<ExprViewAttribute<'T, 'Id, 'valueExt>>
+      Children: List<ExprViewNode<'T, 'Id, 'valueExt>>
+      SelfClosing: bool }
+
+    override self.ToString() =
+      let attrStr =
+        self.Attributes
+        |> List.map (fun a -> a.ToString())
+        |> String.concat " "
+      if self.SelfClosing then
+        $"<{self.Tag} {attrStr} />"
+      else
+        let childStr = self.Children |> List.map (fun c -> c.ToString()) |> String.concat ""
+        $"<{self.Tag} {attrStr}>{childStr}</{self.Tag}>"
+
+  and ExprViewAttribute<'T, 'Id, 'valueExt when 'Id: comparison> =
+    | ViewAttrStringValue of Name: string * Value: string
+    | ViewAttrExprValue of Name: string * Value: Expr<'T, 'Id, 'valueExt>
+
+    override self.ToString() =
+      match self with
+      | ViewAttrStringValue(name, value) -> $"{name}=\"{value}\""
+      | ViewAttrExprValue(name, _) -> $"{name}={{...}}"
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Coroutine AST types (co { } computation expressions)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  and ExprCo<'T, 'Id, 'valueExt when 'Id: comparison> =
+    { Body: ExprCoStep<'T, 'Id, 'valueExt>
+      Location: Location }
+
+    override self.ToString() = $"co {{ {self.Body} }}"
+
+  and ExprCoStep<'T, 'Id, 'valueExt when 'Id: comparison> =
+    { Location: Location
+      Step: ExprCoStepRec<'T, 'Id, 'valueExt> }
+
+    override self.ToString() = self.Step.ToString()
+
+  and ExprCoStepRec<'T, 'Id, 'valueExt when 'Id: comparison> =
+    | CoLetBang of Var: Var * Value: Expr<'T, 'Id, 'valueExt> * Rest: ExprCoStep<'T, 'Id, 'valueExt>
+    | CoDoBang of Value: Expr<'T, 'Id, 'valueExt> * Rest: ExprCoStep<'T, 'Id, 'valueExt>
+    | CoReturn of Expr<'T, 'Id, 'valueExt>
+    | CoReturnBang of Expr<'T, 'Id, 'valueExt>
+
+    override self.ToString() =
+      match self with
+      | CoLetBang(var, value, rest) -> $"let! {var} = {value}; {rest}"
+      | CoDoBang(value, rest) -> $"do! {value}; {rest}"
+      | CoReturn e -> $"return {e}"
+      | CoReturnBang e -> $"return! {e}"
+
+  // ═══════════════════════════════════════════════════════════════════════════
+
   and ExprRecoveredSyntaxError<'T, 'Id, 'valueExt when 'Id: comparison> =
     { ErrorMessage: string
       ErrorLocation: Location
@@ -1546,6 +1639,8 @@ module Model =
     | TupleDes of ExprTupleDes<'T, 'Id, 'valueExt>
     | SumDes of ExprSumDes<'T, 'Id, 'valueExt>
     | Query of ExprQuery<'T, 'Id, 'valueExt>
+    | View of ExprView<'T, 'Id, 'valueExt>
+    | Co of ExprCo<'T, 'Id, 'valueExt>
     | RecoveredSyntaxError of ExprRecoveredSyntaxError<'T, 'Id, 'valueExt>
     | ErrorDanglingRecordDes of ExprErrorDanglingRecordDes<'T, 'Id, 'valueExt>
     | ErrorDanglingScopedIdentifier of ExprErrorDanglingScopedIdentifier<'T, 'Id, 'valueExt>
@@ -1657,6 +1752,8 @@ module Model =
         $"(if {cond.ToString()} then {thenExpr.ToString()} else {elseExpr.ToString()})"
 
       | Query q -> q.ToString()
+      | View v -> v.ToString()
+      | Co c -> c.ToString()
       | RecoveredSyntaxError err -> err.ToString()
       | ErrorDanglingRecordDes err -> err.ToString()
       | ErrorDanglingScopedIdentifier err -> err.ToString()
@@ -2101,6 +2198,8 @@ module Model =
     | TupleDes of TypeCheckedExprTupleDes<'valueExt>
     | SumDes of TypeCheckedExprSumDes<'valueExt>
     | Query of TypeCheckedExprQuery<'valueExt>
+    | View of ExprView<TypeValue<'valueExt>, ResolvedIdentifier, 'valueExt>
+    | Co of ExprCo<TypeValue<'valueExt>, ResolvedIdentifier, 'valueExt>
     | RecoveredSyntaxError of TypeCheckedExprRecoveredSyntaxError
     | ErrorDanglingRecordDes of TypeCheckedExprErrorDanglingRecordDes<'valueExt>
     | ErrorDanglingScopedIdentifier of TypeCheckedExprErrorDanglingScopedIdentifier
@@ -2188,6 +2287,8 @@ module Model =
              Else = elseExpr }) ->
         $"(if {cond} then {thenExpr} else {elseExpr})"
       | Query q -> q.ToString()
+      | View v -> v.ToString()
+      | Co c -> c.ToString()
       | RecoveredSyntaxError err -> err.ToString()
       | ErrorDanglingRecordDes err -> err.ToString()
       | ErrorDanglingScopedIdentifier err -> err.ToString()

--- a/backend/libraries/ballerina-lang/Next/Stdlib/Coroutine/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Coroutine/Extension.fs
@@ -1,0 +1,69 @@
+namespace Ballerina.DSL.Next.StdLib.Coroutine
+
+module Extension =
+  open Ballerina.DSL.Next.Types.Model
+  open Ballerina.DSL.Next.Types.Patterns
+  open Ballerina.DSL.Next.Types.TypeChecker.Model
+  open Ballerina.DSL.Next.Extensions
+
+  let CoroutineExtension<'runtimeContext, 'ext, 'extDTO, 'deltaExt, 'deltaExtDTO
+    when 'ext: comparison
+    and 'extDTO: not null
+    and 'extDTO: not struct
+    and 'deltaExtDTO: not null
+    and 'deltaExtDTO: not struct>
+    (typeSymbol: Option<TypeSymbol>)
+    : TypeExtension<
+        'runtimeContext,
+        'ext,
+        'extDTO,
+        'deltaExt,
+        'deltaExtDTO,
+        Unit,
+        Unit,
+        Unit
+       > *
+      TypeSymbol *
+      (TypeValue<'ext>
+        -> TypeValue<'ext>
+        -> TypeValue<'ext>
+        -> TypeValue<'ext>
+        -> TypeValue<'ext>)
+    =
+    let coId = Identifier.LocalScope "Co"
+
+    let coSymbolId =
+      typeSymbol |> Option.defaultWith (fun () -> coId |> TypeSymbol.Create)
+
+    let coResolvedId = coId |> TypeCheckScope.Empty.Resolve
+
+    let schemaVar, schemaKind = TypeVar.Create("schema"), Kind.Schema
+    let ctxVar, ctxKind = TypeVar.Create("context"), Kind.Star
+    let stVar, stKind = TypeVar.Create("state"), Kind.Star
+    let resVar, resKind = TypeVar.Create("result"), Kind.Star
+
+    let make_coType
+      (schema: TypeValue<'ext>)
+      (ctx: TypeValue<'ext>)
+      (st: TypeValue<'ext>)
+      (res: TypeValue<'ext>)
+      =
+      TypeValue.Imported
+        { Id = coResolvedId
+          Sym = coSymbolId
+          Parameters = []
+          Arguments = [ schema; ctx; st; res ] }
+
+    let coExtension =
+      { TypeName = coResolvedId, coSymbolId
+        TypeVars =
+          [ (schemaVar, schemaKind)
+            (ctxVar, ctxKind)
+            (stVar, stKind)
+            (resVar, resKind) ]
+        Cases = Map.empty
+        Operations = Map.empty
+        Serialization = None
+        ExtTypeChecker = None }
+
+    coExtension, coSymbolId, make_coType

--- a/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
@@ -734,6 +734,27 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
       DeltaExt<_, _, _>.ListDeltaDTOLens
       (typeCheckingConfig |> Option.map (fun cfg -> cfg.ListTypeSymbol))
 
+  let viewExtension, viewPropsExtension, view_sym, view_props_sym, mk_view_type, mk_view_props_type =
+    View.Extension.ViewExtension<
+      'runtimeContext,
+      ValueExt<'runtimeContext, 'db, 'customExtension>,
+      ValueExtDTO,
+      DeltaExt<'runtimeContext, 'db, 'customExtension>,
+      DeltaExtDTO
+     >
+      (typeCheckingConfig |> Option.map (fun cfg -> cfg.ViewTypeSymbol))
+      (typeCheckingConfig |> Option.map (fun cfg -> cfg.ViewPropsTypeSymbol))
+
+  let coroutineExtension, co_sym, mk_co_type =
+    Coroutine.Extension.CoroutineExtension<
+      'runtimeContext,
+      ValueExt<'runtimeContext, 'db, 'customExtension>,
+      ValueExtDTO,
+      DeltaExt<'runtimeContext, 'db, 'customExtension>,
+      DeltaExtDTO
+     >
+      (typeCheckingConfig |> Option.map (fun cfg -> cfg.CoTypeSymbol))
+
   let dateOnlyExtension =
     DateOnly.Extension.DateOnlyExtension<
       'runtimeContext,
@@ -952,6 +973,9 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
     context
     |> registerDBExtensions
     |> (listExtension |> TypeExtension.RegisterLanguageContext)
+    |> (viewExtension |> TypeExtension.RegisterLanguageContext)
+    |> (viewPropsExtension |> TypeExtension.RegisterLanguageContext)
+    |> (coroutineExtension |> TypeExtension.RegisterLanguageContext)
     |> (dateOnlyExtension |> OperationsExtension.RegisterLanguageContext)
     |> (dateTimeExtension |> OperationsExtension.RegisterLanguageContext)
     |> (guidExtension |> OperationsExtension.RegisterLanguageContext)
@@ -986,8 +1010,14 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
   let typeCheckingConfig =
     { QueryTypeSymbol = query_sym
       ListTypeSymbol = list_sym
+      ViewTypeSymbol = view_sym
+      ViewPropsTypeSymbol = view_props_sym
+      CoTypeSymbol = co_sym
       MkQueryType = mk_query
-      MkListType = mk_list_type }
+      MkListType = mk_list_type
+      MkViewType = mk_view_type
+      MkViewPropsType = mk_view_props_type
+      MkCoType = mk_co_type }
 
   extensions, context, typeCheckingConfig
 

--- a/backend/libraries/ballerina-lang/Next/Stdlib/View/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/View/Extension.fs
@@ -1,0 +1,92 @@
+namespace Ballerina.DSL.Next.StdLib.View
+
+module Extension =
+  open Ballerina.DSL.Next.Types.Model
+  open Ballerina.DSL.Next.Types.Patterns
+  open Ballerina.DSL.Next.Types.TypeChecker.Model
+  open Ballerina.DSL.Next.Extensions
+
+  let ViewExtension<'runtimeContext, 'ext, 'extDTO, 'deltaExt, 'deltaExtDTO
+    when 'ext: comparison
+    and 'extDTO: not null
+    and 'extDTO: not struct
+    and 'deltaExtDTO: not null
+    and 'deltaExtDTO: not struct>
+    (viewTypeSymbol: Option<TypeSymbol>)
+    (viewPropsTypeSymbol: Option<TypeSymbol>)
+    : TypeExtension<
+        'runtimeContext,
+        'ext,
+        'extDTO,
+        'deltaExt,
+        'deltaExtDTO,
+        Unit,
+        Unit,
+        Unit
+       > *
+      TypeExtension<
+        'runtimeContext,
+        'ext,
+        'extDTO,
+        'deltaExt,
+        'deltaExtDTO,
+        Unit,
+        Unit,
+        Unit
+       > *
+      TypeSymbol *
+      TypeSymbol *
+      (TypeValue<'ext> -> TypeValue<'ext> -> TypeValue<'ext> -> TypeValue<'ext>) *
+      (TypeValue<'ext> -> TypeValue<'ext> -> TypeValue<'ext> -> TypeValue<'ext>)
+    =
+    // --- View ---
+    let viewId = Identifier.FullyQualified([ "Frontend" ], "View")
+
+    let viewSymbolId =
+      viewTypeSymbol |> Option.defaultWith (fun () -> viewId |> TypeSymbol.Create)
+
+    let viewResolvedId = viewId |> TypeCheckScope.Empty.Resolve
+
+    let schemaVar, schemaKind = TypeVar.Create("schema"), Kind.Schema
+    let ctxVar, ctxKind = TypeVar.Create("context"), Kind.Star
+    let stVar, stKind = TypeVar.Create("state"), Kind.Star
+
+    let make_viewType (schema: TypeValue<'ext>) (ctx: TypeValue<'ext>) (st: TypeValue<'ext>) =
+      TypeValue.Imported
+        { Id = viewResolvedId
+          Sym = viewSymbolId
+          Parameters = []
+          Arguments = [ schema; ctx; st ] }
+
+    let viewExtension =
+      { TypeName = viewResolvedId, viewSymbolId
+        TypeVars = [ (schemaVar, schemaKind); (ctxVar, ctxKind); (stVar, stKind) ]
+        Cases = Map.empty
+        Operations = Map.empty
+        Serialization = None
+        ExtTypeChecker = None }
+
+    // --- View::Props ---
+    let viewPropsId = Identifier.FullyQualified([ "View" ], "Props")
+
+    let viewPropsSymbolId =
+      viewPropsTypeSymbol |> Option.defaultWith (fun () -> viewPropsId |> TypeSymbol.Create)
+
+    let viewPropsResolvedId = viewPropsId |> TypeCheckScope.Empty.Resolve
+
+    let make_viewPropsType (schema: TypeValue<'ext>) (ctx: TypeValue<'ext>) (st: TypeValue<'ext>) =
+      TypeValue.Imported
+        { Id = viewPropsResolvedId
+          Sym = viewPropsSymbolId
+          Parameters = []
+          Arguments = [ schema; ctx; st ] }
+
+    let viewPropsExtension =
+      { TypeName = viewPropsResolvedId, viewPropsSymbolId
+        TypeVars = [ (schemaVar, schemaKind); (ctxVar, ctxKind); (stVar, stKind) ]
+        Cases = Map.empty
+        Operations = Map.empty
+        Serialization = None
+        ExtTypeChecker = None }
+
+    viewExtension, viewPropsExtension, viewSymbolId, viewPropsSymbolId, make_viewType, make_viewPropsType

--- a/backend/libraries/ballerina-lang/Next/Stdlib/ballerina-lang-stdlib.fsproj
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/ballerina-lang-stdlib.fsproj
@@ -77,6 +77,8 @@
     <Compile Include="Updater/Model.fs" />
     <Compile Include="Updater/Patterns.fs" />
     <Compile Include="Updater/Extension.fs" />
+    <Compile Include="View/Extension.fs" />
+    <Compile Include="Coroutine/Extension.fs" />
     <Compile Include="StdExtensions.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/backend/libraries/ballerina-lang/Next/Syntax/Lexer.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Lexer.fs
@@ -51,6 +51,8 @@ module Lexer =
     | Array
     | Ascending
     | Descending
+    | View
+    | Co
 
     override this.ToString() =
       match this with
@@ -86,6 +88,8 @@ module Lexer =
       | Array -> "array"
       | Ascending -> "asc"
       | Descending -> "desc"
+      | View -> "view"
+      | Co -> "co"
 
   type Operator =
     | Equals
@@ -118,6 +122,8 @@ module Lexer =
     | Div
     | Percentage
     | Bang
+    | TagSelfClose
+    | TagClose
 
     override this.ToString() =
       match this with
@@ -154,6 +160,8 @@ module Lexer =
       | GreaterEqual -> ">="
       | LessThanOrEqual -> "<="
       | Percentage -> "%"
+      | TagSelfClose -> "/>"
+      | TagClose -> "</"
 
   let floatSuffixString = 'f'
   let doubleSuffixString = 'd'
@@ -320,6 +328,8 @@ module Lexer =
       Keyword.Ascending.ToString(), LocalizedToken.FromKeyword Keyword.Ascending
       Keyword.Descending.ToString(),
       LocalizedToken.FromKeyword Keyword.Descending
+      Keyword.View.ToString(), LocalizedToken.FromKeyword Keyword.View
+      Keyword.Co.ToString(), LocalizedToken.FromKeyword Keyword.Co
       "true", LocalizedToken.FromBoolLiteral true
       "false", LocalizedToken.FromBoolLiteral false ]
     |> List.sortByDescending (fun (w, _) -> w.Length)
@@ -363,6 +373,7 @@ module Lexer =
         |> tokenizer.Map(LocalizedToken.FromOperator Operator.GreaterEqual)
         word "<="
         |> tokenizer.Map(LocalizedToken.FromOperator Operator.LessThanOrEqual)
+        word "</" |> tokenizer.Map(LocalizedToken.FromOperator Operator.TagClose)
         word ">"
         |> tokenizer.Map(LocalizedToken.FromOperator Operator.GreaterThan)
         word "<" |> tokenizer.Map(LocalizedToken.FromOperator Operator.LessThan)
@@ -403,6 +414,7 @@ module Lexer =
         word "|" |> tokenizer.Map(LocalizedToken.FromOperator Operator.Pipe)
         word "*" |> tokenizer.Map(LocalizedToken.FromOperator Operator.Times)
         word "+" |> tokenizer.Map(LocalizedToken.FromOperator Operator.Plus)
+        word "/>" |> tokenizer.Map(LocalizedToken.FromOperator Operator.TagSelfClose)
         word "/" |> tokenizer.Map(LocalizedToken.FromOperator Operator.Div)
         word "!" |> tokenizer.Map(LocalizedToken.FromOperator Operator.Bang)
         word "%"

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Expr.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Expr.fs
@@ -967,6 +967,8 @@ module Expr =
       | Token.Keyword Keyword.If
       | Token.Keyword Keyword.Match
       | Token.Keyword Keyword.Query
+      | Token.Keyword Keyword.View
+      | Token.Keyword Keyword.Co
       | Token.Operator(Operator.RoundBracket Bracket.Open)
       | Token.Operator(Operator.SquareBracket Bracket.Open)
       | Token.Operator(Operator.CurlyBracket Bracket.Open)
@@ -994,6 +996,12 @@ module Expr =
       | Token.Keyword Keyword.Match -> [ matchWith () ]
       | Token.Keyword Keyword.Query ->
         [ query (fun () -> expr parseAllComplexShapes) () ]
+      | Token.Keyword Keyword.View ->
+        [ viewExpr (fun () -> expr parseAllComplexShapes) () ]
+      | Token.Keyword Keyword.Co ->
+        [ coExpr (fun () -> expr parseAllComplexShapes) () ]
+      | Token.Operator Operator.LessThan ->
+        [ viewNodeExpr (fun () -> expr parseAllComplexShapes) () ]
       | Token.Identifier _
       | Token.Keyword Keyword.Schema
       | Token.Keyword Keyword.Entity

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/View.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/View.fs
@@ -73,6 +73,7 @@ module View =
           viewFragment ()
           viewExprContainer ()
           viewTextNode () ]
+      |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
     and viewElement () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {
@@ -111,6 +112,7 @@ module View =
                           Children = children
                           SelfClosing = false } }
               } ]
+          |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
       }
 
     and viewFragment () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
@@ -187,6 +189,7 @@ module View =
                 do! closeCurlyBracketOperator
                 return ExprViewAttribute.ViewAttrExprValue(name, e)
               } ]
+          |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
       }
 
     // Main view parser: view (param:Type) -> <body>
@@ -209,6 +212,7 @@ module View =
               let! paramName = singleIdentifier
               return paramName, None
             } ]
+        |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
       do! parseOperator Operator.SingleArrow
       let! body = viewNode ()
@@ -251,6 +255,7 @@ module View =
           viewFragment ()
           viewExprContainer ()
           viewTextNode () ]
+      |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
     and viewElement () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {
@@ -287,6 +292,7 @@ module View =
                           Children = children
                           SelfClosing = false } }
               } ]
+          |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
       }
 
     and viewFragment () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
@@ -358,6 +364,7 @@ module View =
                 do! closeCurlyBracketOperator
                 return ExprViewAttribute.ViewAttrExprValue(name, e)
               } ]
+          |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
       }
 
     parser {
@@ -402,6 +409,7 @@ module View =
           coDoBang ()
           coReturnBang ()
           coReturn () ]
+      |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
     and coLetBang () : Parser<ExprCoStep<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/View.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/View.fs
@@ -1,0 +1,478 @@
+namespace Ballerina.DSL.Next.Syntax.Parser
+
+[<AutoOpen>]
+module View =
+
+  open Ballerina.Parser
+  open Ballerina.Collections.NonEmptyList
+  open Ballerina
+  open Ballerina.Collections.Sum
+  open Ballerina.DSL.Next.Types.Model
+  open Ballerina.LocalizedErrors
+  open Ballerina.Errors
+  open Ballerina.DSL.Next.Types
+  open Ballerina.DSL.Next.Terms
+  open Ballerina.DSL.Next.Terms.Patterns
+  open Model
+  open Common
+  open Type
+  open Ballerina.DSL.Next.Syntax
+  open Ballerina
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // JSX View Parser
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  let private lessThanOperator = parseOperator Operator.LessThan
+  let private greaterThanOperator = parseOperator Operator.GreaterThan
+  let private tagSelfCloseOperator = parseOperator Operator.TagSelfClose
+  let private tagCloseOperator = parseOperator Operator.TagClose
+
+  let private tagIdentifier =
+    parser.Exactly(fun t ->
+      match t.Token with
+      | Token.Identifier id -> Some id
+      | _ -> None)
+
+  /// Attribute name parser: accepts identifiers and keywords (e.g. type, for)
+  let private attrIdentifier =
+    parser.Exactly(fun t ->
+      match t.Token with
+      | Token.Identifier id -> Some id
+      | Token.Keyword k -> Some (k.ToString().ToLowerInvariant())
+      | _ -> None)
+
+  /// Parse a string attribute value: attr="value"
+  let private stringAttrValue =
+    parser.Exactly(fun t ->
+      match t.Token with
+      | Token.StringLiteral s -> Some s
+      | _ -> None)
+
+  let viewExpr<'valueExt>
+    (expr:
+      unit
+        -> Parser<
+          Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
+          LocalizedToken,
+          Location,
+          Errors<Location>
+         >)
+    ()
+    : Parser<
+        Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
+        LocalizedToken,
+        Location,
+        Errors<Location>
+       >
+    =
+
+    let rec viewNode () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser.Any
+        [ viewElement ()
+          viewFragment ()
+          viewExprContainer ()
+          viewTextNode () ]
+
+    and viewElement () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! loc = parser.Location
+        do! lessThanOperator
+        let! tag = tagIdentifier
+        let! attrs = viewAttributes () |> parser.Many
+
+        return!
+          parser.Any
+            [ // Self-closing: <tag attrs />
+              parser {
+                do! tagSelfCloseOperator
+                return
+                  { Location = loc
+                    Node =
+                      ExprViewNodeRec.ViewElement
+                        { Tag = tag
+                          Attributes = attrs
+                          Children = []
+                          SelfClosing = true } }
+              }
+              // Opening tag: <tag attrs>children</tag>
+              parser {
+                do! greaterThanOperator
+                let! children = viewChildren ()
+                do! tagCloseOperator
+                let! _closeTag = tagIdentifier
+                do! greaterThanOperator
+                return
+                  { Location = loc
+                    Node =
+                      ExprViewNodeRec.ViewElement
+                        { Tag = tag
+                          Attributes = attrs
+                          Children = children
+                          SelfClosing = false } }
+              } ]
+      }
+
+    and viewFragment () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! loc = parser.Location
+        // <>
+        do! lessThanOperator
+        do! greaterThanOperator
+        // children
+        let! children = viewChildren ()
+        // </>
+        do! tagCloseOperator
+        do! greaterThanOperator
+        return
+          { Location = loc
+            Node = ExprViewNodeRec.ViewFragment children }
+      }
+
+    and viewExprContainer () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! loc = parser.Location
+        do! openCurlyBracketOperator
+        let! e = expr ()
+        do! closeCurlyBracketOperator
+        return
+          { Location = loc
+            Node = ExprViewNodeRec.ViewExprContainer e }
+      }
+
+    and viewTextNode () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! loc = parser.Location
+        let! text =
+          parser.Exactly(fun t ->
+            match t.Token with
+            | Token.StringLiteral s -> Some s
+            | Token.Identifier s -> Some s
+            | Token.Keyword k -> Some (k.ToString())
+            | Token.IntLiteral n -> Some (string n)
+            | Token.BoolLiteral b -> Some (string b)
+            | Token.Operator op ->
+              match op with
+              | Operator.LessThan
+              | Operator.GreaterThan
+              | Operator.TagSelfClose
+              | Operator.TagClose -> None
+              | Operator.CurlyBracket Open
+              | Operator.CurlyBracket Close -> None
+              | _ -> Some (op.ToString())
+            | _ -> None)
+        return
+          { Location = loc
+            Node = ExprViewNodeRec.ViewText text }
+      }
+
+    and viewChildren () : Parser<List<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>>, LocalizedToken, Location, Errors<Location>> =
+      viewNode () |> parser.Many
+
+    and viewAttributes () : Parser<ExprViewAttribute<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! name = attrIdentifier
+        do! equalsOperator
+        return!
+          parser.Any
+            [ // String value: attr="value"
+              parser {
+                let! value = stringAttrValue
+                return ExprViewAttribute.ViewAttrStringValue(name, value)
+              }
+              // Expression value: attr={expr}
+              parser {
+                do! openCurlyBracketOperator
+                let! e = expr ()
+                do! closeCurlyBracketOperator
+                return ExprViewAttribute.ViewAttrExprValue(name, e)
+              } ]
+      }
+
+    // Main view parser: view (param:Type) -> <body>
+    parser {
+      do! parseKeyword Keyword.View
+      let! loc = parser.Location
+
+      // Parse parameter: (name:Type) or just name
+      let! paramName, paramType =
+        parser.Any
+          [ parser {
+              do! openRoundBracketOperator
+              let! paramName = singleIdentifier
+              do! colonOperator
+              let! typeDecl = typeDecl (expr ()) parseAllComplexTypeShapes
+              do! closeRoundBracketOperator
+              return paramName, Some typeDecl
+            }
+            parser {
+              let! paramName = singleIdentifier
+              return paramName, None
+            } ]
+
+      do! parseOperator Operator.SingleArrow
+      let! body = viewNode ()
+
+      return
+        { Expr =
+            ExprRec.View
+              { Param = Var.Create paramName
+                ParamType = paramType
+                Body = body
+                Location = loc }
+          Location = loc
+          Scope = TypeCheckScope.Empty }
+    }
+
+  /// Standalone JSX element expression: <tag .../> or <tag ...>children</tag>
+  /// Used when JSX elements appear inside expression contexts (e.g. lambda bodies).
+  /// Wraps the JSX node in an ExprRec.View with a synthesized unit parameter.
+  let viewNodeExpr<'valueExt>
+    (expr:
+      unit
+        -> Parser<
+          Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
+          LocalizedToken,
+          Location,
+          Errors<Location>
+         >)
+    ()
+    : Parser<
+        Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
+        LocalizedToken,
+        Location,
+        Errors<Location>
+       >
+    =
+
+    let rec viewNode () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser.Any
+        [ viewElement ()
+          viewFragment ()
+          viewExprContainer ()
+          viewTextNode () ]
+
+    and viewElement () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! loc = parser.Location
+        do! lessThanOperator
+        let! tag = tagIdentifier
+        let! attrs = viewAttributes () |> parser.Many
+
+        return!
+          parser.Any
+            [ parser {
+                do! tagSelfCloseOperator
+                return
+                  { Location = loc
+                    Node =
+                      ExprViewNodeRec.ViewElement
+                        { Tag = tag
+                          Attributes = attrs
+                          Children = []
+                          SelfClosing = true } }
+              }
+              parser {
+                do! greaterThanOperator
+                let! children = viewChildren ()
+                do! tagCloseOperator
+                let! _closeTag = tagIdentifier
+                do! greaterThanOperator
+                return
+                  { Location = loc
+                    Node =
+                      ExprViewNodeRec.ViewElement
+                        { Tag = tag
+                          Attributes = attrs
+                          Children = children
+                          SelfClosing = false } }
+              } ]
+      }
+
+    and viewFragment () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! loc = parser.Location
+        do! lessThanOperator
+        do! greaterThanOperator
+        let! children = viewChildren ()
+        do! tagCloseOperator
+        do! greaterThanOperator
+        return
+          { Location = loc
+            Node = ExprViewNodeRec.ViewFragment children }
+      }
+
+    and viewExprContainer () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! loc = parser.Location
+        do! openCurlyBracketOperator
+        let! e = expr ()
+        do! closeCurlyBracketOperator
+        return
+          { Location = loc
+            Node = ExprViewNodeRec.ViewExprContainer e }
+      }
+
+    and viewTextNode () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! loc = parser.Location
+        let! text =
+          parser.Exactly(fun t ->
+            match t.Token with
+            | Token.StringLiteral s -> Some s
+            | Token.Identifier s -> Some s
+            | Token.Keyword k -> Some (k.ToString().ToLowerInvariant())
+            | Token.IntLiteral n -> Some (string n)
+            | Token.BoolLiteral b -> Some (string b)
+            | Token.Operator op ->
+              match op with
+              | Operator.LessThan
+              | Operator.GreaterThan
+              | Operator.TagSelfClose
+              | Operator.TagClose -> None
+              | Operator.CurlyBracket Open
+              | Operator.CurlyBracket Close -> None
+              | _ -> Some (op.ToString())
+            | _ -> None)
+        return
+          { Location = loc
+            Node = ExprViewNodeRec.ViewText text }
+      }
+
+    and viewChildren () : Parser<List<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>>, LocalizedToken, Location, Errors<Location>> =
+      viewNode () |> parser.Many
+
+    and viewAttributes () : Parser<ExprViewAttribute<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! name = attrIdentifier
+        do! equalsOperator
+        return!
+          parser.Any
+            [ parser {
+                let! value = stringAttrValue
+                return ExprViewAttribute.ViewAttrStringValue(name, value)
+              }
+              parser {
+                do! openCurlyBracketOperator
+                let! e = expr ()
+                do! closeCurlyBracketOperator
+                return ExprViewAttribute.ViewAttrExprValue(name, e)
+              } ]
+      }
+
+    parser {
+      let! loc = parser.Location
+      let! body = viewNode ()
+      return
+        { Expr =
+            ExprRec.View
+              { Param = Var.Create "_"
+                ParamType = None
+                Body = body
+                Location = loc }
+          Location = loc
+          Scope = TypeCheckScope.Empty }
+    }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Coroutine Parser (co { ... })
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  let coExpr<'valueExt>
+    (expr:
+      unit
+        -> Parser<
+          Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
+          LocalizedToken,
+          Location,
+          Errors<Location>
+         >)
+    ()
+    : Parser<
+        Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
+        LocalizedToken,
+        Location,
+        Errors<Location>
+       >
+    =
+
+    let rec coStep () : Parser<ExprCoStep<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser.Any
+        [ coLetBang ()
+          coDoBang ()
+          coReturnBang ()
+          coReturn () ]
+
+    and coLetBang () : Parser<ExprCoStep<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! loc = parser.Location
+        do! parseKeyword Keyword.Let
+        do! parseOperator Operator.Bang
+        let! varName = singleIdentifier
+        do! equalsOperator
+        let! value = expr ()
+        do! semicolonOperator
+        let! rest = coStep ()
+        return
+          { Location = loc
+            Step = ExprCoStepRec.CoLetBang(Var.Create varName, value, rest) }
+      }
+
+    and coDoBang () : Parser<ExprCoStep<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! loc = parser.Location
+        do! parseKeyword Keyword.Do
+        do! parseOperator Operator.Bang
+        let! value = expr ()
+        do! semicolonOperator
+        let! rest = coStep ()
+        return
+          { Location = loc
+            Step = ExprCoStepRec.CoDoBang(value, rest) }
+      }
+
+    and coReturn () : Parser<ExprCoStep<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! loc = parser.Location
+        // "return" is not a keyword, parse as identifier
+        let! _ = parser.Exactly(fun t ->
+          match t.Token with
+          | Token.Identifier "return" -> Some ()
+          | _ -> None)
+        let! value = expr ()
+        return
+          { Location = loc
+            Step = ExprCoStepRec.CoReturn value }
+      }
+
+    and coReturnBang () : Parser<ExprCoStep<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! loc = parser.Location
+        // "return!" is "return" followed by "!"
+        let! _ = parser.Exactly(fun t ->
+          match t.Token with
+          | Token.Identifier "return" -> Some ()
+          | _ -> None)
+        do! parseOperator Operator.Bang
+        let! value = expr ()
+        return
+          { Location = loc
+            Step = ExprCoStepRec.CoReturnBang value }
+      }
+
+    // Main co parser: co { steps }
+    parser {
+      do! parseKeyword Keyword.Co
+      let! loc = parser.Location
+      do! openCurlyBracketOperator
+      let! body = coStep ()
+      do! closeCurlyBracketOperator
+
+      return
+        { Expr =
+            ExprRec.Co
+              { Body = body
+                Location = loc }
+          Location = loc
+          Scope = TypeCheckScope.Empty }
+    }

--- a/backend/libraries/ballerina-lang/Next/Syntax/ballerina-lang-parser.fsproj
+++ b/backend/libraries/ballerina-lang/Next/Syntax/ballerina-lang-parser.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="Parser/Type/Schema.fs" />
     <Compile Include="Parser/Type.fs" />
     <Compile Include="Parser/Query.fs" />
+    <Compile Include="Parser/View.fs" />
     <Compile Include="Parser/Expr.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/Conversion/TypeCheckedExprToRunnable.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/Conversion/TypeCheckedExprToRunnable.fs
@@ -142,6 +142,10 @@ module Conversion =
         let! q' = convertQuery q
         return RunnableExprRec.Query q'
       }
+    | TypeCheckedExprRec.View _ ->
+      Right(conversionError _loc $"Cannot convert View to RunnableExpr: views are not yet executable")
+    | TypeCheckedExprRec.Co _ ->
+      Right(conversionError _loc $"Cannot convert Co to RunnableExpr: coroutines are not yet executable")
     | TypeCheckedExprRec.RecoveredSyntaxError err ->
       Right(conversionError err.ErrorLocation $"Cannot convert RecoveredSyntaxError to RunnableExpr: {err.ErrorMessage} (context: {err.RecoveryContext})")
     | TypeCheckedExprRec.ErrorDanglingRecordDes _ ->

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/Model.fs
@@ -171,9 +171,18 @@ module Model =
   type TypeCheckingConfig<'valueExt when 'valueExt: comparison> =
     { QueryTypeSymbol: TypeSymbol
       ListTypeSymbol: TypeSymbol
+      ViewTypeSymbol: TypeSymbol
+      ViewPropsTypeSymbol: TypeSymbol
+      CoTypeSymbol: TypeSymbol
       MkQueryType:
         Schema<'valueExt> -> TypeQueryRow<'valueExt> -> TypeValue<'valueExt>
-      MkListType: TypeValue<'valueExt> -> TypeValue<'valueExt> }
+      MkListType: TypeValue<'valueExt> -> TypeValue<'valueExt>
+      MkViewType:
+        TypeValue<'valueExt> -> TypeValue<'valueExt> -> TypeValue<'valueExt> -> TypeValue<'valueExt>
+      MkViewPropsType:
+        TypeValue<'valueExt> -> TypeValue<'valueExt> -> TypeValue<'valueExt> -> TypeValue<'valueExt>
+      MkCoType:
+        TypeValue<'valueExt> -> TypeValue<'valueExt> -> TypeValue<'valueExt> -> TypeValue<'valueExt> -> TypeValue<'valueExt> }
 
   type TypeExprEvalResult<'valueExt when 'valueExt: comparison> =
     State<

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/Expr.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/Expr.fs
@@ -234,6 +234,18 @@ module Expr =
 
                 return TypeCheckedExpr.Query(q, t, k), ctx
 
+              | ExprRec.View _v ->
+                return!
+                  Errors.Singleton loc0 (fun () ->
+                    $"Error: view expressions are not yet supported by the typechecker")
+                  |> state.Throw
+
+              | ExprRec.Co _c ->
+                return!
+                  Errors.Singleton loc0 (fun () ->
+                    $"Error: co expressions are not yet supported by the typechecker")
+                  |> state.Throw
+
               | ExprRec.RecoveredSyntaxError err ->
                 return!
                   Errors.Singleton err.ErrorLocation (fun () -> err.ErrorMessage)

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/InstantiateSyntheticVars.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/InstantiateSyntheticVars.fs
@@ -306,6 +306,20 @@ module InstantiateSyntheticVars =
         | TypeCheckedExprRec.Query q ->
           return
             TypeCheckedExpr.Query(q, expr.Type, expr.Kind, loc0, expr.Scope)
+        | TypeCheckedExprRec.View v ->
+          return
+            { Expr = TypeCheckedExprRec.View v
+              Location = loc0
+              Type = expr.Type
+              Kind = expr.Kind
+              Scope = expr.Scope }
+        | TypeCheckedExprRec.Co c ->
+          return
+            { Expr = TypeCheckedExprRec.Co c
+              Location = loc0
+              Type = expr.Type
+              Kind = expr.Kind
+              Scope = expr.Scope }
         | TypeCheckedExprRec.RecoveredSyntaxError err ->
           return
             { Expr = TypeCheckedExprRec.RecoveredSyntaxError err

--- a/samples/24-views.bl
+++ b/samples/24-views.bl
@@ -11,6 +11,8 @@
 //   - JSX-like body with HTML tags, attributes, and expression containers
 //   - Custom components referenced by name (lowercase identifiers)
 //   - `Frontend::View[Schema][I][S]` built-in type
+//   - `Co[Schema][Ctx][St][Res]` coroutine type for long-running UI flows
+//   - `co { ... }` computation expressions with `let!`, `do!`, `return`
 //   - `WebApp::run` builder collects views into routes and components
 //
 // Every view takes one parameter of the built-in generic type
@@ -33,16 +35,44 @@
 // When composing child views, the parent passes its `props` and adapts
 // context/state with two built-in combinators:
 //
-//   View::Props::mapContext : (I -> I') -> View::Props[S][I][St] -> View::Props[S][I'][St]
+//   View::mapContext : (I -> I') -> View::Props[S][I][St] -> View::Props[S][I'][St]
 //     Transforms the readonly context. The state and setState pass through.
 //
-//   View::Props::mapState : (St -> St') -> ((St' -> St') -> (St -> St)) -> View::Props[S][I][St] -> View::Props[S][I][St']
+//   View::mapState : (St -> St') -> ((St' -> St') -> (St -> St)) -> View::Props[S][I][St] -> View::Props[S][I][St']
 //     Focuses the state. First arg extracts child state from parent state.
 //     Second arg lifts a child updater back into a parent updater.
 //
 // Children receive the whole `props` object, already adapted:
 //
-//   <child props={props |> View::Props::mapContext(...) |> View::Props::mapState(...)} />
+//   <child props={props |> View::mapContext(...) |> View::mapState(...)} />
+//
+// ── Coroutines ───────────────────────────────────────────────────────────
+//
+// `Co[Schema][Ctx][St][Res]` is a coroutine that lives inside the
+// frontend. It can show views, wait for results, sequence steps, and
+// eventually produce a value of type `Res`.
+//
+// Syntax (computation expression):
+//
+//   co {
+//     let! result = someCoroutine        // bind: suspend until result
+//     do! someVoidCoroutine              // bind + discard result
+//     return value                       // finish with a value
+//     return! anotherCoroutine           // tail-call another coroutine
+//   }
+//
+// The bridge between views and coroutines is `Co::show`:
+//
+//   Co::show : I -> S -> (S -> () + O) -> View[Schema][I][S] -> Co[Schema][Ctx][St][O]
+//
+// It instantiates a view with initial context `I` and state `S`, renders
+// it, and on every state change calls the predicate `(S -> () + O)`:
+//   - `1Of2()` means "keep running" (the view stays on screen)
+//   - `2Of2(result)` means "done" (the coroutine yields `result`)
+//
+// This turns interactive UI into sequential code: show a form, wait for
+// submission, show a confirmation, call an API, show the result — all
+// as straight-line statements in a `co { }` block.
 
 // ── Domain schema ────────────────────────────────────────────────────────
 // A minimal todo-list schema. We keep it simple to focus on view syntax.
@@ -103,8 +133,8 @@ let todoList = view (props:View::Props[TodoSchema][unit][List[Todo]]) ->
     <ul>
       {List::map (fun todo ->
         <todoItem props={
-          props |> View::Props::mapState
-            (fun _ -> todo)
+          props |> View::mapState
+            (replaceWith todo)
             (fun f items -> List::map (fun t ->
               if t.Title == todo.Title then f t else t
             ) items)
@@ -169,50 +199,116 @@ let homePage = view (props:View::Props[TodoSchema][unit][PageState]) ->
   <div class="home">
     <pageHeader props={
       props
-      |> View::Props::mapContext(fun _ -> { Title = "Todo App"; Subtitle = "Built with Ballerina views" })
-      |> View::Props::mapState (fun _ -> ()) (fun _ s -> s)
+      |> View::mapContext(replaceWith { Title = "Todo App"; Subtitle = "Built with Ballerina views" })
+      |> View::mapState (replaceWith ()) (replaceWith id)
     } />
     <divider props={
       props
-      |> View::Props::mapState (fun _ -> ()) (fun _ s -> s)
+      |> View::mapState (replaceWith ()) (replaceWith id)
     } />
     <counter props={
       props
-      |> View::Props::mapContext(fun _ -> "Visits")
-      |> View::Props::mapState
+      |> View::mapContext(replaceWith "Visits")
+      |> View::mapState
         (fun s -> s.Count)
         (fun f s -> { s with PageState::Count = f s.Count })
     } />
     <divider props={
       props
-      |> View::Props::mapState (fun _ -> ()) (fun _ s -> s)
+      |> View::mapState (replaceWith ()) (replaceWith id)
     } />
     <todoList props={
       props
-      |> View::Props::mapState
+      |> View::mapState
         (fun s -> s.Todos)
         (fun f s -> { s with PageState::Todos = f s.Todos })
     } />
   </div>;
 
 // ═════════════════════════════════════════════════════════════════════════
+// COROUTINES
+// ═════════════════════════════════════════════════════════════════════════
+
+// ── 7. A "done" message view ─────────────────────────────────────────────
+// Shown after the counter coroutine completes.
+// Type: Frontend::View[TodoSchema][int32][unit]
+
+let doneMessage = view (props:View::Props[TodoSchema][int32][unit]) ->
+  <div class="done">
+    <h1>Done!</h1>
+    <p>You counted to {props.context}.</p>
+  </div>;
+
+// ── 8. Counter coroutine ─────────────────────────────────────────────────
+// Shows the counter view. When the count exceeds 10, the coroutine
+// finishes and yields the final count.
+// Type: Co[TodoSchema][unit][unit][int32]
+
+let counterFlow = co {
+  let! finalCount =
+    Co::show
+      "Click counter"    // initial context (I = string)
+      0                   // initial state   (S = int32)
+      (fun n ->           // predicate: S -> () + int32
+        if n > 10 then 2Of2(n)
+        else 1Of2())
+      counter;            // the view to render
+  return finalCount
+};
+
+// ── 9. Full page coroutine ───────────────────────────────────────────────
+// Sequences two phases: first the counter, then a "done" message.
+// Demonstrates how coroutines turn multi-step UI into straight-line code.
+// Type: Co[TodoSchema][unit][unit][unit]
+
+let homeFlow = co {
+  // Phase 1: show the counter until count > 10
+  let! finalCount = counterFlow;
+
+  // Phase 2: show the done message forever (never completes)
+  do! Co::show
+    finalCount            // pass the final count as context
+    ()                    // no local state
+    (replaceWith (1Of2()))   // never done — stays on screen
+    doneMessage;
+
+  return ()
+};
+
+// ═════════════════════════════════════════════════════════════════════════
 // WEBAPP BUILDER
 // ═════════════════════════════════════════════════════════════════════════
 // WebApp::run wraps a DB::run and attaches routes and components.
-// Routes map URL paths to top-level views.
+// Routes map URL paths to coroutines (which manage page-level state).
 // Components register reusable views by name.
+// Routes are always coroutines — views are lifted via Co::show.
 
 let main = fun (schema: TodoSchema) ->
-  let seed_todos = [
-    { Title = "Learn Ballerina"; Done = true },
-    { Title = "Build views"; Done = false },
+  let seed_todos = {
+    { Title = "Learn Ballerina"; Done = true };
+    { Title = "Build views"; Done = false };
     { Title = "Ship it"; Done = false }
-  ];
+  };
   (seed_todos, "seeded");
 
 WebApp::run [TodoSchema] (DB::run [TodoSchema] main)
-  |> WebApp::withRoute("/", homePage)
-  |> WebApp::withRoute("/header", pageHeader)
+  |> WebApp::withRoute("/", co {
+    do! Co::show
+      ()
+      { Todos = seed_todos; Count = 0 }
+      (replaceWith (1Of2()))
+      homePage;
+    return ()
+  })
+  |> WebApp::withRoute("/flow", homeFlow)
+  |> WebApp::withRoute("/header", co {
+    do! Co::show
+      { Title = "Header"; Subtitle = "Standalone page" }
+      ()
+      (replaceWith (1Of2()))
+      pageHeader;
+    return ()
+  })
   |> WebApp::withComponent("counter", counter)
   |> WebApp::withComponent("todoItem", todoItem)
   |> WebApp::withComponent("divider", divider)


### PR DESCRIPTION
Add View and Coroutine typechecker extensions following the ListExtension pattern, plus parser improvements and HddCache fix.

### Changes
- **View/Extension.fs** and **Coroutine/Extension.fs**: typechecker scaffolding following the existing ListExtension pattern
- **StdExtensions.fs**: register new extensions
- **ballerina-lang-stdlib.fsproj**: include new files in build
- **View.fs (Parser)**: filter recovered syntax errors from parser output
- **Model.fs (TypeChecker)**: add ViewTypeChecker/CoroutineTypeChecker to TypeCheckContext
- **HddCache.fs**: fix symbol lifecycle — deserialize symbols properly instead of creating fresh Guids