### PR TITLE
Replace ValueExt Choice<7> with explicit DU cases including View/Co

### DIFF
--- a/backend/libraries/ballerina-api-filedb-factory/API/Publication.fs
+++ b/backend/libraries/ballerina-api-filedb-factory/API/Publication.fs
@@ -147,7 +147,7 @@ module API =
           schemaDefinition
 
       match evalResult with
-      | Ext(ValueExt.ValueExt(Choice5Of7(DBExt.DBValues(DBValues.DBIO dbio))), _) ->
+      | Ext(ValueExt.VDB(DBExt.DBValues(DBValues.DBIO dbio)), _) ->
         let! schema =
           fileManager.TryReadContent()
           |> sum.MapError(Errors.MapContext(replaceWith Location.Unknown))

--- a/backend/libraries/ballerina-api-filedb-factory/MemoryDBFactory.fs
+++ b/backend/libraries/ballerina-api-filedb-factory/MemoryDBFactory.fs
@@ -106,7 +106,7 @@ module MemoryDBAPIFactory =
           )
 
       match evalResult with
-      | Ext(ValueExt.ValueExt(Choice5Of7(DBExt.DBValues(DBValues.DBIO dbio))), _) ->
+      | Ext(ValueExt.VDB(DBExt.DBValues(DBValues.DBIO dbio)), _) ->
         let languageContext, _ = contextFactory dbFileConfig
 
         return

--- a/backend/libraries/ballerina-api/Common/Utils.fs
+++ b/backend/libraries/ballerina-api/Common/Utils.fs
@@ -228,11 +228,9 @@ module APIUtils =
       let! updater = delta |> Delta.ToUpdater DeltaExt.ToUpdater
 
       let updaterExtension =
-        ValueExt(
-          Choice4Of7(
-            CompositeType(
-              Choice5Of5(UpdaterOperations(Apply { Updater = updater }))
-            )
+        VComposite(
+          CompositeType(
+            Choice5Of5(UpdaterOperations(Apply { Updater = updater }))
           )
         )
 

--- a/backend/libraries/ballerina-api/Endpoints/Delete.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Delete.fs
@@ -281,8 +281,7 @@ module Delete =
                 |> Map.ofList
                 |> Ballerina.DSL.Next.StdLib.Map.Model.MapValues.Map
                 |> MapExt.MapValues
-                |> Choice6Of7
-                |> ValueExt
+                |> VMap
 
 
               let deleters

--- a/backend/libraries/ballerina-api/Endpoints/Update.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Update.fs
@@ -334,8 +334,7 @@ module Update =
                 |> Map.ofList
                 |> Ballerina.DSL.Next.StdLib.Map.Model.MapValues.Map
                 |> MapExt.MapValues
-                |> Choice6Of7
-                |> ValueExt
+                |> VMap
 
               let updaters = Value.Ext(updaters, None)
 

--- a/backend/libraries/ballerina-api/Endpoints/Upsert.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Upsert.fs
@@ -384,8 +384,7 @@ module Upsert =
                 |> Map.ofList
                 |> Ballerina.DSL.Next.StdLib.Map.Model.MapValues.Map
                 |> MapExt.MapValues
-                |> Choice6Of7
-                |> ValueExt
+                |> VMap
 
               let upserters = Value.Ext(upserters, None)
 

--- a/backend/libraries/ballerina-lang/Next/Stdlib/Coroutine/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Coroutine/Extension.fs
@@ -5,6 +5,15 @@ module Extension =
   open Ballerina.DSL.Next.Types.Patterns
   open Ballerina.DSL.Next.Types.TypeChecker.Model
   open Ballerina.DSL.Next.Extensions
+  open Ballerina.Collections.Sum
+  open Ballerina.Errors
+  open Ballerina.Reader.WithError
+  open Ballerina.Lenses
+
+  type CoroutineOperations =
+    | Co_Show
+    | Co_Until
+    | Co_Ignore
 
   let CoroutineExtension<'runtimeContext, 'ext, 'extDTO, 'deltaExt, 'deltaExtDTO
     when 'ext: comparison
@@ -12,7 +21,9 @@ module Extension =
     and 'extDTO: not struct
     and 'deltaExtDTO: not null
     and 'deltaExtDTO: not struct>
+    (operationLens: PartialLens<'ext, CoroutineOperations>)
     (typeSymbol: Option<TypeSymbol>)
+    (viewTypeId: Identifier)
     : TypeExtension<
         'runtimeContext,
         'ext,
@@ -21,7 +32,7 @@ module Extension =
         'deltaExtDTO,
         Unit,
         Unit,
-        Unit
+        CoroutineOperations
        > *
       TypeSymbol *
       (TypeValue<'ext>
@@ -54,6 +65,265 @@ module Extension =
           Parameters = []
           Arguments = [ schema; ctx; st; res ] }
 
+    // --- Co::show ---
+    // show : Λschema::Schema. Λctx::*. Λst::*. Λi::*. Λs::*. Λo::*.
+    //   i -> s -> (s -> () + o) -> Frontend::View[schema][i][s] -> Co[schema][ctx][st][o]
+    let showId =
+      Identifier.FullyQualified([ "Co" ], "show")
+      |> TypeCheckScope.Empty.Resolve
+
+    let _iVar, iKind = TypeVar.Create("i"), Kind.Star
+    let _sVar, sKind = TypeVar.Create("s"), Kind.Star
+    let _oVar, oKind = TypeVar.Create("o"), Kind.Star
+
+    let showOperation
+      : ResolvedIdentifier *
+        TypeOperationExtension<'runtimeContext, 'ext, Unit, Unit, CoroutineOperations> =
+      showId,
+      { Type =
+          TypeValue.CreateLambda(
+            TypeParameter.Create("schema", schemaKind),
+            TypeExpr.Lambda(
+              TypeParameter.Create("ctx", ctxKind),
+              TypeExpr.Lambda(
+                TypeParameter.Create("st", stKind),
+                TypeExpr.Lambda(
+                  TypeParameter.Create("i", iKind),
+                  TypeExpr.Lambda(
+                    TypeParameter.Create("s", sKind),
+                    TypeExpr.Lambda(
+                      TypeParameter.Create("o", oKind),
+                      TypeExpr.Arrow(
+                        TypeExpr.Lookup(Identifier.LocalScope "i"),
+                        TypeExpr.Arrow(
+                          TypeExpr.Lookup(Identifier.LocalScope "s"),
+                          TypeExpr.Arrow(
+                            TypeExpr.Arrow(
+                              TypeExpr.Lookup(Identifier.LocalScope "s"),
+                            TypeExpr.Sum
+                              [ TypeExpr.Primitive PrimitiveType.Unit
+                                TypeExpr.Lookup(Identifier.LocalScope "o") ]
+                            ),
+                            TypeExpr.Arrow(
+                              TypeExpr.Apply(
+                                TypeExpr.Apply(
+                                  TypeExpr.Apply(
+                                    TypeExpr.Lookup viewTypeId,
+                                    TypeExpr.Lookup(Identifier.LocalScope "schema")
+                                  ),
+                                  TypeExpr.Lookup(Identifier.LocalScope "i")
+                                ),
+                                TypeExpr.Lookup(Identifier.LocalScope "s")
+                              ),
+                              TypeExpr.Apply(
+                                TypeExpr.Apply(
+                                  TypeExpr.Apply(
+                                    TypeExpr.Apply(
+                                      TypeExpr.Lookup(Identifier.LocalScope "Co"),
+                                      TypeExpr.Lookup(Identifier.LocalScope "schema")
+                                    ),
+                                    TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                                  ),
+                                  TypeExpr.Lookup(Identifier.LocalScope "st")
+                                ),
+                                TypeExpr.Lookup(Identifier.LocalScope "o")
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        Kind =
+          Kind.Arrow(
+            Kind.Schema,
+            Kind.Arrow(
+              Kind.Star,
+              Kind.Arrow(
+                Kind.Star,
+                Kind.Arrow(
+                  Kind.Star,
+                  Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+                )
+              )
+            )
+          )
+        Operation = Co_Show
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | Co_Show -> Some Co_Show
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (_op, _v) ->
+            reader {
+              return!
+                Errors.Singleton loc0 (fun () -> "Co::show is not yet implemented")
+                |> reader.Throw
+            } }
+
+    // --- Co::until ---
+    // until : Λschema::Schema. Λctx::*. Λst::*. Λres::*.
+    //   (st -> () + res) -> Co[schema][ctx][st][()] -> Co[schema][ctx][st][res]
+    let untilId =
+      Identifier.FullyQualified([ "Co" ], "until")
+      |> TypeCheckScope.Empty.Resolve
+
+    let _res2Var, res2Kind = TypeVar.Create("res2"), Kind.Star
+
+    let untilOperation
+      : ResolvedIdentifier *
+        TypeOperationExtension<'runtimeContext, 'ext, Unit, Unit, CoroutineOperations> =
+      untilId,
+      { Type =
+          TypeValue.CreateLambda(
+            TypeParameter.Create("schema", schemaKind),
+            TypeExpr.Lambda(
+              TypeParameter.Create("ctx", ctxKind),
+              TypeExpr.Lambda(
+                TypeParameter.Create("st", stKind),
+                TypeExpr.Lambda(
+                  TypeParameter.Create("res2", res2Kind),
+                  TypeExpr.Arrow(
+                    TypeExpr.Arrow(
+                      TypeExpr.Lookup(Identifier.LocalScope "st"),
+                      TypeExpr.Sum
+                        [ TypeExpr.Primitive PrimitiveType.Unit
+                          TypeExpr.Lookup(Identifier.LocalScope "res2") ]
+                    ),
+                    TypeExpr.Arrow(
+                      TypeExpr.Apply(
+                        TypeExpr.Apply(
+                          TypeExpr.Apply(
+                            TypeExpr.Apply(
+                              TypeExpr.Lookup(Identifier.LocalScope "Co"),
+                              TypeExpr.Lookup(Identifier.LocalScope "schema")
+                            ),
+                            TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                          ),
+                          TypeExpr.Lookup(Identifier.LocalScope "st")
+                        ),
+                        TypeExpr.Primitive PrimitiveType.Unit
+                      ),
+                      TypeExpr.Apply(
+                        TypeExpr.Apply(
+                          TypeExpr.Apply(
+                            TypeExpr.Apply(
+                              TypeExpr.Lookup(Identifier.LocalScope "Co"),
+                              TypeExpr.Lookup(Identifier.LocalScope "schema")
+                            ),
+                            TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                          ),
+                          TypeExpr.Lookup(Identifier.LocalScope "st")
+                        ),
+                        TypeExpr.Lookup(Identifier.LocalScope "res2")
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        Kind =
+          Kind.Arrow(
+            Kind.Schema,
+            Kind.Arrow(
+              Kind.Star,
+              Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+            )
+          )
+        Operation = Co_Until
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | Co_Until -> Some Co_Until
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (_op, _v) ->
+            reader {
+              return!
+                Errors.Singleton loc0 (fun () -> "Co::until is not yet implemented")
+                |> reader.Throw
+            } }
+
+    // --- Co::ignore ---
+    // ignore : Λschema::Schema. Λctx::*. Λst::*. Λres::*.
+    //   Co[schema][ctx][st][res] -> Co[schema][ctx][st][()]
+    let ignoreId =
+      Identifier.FullyQualified([ "Co" ], "ignore")
+      |> TypeCheckScope.Empty.Resolve
+
+    let ignoreOperation
+      : ResolvedIdentifier *
+        TypeOperationExtension<'runtimeContext, 'ext, Unit, Unit, CoroutineOperations> =
+      ignoreId,
+      { Type =
+          TypeValue.CreateLambda(
+            TypeParameter.Create("schema", schemaKind),
+            TypeExpr.Lambda(
+              TypeParameter.Create("ctx", ctxKind),
+              TypeExpr.Lambda(
+                TypeParameter.Create("st", stKind),
+                TypeExpr.Lambda(
+                  TypeParameter.Create("res", resKind),
+                  TypeExpr.Arrow(
+                    TypeExpr.Apply(
+                      TypeExpr.Apply(
+                        TypeExpr.Apply(
+                          TypeExpr.Apply(
+                            TypeExpr.Lookup(Identifier.LocalScope "Co"),
+                            TypeExpr.Lookup(Identifier.LocalScope "schema")
+                          ),
+                          TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                        ),
+                        TypeExpr.Lookup(Identifier.LocalScope "st")
+                      ),
+                      TypeExpr.Lookup(Identifier.LocalScope "res")
+                    ),
+                    TypeExpr.Apply(
+                      TypeExpr.Apply(
+                        TypeExpr.Apply(
+                          TypeExpr.Apply(
+                            TypeExpr.Lookup(Identifier.LocalScope "Co"),
+                            TypeExpr.Lookup(Identifier.LocalScope "schema")
+                          ),
+                          TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                        ),
+                        TypeExpr.Lookup(Identifier.LocalScope "st")
+                      ),
+                      TypeExpr.Primitive PrimitiveType.Unit
+                    )
+                  )
+                )
+              )
+            )
+          )
+        Kind =
+          Kind.Arrow(
+            Kind.Schema,
+            Kind.Arrow(
+              Kind.Star,
+              Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+            )
+          )
+        Operation = Co_Ignore
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | Co_Ignore -> Some Co_Ignore
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (_op, _v) ->
+            reader {
+              return!
+                Errors.Singleton loc0 (fun () -> "Co::ignore is not yet implemented")
+                |> reader.Throw
+            } }
+
     let coExtension =
       { TypeName = coResolvedId, coSymbolId
         TypeVars =
@@ -62,7 +332,8 @@ module Extension =
             (stVar, stKind)
             (resVar, resKind) ]
         Cases = Map.empty
-        Operations = Map.empty
+        Operations =
+          [ showOperation; untilOperation; ignoreOperation ] |> Map.ofList
         Serialization = None
         ExtTypeChecker = None }
 

--- a/backend/libraries/ballerina-lang/Next/Stdlib/Extensions/Types.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Extensions/Types.fs
@@ -42,9 +42,8 @@ module Types =
       : Updater<TypeCheckContext<'ext>> =
       fun typeCheckContext ->
         let kind =
-          typeExt.TypeVars
-          |> List.map snd
-          |> List.fold (fun acc k -> Kind.Arrow(k, acc)) Kind.Star
+          (typeExt.TypeVars |> List.map snd, Kind.Star)
+          ||> List.foldBack (fun k acc -> Kind.Arrow(k, acc))
 
         let values =
           typeExt.Cases
@@ -81,9 +80,8 @@ module Types =
       : Updater<TypeCheckState<'ext>> =
       fun typeCheckState ->
         let kind =
-          typeExt.TypeVars
-          |> List.map snd
-          |> List.fold (fun acc k -> Kind.Arrow(k, acc)) Kind.Star
+          (typeExt.TypeVars |> List.map snd, Kind.Star)
+          ||> List.foldBack (fun k acc -> Kind.Arrow(k, acc))
 
         let typeExtUnion =
           typeExt |> TypeExtension.ToImportedTypeValue |> TypeValue.Imported

--- a/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
@@ -17,34 +17,30 @@ open Ballerina.DSL.Next.StdLib.Email
 open Ballerina.DSL.Next.StdLib.String
 open Ballerina.DSL.Next.Types.TypeChecker.Model
 open Ballerina.DSL.Next.StdLib.DB.Extension.DBRun
+open Ballerina.DSL.Next.StdLib.View.Extension
+open Ballerina.DSL.Next.StdLib.Coroutine.Extension
 
 type ValueExt<'runtimeContext, 'db, 'customExtension
   when 'db: comparison and 'customExtension: comparison> =
-  | ValueExt of
-    Choice<
-      ListExt<'runtimeContext, 'db, 'customExtension>,
-      Unit,
-      PrimitiveExt<'runtimeContext, 'db, 'customExtension>,
-      CompositeTypeExt<'runtimeContext, 'db, 'customExtension>,
-      DBExt<'runtimeContext, 'db, 'customExtension>,
-      MapExt<'runtimeContext, 'db, 'customExtension>,
-      'customExtension
-     >
+  | VList of ListExt<'runtimeContext, 'db, 'customExtension>
+  | VViewProps of ViewPropsOperations
+  | VCo of CoroutineOperations
+  | VPrimitive of PrimitiveExt<'runtimeContext, 'db, 'customExtension>
+  | VComposite of CompositeTypeExt<'runtimeContext, 'db, 'customExtension>
+  | VDB of DBExt<'runtimeContext, 'db, 'customExtension>
+  | VMap of MapExt<'runtimeContext, 'db, 'customExtension>
+  | VCustom of 'customExtension
 
   override self.ToString() =
     match self with
-    | ValueExt(Choice1Of7 ext) -> ext.ToString()
-    | ValueExt(Choice2Of7 ext) -> ext.ToString()
-    | ValueExt(Choice3Of7 ext) -> ext.ToString()
-    | ValueExt(Choice4Of7 ext) -> ext.ToString()
-    | ValueExt(Choice5Of7 ext) -> ext.ToString()
-    | ValueExt(Choice6Of7 ext) -> ext.ToString()
-    | ValueExt(Choice7Of7 ext) -> ext.ToString()
-
-
-  static member Getters = {| ValueExt = fun (ValueExt e) -> e |}
-
-  static member Updaters = {| ValueExt = fun u (ValueExt e) -> ValueExt(u e) |}
+    | VList ext -> ext.ToString()
+    | VViewProps ext -> ext.ToString()
+    | VCo ext -> ext.ToString()
+    | VPrimitive ext -> ext.ToString()
+    | VComposite ext -> ext.ToString()
+    | VDB ext -> ext.ToString()
+    | VMap ext -> ext.ToString()
+    | VCustom ext -> ext.ToString()
 
 and [<NoComparison; NoEquality>] ValueExtDTO =
   { List: List.Model.ListValueDTO<ValueExtDTO>
@@ -76,9 +72,9 @@ and DBExt<'runtimeContext, 'db, 'customExtension
        > =
     { Get =
         function
-        | ValueExt(Choice5Of7(DBExt.DBValues x)) -> Some x
+        | VDB(DBExt.DBValues x) -> Some x
         | _ -> None
-      Set = DBExt.DBValues >> Choice5Of7 >> ValueExt.ValueExt }
+      Set = DBExt.DBValues >> VDB }
 
 and MapExt<'runtimeContext, 'db, 'customExtension
   when 'db: comparison and 'customExtension: comparison> =
@@ -99,9 +95,9 @@ and MapExt<'runtimeContext, 'db, 'customExtension
        > =
     { Get =
         function
-        | ValueExt(Choice6Of7(MapValues x)) -> Some x
+        | VMap(MapValues x) -> Some x
         | _ -> None
-      Set = MapValues >> Choice6Of7 >> ValueExt.ValueExt }
+      Set = MapValues >> VMap }
 
   static member inline ValueDTOLens =
     { Get =
@@ -153,9 +149,9 @@ and ListExt<'runtimeContext, 'db, 'customExtension
     { Get =
         fun (v: ValueExt<'runtimeContext, 'db, 'customExtension>) ->
           match v with
-          | ValueExt(Choice1Of7(ListValues x)) -> Some x
+          | VList(ListValues x) -> Some x
           | _ -> None
-      Set = ListValues >> Choice1Of7 >> ValueExt.ValueExt }
+      Set = ListValues >> VList }
 
 
   static member inline ValueDTOLens =
@@ -348,7 +344,7 @@ and DeltaExt<'runtimeContext, 'db, 'customExtension
              >) ->
         sum {
           match value with
-          | Value.Ext(ValueExt(Choice1Of7(ListValues(List.Model.ListValues.List l))),
+          | Value.Ext(VList(ListValues(List.Model.ListValues.List l)),
                       _) ->
             match delta with
             | DeltaExt.DeltaExtension(Choice1Of4(UpdateElement(i, delta))) ->
@@ -362,63 +358,49 @@ and DeltaExt<'runtimeContext, 'db, 'customExtension
               let next = List.updateAt i updatedElement l
 
               return
-                (ValueExt(
-                  Choice1Of7(ListValues(List.Model.ListValues.List next))
-                 ),
+                (VList(ListValues(List.Model.ListValues.List next)),
                  None)
                 |> Value.Ext
             | DeltaExt.DeltaExtension(Choice1Of4(ListDeltaExt.AppendElement(v))) ->
               let next = List.append l [ v ]
 
               return
-                (ValueExt(
-                  Choice1Of7(ListValues(List.Model.ListValues.List next))
-                 ),
+                (VList(ListValues(List.Model.ListValues.List next)),
                  None)
                 |> Value.Ext
             | DeltaExt.DeltaExtension(Choice1Of4(ListDeltaExt.RemoveElement(i))) ->
               let next = List.removeAt i l
 
               return
-                (ValueExt(
-                  Choice1Of7(ListValues(List.Model.ListValues.List next))
-                 ),
+                (VList(ListValues(List.Model.ListValues.List next)),
                  None)
                 |> Value.Ext
             | DeltaExt.DeltaExtension(Choice1Of4(ListDeltaExt.InsertElement(i, v))) ->
               let next = List.insertAt (i + 1) v l
 
               return
-                (ValueExt(
-                  Choice1Of7(ListValues(List.Model.ListValues.List next))
-                 ),
+                (VList(ListValues(List.Model.ListValues.List next)),
                  None)
                 |> Value.Ext
             | DeltaExt.DeltaExtension(Choice1Of4(ListDeltaExt.DuplicateElement(i))) ->
               let next = List.insertAt (i + 1) (List.item i l) l
 
               return
-                (ValueExt(
-                  Choice1Of7(ListValues(List.Model.ListValues.List next))
-                 ),
+                (VList(ListValues(List.Model.ListValues.List next)),
                  None)
                 |> Value.Ext
             | DeltaExt.DeltaExtension(Choice1Of4(ListDeltaExt.SetAllElements(v))) ->
               let next = List.map (fun _ -> v) l
 
               return
-                (ValueExt(
-                  Choice1Of7(ListValues(List.Model.ListValues.List next))
-                 ),
+                (VList(ListValues(List.Model.ListValues.List next)),
                  None)
                 |> Value.Ext
             | DeltaExt.DeltaExtension(Choice1Of4(ListDeltaExt.RemoveAllElements)) ->
               let next = List.empty
 
               return
-                (ValueExt(
-                  Choice1Of7(ListValues(List.Model.ListValues.List next))
-                 ),
+                (VList(ListValues(List.Model.ListValues.List next)),
                  None)
                 |> Value.Ext
             | DeltaExt.DeltaExtension(Choice1Of4(ListDeltaExt.MoveElement(fromIndex,
@@ -438,9 +420,7 @@ and DeltaExt<'runtimeContext, 'db, 'customExtension
                   List.insertAt toIndex element withoutElement
 
               return
-                (ValueExt(
-                  Choice1Of7(ListValues(List.Model.ListValues.List next))
-                 ),
+                (VList(ListValues(List.Model.ListValues.List next)),
                  None)
                 |> Value.Ext
             | other ->
@@ -449,7 +429,7 @@ and DeltaExt<'runtimeContext, 'db, 'customExtension
                   Errors.Singleton () (fun () ->
                     $"Unimplemented delta ext toUpdater for {other}")
                 )
-          | Value.Ext(ValueExt(Choice6Of7(MapExt.MapValues(Map.Model.MapValues.Map m))),
+          | Value.Ext(VMap(MapExt.MapValues(Map.Model.MapValues.Map m)),
                       _) ->
             match delta with
             | DeltaExt.DeltaExtension(Choice4Of4(Map.Model.MapDeltaExt.UpdateKey(oldKey,
@@ -459,9 +439,7 @@ and DeltaExt<'runtimeContext, 'db, 'customExtension
                 let next = m |> Map.remove oldKey |> Map.add newKey value
 
                 return
-                  (ValueExt(
-                    Choice6Of7(MapExt.MapValues(Map.Model.MapValues.Map next))
-                   ),
+                  (VMap(MapExt.MapValues(Map.Model.MapValues.Map next)),
                    None)
                   |> Value.Ext
               | None ->
@@ -483,9 +461,7 @@ and DeltaExt<'runtimeContext, 'db, 'customExtension
                 let next = m |> Map.add key updatedValue
 
                 return
-                  (ValueExt(
-                    Choice6Of7(MapExt.MapValues(Map.Model.MapValues.Map next))
-                   ),
+                  (VMap(MapExt.MapValues(Map.Model.MapValues.Map next)),
                    None)
                   |> Value.Ext
               | None ->
@@ -499,18 +475,14 @@ and DeltaExt<'runtimeContext, 'db, 'customExtension
               let next = m |> Map.add key value
 
               return
-                (ValueExt(
-                  Choice6Of7(MapExt.MapValues(Map.Model.MapValues.Map next))
-                 ),
+                (VMap(MapExt.MapValues(Map.Model.MapValues.Map next)),
                  None)
                 |> Value.Ext
             | DeltaExt.DeltaExtension(Choice4Of4(Map.Model.MapDeltaExt.RemoveItem(key))) ->
               let next = m |> Map.remove key
 
               return
-                (ValueExt(
-                  Choice6Of7(MapExt.MapValues(Map.Model.MapValues.Map next))
-                 ),
+                (VMap(MapExt.MapValues(Map.Model.MapValues.Map next)),
                  None)
                 |> Value.Ext
             | other ->
@@ -559,44 +531,7 @@ and [<NoComparison; NoEquality>] DeltaExtDTO =
 
   static member Empty = { ListDelta = null; MapDelta = null }
 
-/// Named active patterns for the Choice slots inside ValueExt.
-/// Use these instead of raw Choice*Of7 for readability.
-/// Open this module or qualify as ValueExtInner.DB etc.
-module ValueExtInner =
-  let (|ListExt|_|) =
-    function
-    | Choice1Of7 v -> Some v
-    | _ -> None
 
-  let (|UnitExt|_|) =
-    function
-    | Choice2Of7 v -> Some v
-    | _ -> None
-
-  let (|PrimitiveExt|_|) =
-    function
-    | Choice3Of7 v -> Some v
-    | _ -> None
-
-  let (|CompositeTypeExt|_|) =
-    function
-    | Choice4Of7 v -> Some v
-    | _ -> None
-
-  let (|DB|_|) =
-    function
-    | Choice5Of7 v -> Some v
-    | _ -> None
-
-  let (|MapExt|_|) =
-    function
-    | Choice6Of7 v -> Some v
-    | _ -> None
-
-  let (|CustomExt|_|) =
-    function
-    | Choice7Of7 v -> Some v
-    | _ -> None
 
 [<NoComparison; NoEquality>]
 type StdExtensions<'runtimeContext, 'valueExt, 'valueExtDTO, 'deltaExt, 'deltaExtDTO
@@ -735,23 +670,21 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
       db_ops
       { Get =
           function
-          | ValueExt(Choice1Of7(ListExt.ListValues(List.Model.ListValues.List values))) ->
+          | VList(ListExt.ListValues(List.Model.ListValues.List values)) ->
             Some values
           | _ -> None
         Set =
           List.Model.ListValues.List
           >> ListExt.ListValues
-          >> Choice1Of7
-          >> ValueExt.ValueExt }
+          >> VList }
       { Get =
           function
-          | ValueExt(Choice6Of7(MapValues(Map.Model.MapValues.Map x))) -> Some x
+          | VMap(MapValues(Map.Model.MapValues.Map x)) -> Some x
           | _ -> None
         Set =
           Map.Model.MapValues.Map
           >> MapValues
-          >> Choice6Of7
-          >> ValueExt.ValueExt }
+          >> VMap }
       DBExt<_, _, _>.ValueLens
       typeCheckingConfig
 
@@ -766,9 +699,9 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
       ListExt<_, _, _>.ValueLens
       { Get =
           function
-          | ValueExt(Choice1Of7(ListOperations x)) -> Some x
+          | VList(ListOperations x) -> Some x
           | _ -> None
-        Set = ListOperations >> Choice1Of7 >> ValueExt.ValueExt }
+        Set = ListOperations >> VList }
       ListExt<_, _, _>.ValueDTOLens
       DeltaExt<_, _, _>.ListDeltaLens
       DeltaExt<_, _, _>.ListDeltaDTOLens
@@ -782,6 +715,8 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
       DeltaExt<'runtimeContext, 'db, 'customExtension>,
       DeltaExtDTO
      >
+      { Get = function | VViewProps x -> Some x | _ -> None
+        Set = VViewProps }
       (typeCheckingConfig |> Option.map (fun cfg -> cfg.ViewTypeSymbol))
       (typeCheckingConfig |> Option.map (fun cfg -> cfg.ViewPropsTypeSymbol))
 
@@ -793,7 +728,10 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
       DeltaExt<'runtimeContext, 'db, 'customExtension>,
       DeltaExtDTO
      >
+      { Get = function | VCo x -> Some x | _ -> None
+        Set = VCo }
       (typeCheckingConfig |> Option.map (fun cfg -> cfg.CoTypeSymbol))
+      (Identifier.FullyQualified([ "Frontend" ], "View"))
 
   let dateOnlyExtension =
     DateOnly.Extension.DateOnlyExtension<
@@ -803,15 +741,14 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
      >
       { Get =
           function
-          | ValueExt(Choice4Of7(CompositeType(Choice1Of5(DateOnlyOperations x)))) ->
+          | VComposite(CompositeType(Choice1Of5(DateOnlyOperations x))) ->
             Some x
           | _ -> None
         Set =
           DateOnlyOperations
           >> Choice1Of5
           >> CompositeType
-          >> Choice4Of7
-          >> ValueExt.ValueExt }
+          >> VComposite }
 
   let boolExtension =
     Bool.Extension.BoolExtension<
@@ -820,9 +757,9 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
      >
       { Get =
           function
-          | ValueExt(Choice3Of7(BoolOperations x)) -> Some x
+          | VPrimitive(BoolOperations x) -> Some x
           | _ -> None
-        Set = BoolOperations >> Choice3Of7 >> ValueExt.ValueExt }
+        Set = BoolOperations >> VPrimitive }
 
   let int32Extension =
     Int32.Extension.Int32Extension<
@@ -831,9 +768,9 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
      >
       { Get =
           function
-          | ValueExt(Choice3Of7(Int32Operations x)) -> Some x
+          | VPrimitive(Int32Operations x) -> Some x
           | _ -> None
-        Set = Int32Operations >> Choice3Of7 >> ValueExt.ValueExt }
+        Set = Int32Operations >> VPrimitive }
 
   let int64Extension =
     Int64.Extension.Int64Extension<
@@ -842,9 +779,9 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
      >
       { Get =
           function
-          | ValueExt(Choice3Of7(Int64Operations x)) -> Some x
+          | VPrimitive(Int64Operations x) -> Some x
           | _ -> None
-        Set = Int64Operations >> Choice3Of7 >> ValueExt.ValueExt }
+        Set = Int64Operations >> VPrimitive }
 
   let float32Extension =
     Float32.Extension.Float32Extension<
@@ -853,9 +790,9 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
      >
       { Get =
           function
-          | ValueExt(Choice3Of7(Float32Operations x)) -> Some x
+          | VPrimitive(Float32Operations x) -> Some x
           | _ -> None
-        Set = Float32Operations >> Choice3Of7 >> ValueExt.ValueExt }
+        Set = Float32Operations >> VPrimitive }
 
   let float64Extension =
     Float64.Extension.Float64Extension<
@@ -864,9 +801,9 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
      >
       { Get =
           function
-          | ValueExt(Choice3Of7(Float64Operations x)) -> Some x
+          | VPrimitive(Float64Operations x) -> Some x
           | _ -> None
-        Set = Float64Operations >> Choice3Of7 >> ValueExt.ValueExt }
+        Set = Float64Operations >> VPrimitive }
 
   let decimalExtension =
     Decimal.Extension.DecimalExtension<
@@ -875,9 +812,9 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
      >
       { Get =
           function
-          | ValueExt(Choice3Of7(DecimalOperations x)) -> Some x
+          | VPrimitive(DecimalOperations x) -> Some x
           | _ -> None
-        Set = DecimalOperations >> Choice3Of7 >> ValueExt.ValueExt }
+        Set = DecimalOperations >> VPrimitive }
 
   let dateTimeExtension =
     DateTime.Extension.DateTimeExtension<
@@ -887,15 +824,14 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
      >
       { Get =
           function
-          | ValueExt(Choice4Of7(CompositeType(Choice2Of5(DateTimeOperations x)))) ->
+          | VComposite(CompositeType(Choice2Of5(DateTimeOperations x))) ->
             Some x
           | _ -> None
         Set =
           DateTimeOperations
           >> Choice2Of5
           >> CompositeType
-          >> Choice4Of7
-          >> ValueExt.ValueExt }
+          >> VComposite }
 
   let timeSpanExtension =
     TimeSpanExtension<
@@ -905,15 +841,14 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
      >
       { Get =
           function
-          | ValueExt(Choice4Of7(CompositeType(Choice4Of5(TimeSpanOperations x)))) ->
+          | VComposite(CompositeType(Choice4Of5(TimeSpanOperations x))) ->
             Some x
           | _ -> None
         Set =
           TimeSpanOperations
           >> Choice4Of5
           >> CompositeType
-          >> Choice4Of7
-          >> ValueExt.ValueExt }
+          >> VComposite }
 
   let stringExtension =
     String.Extension.StringExtension<
@@ -923,9 +858,9 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
       string_ops
       { Get =
           function
-          | ValueExt(Choice3Of7(StringOperations x)) -> Some x
+          | VPrimitive(StringOperations x) -> Some x
           | _ -> None
-        Set = StringOperations >> Choice3Of7 >> ValueExt.ValueExt }
+        Set = StringOperations >> VPrimitive }
 
   let emailExtension =
     Email.Extension.EmailExtension<
@@ -935,9 +870,9 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
       email_ops
       { Get =
           function
-          | ValueExt(Choice3Of7(EmailOperations x)) -> Some x
+          | VPrimitive(EmailOperations x) -> Some x
           | _ -> None
-        Set = EmailOperations >> Choice3Of7 >> ValueExt.ValueExt }
+        Set = EmailOperations >> VPrimitive }
 
   let guidExtension =
     Guid.Extension.GuidExtension<
@@ -947,15 +882,14 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
      >
       { Get =
           function
-          | ValueExt(Choice4Of7(CompositeType(Choice3Of5(GuidOperations x)))) ->
+          | VComposite(CompositeType(Choice3Of5(GuidOperations x))) ->
             Some x
           | _ -> None
         Set =
           GuidOperations
           >> Choice3Of5
           >> CompositeType
-          >> Choice4Of7
-          >> ValueExt.ValueExt }
+          >> VComposite }
 
   let updaterExtension =
     Updater.Extension.UpdaterExtension<
@@ -964,15 +898,14 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
      >
       { Get =
           function
-          | ValueExt(Choice4Of7(CompositeType(Choice5Of5(UpdaterOperations x)))) ->
+          | VComposite(CompositeType(Choice5Of5(UpdaterOperations x))) ->
             Some x
           | _ -> None
         Set =
           UpdaterOperations
           >> Choice5Of5
           >> CompositeType
-          >> Choice4Of7
-          >> ValueExt.ValueExt }
+          >> VComposite }
 
   let mapExtension =
     Map.Extension.MapExtension<
@@ -985,9 +918,9 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
       MapExt<_, _, _>.ValueLens
       { Get =
           function
-          | ValueExt(Choice6Of7(MapOperations x)) -> Some x
+          | VMap(MapOperations x) -> Some x
           | _ -> None
-        Set = MapOperations >> Choice6Of7 >> ValueExt.ValueExt }
+        Set = MapOperations >> VMap }
       (Some ListExt<'runtimeContext, 'db, 'customExtension>.ValueLens)
       MapExt<_, _, _>.ValueDTOLens
       DeltaExt<_, _, _>.MapDeltaLens

--- a/backend/libraries/ballerina-lang/Next/Stdlib/View/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/View/Extension.fs
@@ -5,6 +5,14 @@ module Extension =
   open Ballerina.DSL.Next.Types.Patterns
   open Ballerina.DSL.Next.Types.TypeChecker.Model
   open Ballerina.DSL.Next.Extensions
+  open Ballerina.Collections.Sum
+  open Ballerina.Errors
+  open Ballerina.Reader.WithError
+  open Ballerina.Lenses
+
+  type ViewPropsOperations =
+    | View_MapContext
+    | View_MapState
 
   let ViewExtension<'runtimeContext, 'ext, 'extDTO, 'deltaExt, 'deltaExtDTO
     when 'ext: comparison
@@ -12,6 +20,7 @@ module Extension =
     and 'extDTO: not struct
     and 'deltaExtDTO: not null
     and 'deltaExtDTO: not struct>
+    (operationLens: PartialLens<'ext, ViewPropsOperations>)
     (viewTypeSymbol: Option<TypeSymbol>)
     (viewPropsTypeSymbol: Option<TypeSymbol>)
     : TypeExtension<
@@ -32,7 +41,7 @@ module Extension =
         'deltaExtDTO,
         Unit,
         Unit,
-        Unit
+        ViewPropsOperations
        > *
       TypeSymbol *
       TypeSymbol *
@@ -81,11 +90,181 @@ module Extension =
           Parameters = []
           Arguments = [ schema; ctx; st ] }
 
+    // --- View::mapContext ---
+    // mapContext : Λschema. Λctx. Λst. Λctx2. (ctx -> ctx2) -> Props[schema][ctx][st] -> Props[schema][ctx2][st]
+    let mapContextId =
+      Identifier.FullyQualified([ "View" ], "mapContext")
+      |> TypeCheckScope.Empty.Resolve
+
+    let _ctx2Var, ctx2Kind = TypeVar.Create("ctx2"), Kind.Star
+
+    let mapContextOperation
+      : ResolvedIdentifier *
+        TypeOperationExtension<'runtimeContext, 'ext, Unit, Unit, ViewPropsOperations> =
+      mapContextId,
+      { Type =
+          TypeValue.CreateLambda(
+            TypeParameter.Create("schema", schemaKind),
+            TypeExpr.Lambda(
+              TypeParameter.Create("ctx", ctxKind),
+              TypeExpr.Lambda(
+                TypeParameter.Create("st", stKind),
+                TypeExpr.Lambda(
+                  TypeParameter.Create("ctx2", ctx2Kind),
+                  TypeExpr.Arrow(
+                    TypeExpr.Arrow(
+                      TypeExpr.Lookup(Identifier.LocalScope "ctx"),
+                      TypeExpr.Lookup(Identifier.LocalScope "ctx2")
+                    ),
+                    TypeExpr.Arrow(
+                      TypeExpr.Apply(
+                        TypeExpr.Apply(
+                          TypeExpr.Apply(
+                            TypeExpr.Lookup(Identifier.FullyQualified([ "View" ], "Props")),
+                            TypeExpr.Lookup(Identifier.LocalScope "schema")
+                          ),
+                          TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                        ),
+                        TypeExpr.Lookup(Identifier.LocalScope "st")
+                      ),
+                      TypeExpr.Apply(
+                        TypeExpr.Apply(
+                          TypeExpr.Apply(
+                            TypeExpr.Lookup(Identifier.FullyQualified([ "View" ], "Props")),
+                            TypeExpr.Lookup(Identifier.LocalScope "schema")
+                          ),
+                          TypeExpr.Lookup(Identifier.LocalScope "ctx2")
+                        ),
+                        TypeExpr.Lookup(Identifier.LocalScope "st")
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        Kind =
+          Kind.Arrow(
+            Kind.Schema,
+            Kind.Arrow(
+              Kind.Star,
+              Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+            )
+          )
+        Operation = View_MapContext
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | View_MapContext -> Some View_MapContext
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (_op, _v) ->
+            reader {
+              return!
+                Errors.Singleton loc0 (fun () -> "View::mapContext is not yet implemented")
+                |> reader.Throw
+            } }
+
+    // --- View::mapState ---
+    // mapState : Λschema. Λctx. Λst. Λst2.
+    //   (st -> st2) -> (((st2 -> st2) -> ()) -> ((st -> st) -> ())) -> Props[schema][ctx][st] -> Props[schema][ctx][st2]
+    let mapStateId =
+      Identifier.FullyQualified([ "View" ], "mapState")
+      |> TypeCheckScope.Empty.Resolve
+
+    let _st2Var, st2Kind = TypeVar.Create("st2"), Kind.Star
+
+    let mapStateOperation
+      : ResolvedIdentifier *
+        TypeOperationExtension<'runtimeContext, 'ext, Unit, Unit, ViewPropsOperations> =
+      mapStateId,
+      { Type =
+          TypeValue.CreateLambda(
+            TypeParameter.Create("schema", schemaKind),
+            TypeExpr.Lambda(
+              TypeParameter.Create("ctx", ctxKind),
+              TypeExpr.Lambda(
+                TypeParameter.Create("st", stKind),
+                TypeExpr.Lambda(
+                  TypeParameter.Create("st2", st2Kind),
+                  TypeExpr.Arrow(
+                    TypeExpr.Arrow(
+                      TypeExpr.Lookup(Identifier.LocalScope "st"),
+                      TypeExpr.Lookup(Identifier.LocalScope "st2")
+                    ),
+                    TypeExpr.Arrow(
+                      TypeExpr.Arrow(
+                        TypeExpr.Arrow(
+                          TypeExpr.Arrow(
+                            TypeExpr.Lookup(Identifier.LocalScope "st2"),
+                            TypeExpr.Lookup(Identifier.LocalScope "st2")
+                          ),
+                          TypeExpr.Primitive PrimitiveType.Unit
+                        ),
+                        TypeExpr.Arrow(
+                          TypeExpr.Arrow(
+                            TypeExpr.Lookup(Identifier.LocalScope "st"),
+                            TypeExpr.Lookup(Identifier.LocalScope "st")
+                          ),
+                          TypeExpr.Primitive PrimitiveType.Unit
+                        )
+                      ),
+                      TypeExpr.Arrow(
+                        TypeExpr.Apply(
+                          TypeExpr.Apply(
+                            TypeExpr.Apply(
+                              TypeExpr.Lookup(Identifier.FullyQualified([ "View" ], "Props")),
+                              TypeExpr.Lookup(Identifier.LocalScope "schema")
+                            ),
+                            TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                          ),
+                          TypeExpr.Lookup(Identifier.LocalScope "st")
+                        ),
+                        TypeExpr.Apply(
+                          TypeExpr.Apply(
+                            TypeExpr.Apply(
+                              TypeExpr.Lookup(Identifier.FullyQualified([ "View" ], "Props")),
+                              TypeExpr.Lookup(Identifier.LocalScope "schema")
+                            ),
+                            TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                          ),
+                          TypeExpr.Lookup(Identifier.LocalScope "st2")
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        Kind =
+          Kind.Arrow(
+            Kind.Schema,
+            Kind.Arrow(
+              Kind.Star,
+              Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+            )
+          )
+        Operation = View_MapState
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | View_MapState -> Some View_MapState
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (_op, _v) ->
+            reader {
+              return!
+                Errors.Singleton loc0 (fun () -> "View::mapState is not yet implemented")
+                |> reader.Throw
+            } }
+
     let viewPropsExtension =
       { TypeName = viewPropsResolvedId, viewPropsSymbolId
         TypeVars = [ (schemaVar, schemaKind); (ctxVar, ctxKind); (stVar, stKind) ]
         Cases = Map.empty
-        Operations = Map.empty
+        Operations =
+          [ mapContextOperation; mapStateOperation ] |> Map.ofList
         Serialization = None
         ExtTypeChecker = None }
 

--- a/backend/libraries/ballerina-memorydb/MemoryDB.fs
+++ b/backend/libraries/ballerina-memorydb/MemoryDB.fs
@@ -350,7 +350,7 @@ module MutableMemoryDB =
         |> NonEmptyList.map (fun it ->
           reader {
             match it.Source with
-            | Value.Ext(ValueExt.ValueExt(Choice5Of7(DBExt.DBValues(DBValues.EntityRef entity_ref))),
+            | Value.Ext(ValueExt.VDB(DBExt.DBValues(DBValues.EntityRef entity_ref)),
                         _) ->
               let (db: MutableMemoryDB<_, _>) =
                 queryRunAdapter.GetDbFromEntityRef entity_ref
@@ -392,11 +392,11 @@ module MutableMemoryDB =
                 |> reader.OfSum
 
               match relation with
-              | Value.Ext(ValueExt.ValueExt(Choice5Of7(DBExt.DBValues(DBValues.RelationRef(relation_ref:
+              | Value.Ext(ValueExt.VDB(DBExt.DBValues(DBValues.RelationRef(relation_ref:
                             RelationRef<
                               MutableMemoryDB<'a, 'b>,
                               ValueExt<'a, MutableMemoryDB<'a, 'b>, 'b>
-                             >)))),
+                             >))),
                           _) ->
                 let (db: MutableMemoryDB<_, _>) =
                   queryRunAdapter.GetDbFromRelationRef relation_ref


### PR DESCRIPTION
## Summary

Replace the single-case `ValueExt of Choice<7 types>` wrapper with named discriminated union cases, eliminating all raw `Choice*Of7` patterns throughout the codebase.

## Changes

### ValueExt DU (StdExtensions.fs)
| New Case | Type | Replaces |
|----------|------|----------|
| `VList` | `ListExt<...>` | `Choice1Of7` |
| `VViewProps` | `ViewPropsOperations` | **new** |
| `VCo` | `CoroutineOperations` | **new** |
| `VPrimitive` | `PrimitiveExt<...>` | `Choice3Of7` |
| `VComposite` | `CompositeTypeExt<...>` | `Choice4Of7` |
| `VDB` | `DBExt<...>` | `Choice5Of7` |
| `VMap` | `MapExt<...>` | `Choice6Of7` |
| `VCustom` | `'customExtension` | `Choice7Of7` |

### View/Coroutine extensions
- Added `operationLens: PartialLens<'ext, ViewPropsOperations>` to `ViewExtension`
- Added `operationLens: PartialLens<'ext, CoroutineOperations>` to `CoroutineExtension`
- View::mapContext, View::mapState type operations
- Co::show, Co::until, Co::ignore type operations

### Other
- Fixed Kind fold order bug in Extensions/Types.fs (`List.foldBack` instead of `List.fold`)
- Removed obsolete `ValueExtInner` active-pattern module
- Updated all downstream consumers (MemoryDB, API endpoints, etc.)

## Verification
- `dotnet build backend/backend.sln` — 0 errors
- Integration tests: 26/26 pass