### PR TITLE
feat(api): add transaction management to mutation endpoints

### DIFF
--- a/backend/libraries/ballerina-api-filedb-factory/MemoryDBFactory.fs
+++ b/backend/libraries/ballerina-api-filedb-factory/MemoryDBFactory.fs
@@ -116,7 +116,8 @@ module MemoryDBAPIFactory =
                   Scope = dbio.EvalContext }
             TypeCheckContext = typeCheckContext
             TypeCheckState = typeCheckState
-            LanguageContext = languageContext }
+            LanguageContext = languageContext
+            DataSource = None }
       | _ ->
         return!
           sum.Throw(

--- a/backend/libraries/ballerina-api/Common/Utils.fs
+++ b/backend/libraries/ballerina-api/Common/Utils.fs
@@ -20,6 +20,7 @@ module APIUtils =
   open Ballerina.DSL.Next.Terms.Eval
   open Ballerina.Data.Delta
   open Ballerina.DSL.Next.StdLib.Updater.Model
+  open Npgsql
 
   [<Extension>]
   type HttpContextExtensions() =
@@ -273,7 +274,8 @@ module APIUtils =
           ValueExt<'runtimeContext, 'db, 'customExtension>
          > *
         TypeCheckContext<ValueExt<'runtimeContext, 'db, 'customExtension>> *
-        TypeCheckState<ValueExt<'runtimeContext, 'db, 'customExtension>>,
+        TypeCheckState<ValueExt<'runtimeContext, 'db, 'customExtension>> *
+        Option<NpgsqlDataSource>,
         APIError<'runtimeContext, 'db, 'customExtension, Location>
        >
     =
@@ -285,7 +287,8 @@ module APIUtils =
         dbDescriptor.LanguageContext,
         dbDescriptor.EvalContext,
         dbDescriptor.TypeCheckContext,
-        dbDescriptor.TypeCheckState
+        dbDescriptor.TypeCheckState,
+        dbDescriptor.DataSource
     }
     |> sum.MapError
       APIError<'runtimeContext, 'db, 'customExtension, Location>.Create
@@ -296,17 +299,20 @@ module APIUtils =
     and 'db: comparison
     and 'deltaDb: comparison>
     (body: Sum<'a, APIError<'runtimeContext, 'db, 'customExtension, 'context>>)
+    (onFail: APIError<'runtimeContext, 'db, 'customExtension, 'context> -> unit)
     (onSuccess: 'a -> 'b)
     : IResult =
     match body with
     | Left result -> onSuccess >> Results.Ok <| result
-    | Right { Errors = errors; TypeError = Some _ } ->
+    | Right ({ Errors = errors; TypeError = Some _ } as apiError) ->
+      onFail apiError
       let serializedErrors = errorsToSerializable errors
 
       Results.BadRequest
         { Errors = serializedErrors
           Examples = [||] }
-    | Right { Errors = errors; TypeError = None } ->
+    | Right ({ Errors = errors; TypeError = None } as apiError) ->
+      onFail apiError
       Results.BadRequest
         { Errors = errorsToSerializable errors
           Examples = [||] }

--- a/backend/libraries/ballerina-api/Endpoints/Create.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Create.fs
@@ -23,6 +23,7 @@ module Create =
   open Ballerina.DSL.Next.Serialization.ValueSerializer
   open Ballerina.DSL.Next.Types.TypeChecker.Value
   open Ballerina.DSL.Next.StdLib.DB
+  open Npgsql
 
   [<NoComparison; NoEquality>]
   type CreatePayload =
@@ -51,152 +52,176 @@ module Create =
           let entityId = payload.Id
           let entity = payload.Entity
 
+          let txn : NpgsqlTransaction option ref = ref None
+          let conn : NpgsqlConnection option ref = ref None
+          let cleanup () =
+            txn.Value |> Option.iter (fun t -> try t.Rollback() with _ -> ())
+            conn.Value |> Option.iter (fun c -> try c.Dispose() with _ -> ())
+            txn.Value <- None
+            conn.Value <- None
+          try
+            let result =
+              sum {
+                let! dbio,
+                     languageContext,
+                     evalContext,
+                     typeCheckContext,
+                     typeCheckState,
+                     dataSource =
+                  getDbDescriptor tenantId schemaName context
 
-          let result =
-            sum {
-              let! dbio,
-                   languageContext,
-                   evalContext,
-                   typeCheckContext,
-                   typeCheckState =
-                getDbDescriptor tenantId schemaName context
+                let! _tableDescriptor =
+                  dbio.Schema.Entities
+                  |> OrderedMap.tryFind (entityName |> SchemaEntityName.Create)
+                  |> Sum.fromOption (fun () ->
+                    Errors.Singleton Location.Unknown (fun () ->
+                      $"Entity {entityName} not found in schema {dbio.Schema}."))
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! _tableDescriptor =
-                dbio.Schema.Entities
-                |> OrderedMap.tryFind (entityName |> SchemaEntityName.Create)
-                |> Sum.fromOption (fun () ->
-                  Errors.Singleton Location.Unknown (fun () ->
-                    $"Entity {entityName} not found in schema {dbio.Schema}."))
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! schema =
+                  dbio.SchemaAsValue
+                  |> Value.AsRecord
+                  |> toUknonwLocation
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! schema =
-                dbio.SchemaAsValue
-                |> Value.AsRecord
-                |> toUknonwLocation
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entities =
+                  schema
+                  |> Map.tryFindWithError
+                    ("Entities"
+                     |> Identifier.LocalScope
+                     |> ResolvedIdentifier.FromIdentifier)
+                    "schema"
+                    (fun () -> "Entities")
+                    Location.Unknown
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! entities =
-                schema
-                |> Map.tryFindWithError
-                  ("Entities"
-                   |> Identifier.LocalScope
-                   |> ResolvedIdentifier.FromIdentifier)
-                  "schema"
-                  (fun () -> "Entities")
-                  Location.Unknown
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entities =
+                  entities
+                  |> Value.AsRecord
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! entities =
-                entities
-                |> Value.AsRecord
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entityDescriptor =
+                  entities
+                  |> Map.tryFindWithError
+                    (entityName
+                     |> Identifier.LocalScope
+                     |> ResolvedIdentifier.FromIdentifier)
+                    "schema"
+                    (fun () -> "Entities")
+                    Location.Unknown
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! entityDescriptor =
-                entities
-                |> Map.tryFindWithError
-                  (entityName
-                   |> Identifier.LocalScope
-                   |> ResolvedIdentifier.FromIdentifier)
-                  "schema"
-                  (fun () -> "Entities")
-                  Location.Unknown
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! idValue =
+                  runDTOConverter languageContext (valueFromDTO entityId)
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! idValue =
-                runDTOConverter languageContext (valueFromDTO entityId)
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entityValue =
+                  runDTOConverter languageContext (valueFromDTO entity)
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! entityValue =
-                runDTOConverter languageContext (valueFromDTO entity)
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let idType, entityType =
+                  _tableDescriptor.Id, _tableDescriptor.TypeOriginal
 
-              let idType, entityType =
-                _tableDescriptor.Id, _tableDescriptor.TypeOriginal
+                do!
+                  typeCheckValue
+                    idValue
+                    idType
+                    languageContext
+                    typeCheckContext
+                    typeCheckState
 
-              do!
-                typeCheckValue
-                  idValue
-                  idType
-                  languageContext
-                  typeCheckContext
-                  typeCheckState
+                do!
+                  typeCheckValue
+                    entityValue
+                    entityType
+                    languageContext
+                    typeCheckContext
+                    typeCheckState
 
-              do!
-                typeCheckValue
-                  entityValue
-                  entityType
-                  languageContext
-                  typeCheckContext
-                  typeCheckState
-
-              let doUpdateExpr
-                : RunnableExpr<
-                    ValueExt<'runtimeContext, 'db, 'customExtension>
-                   > =
-                RunnableExpr.UnsafeApplyForUntypedEval(
+                let doUpdateExpr
+                  : RunnableExpr<
+                      ValueExt<'runtimeContext, 'db, 'customExtension>
+                     > =
                   RunnableExpr.UnsafeApplyForUntypedEval(
-                    RunnableExpr.UnsafeLookupForUntypedEval(
-                      Identifier.FullyQualified([ "DB" ], "create")
-                      |> ResolvedIdentifier.FromIdentifier
-                    ),
-                    RunnableExpr.FromValue(
-                      entityDescriptor,
-                      TypeValue.CreatePrimitive PrimitiveType.Unit,
-                      Kind.Star
-                    )
-                  ),
-                  RunnableExpr.UnsafeTupleConsForUntypedEval
-                    [ RunnableExpr.FromValue(
-                        idValue,
+                    RunnableExpr.UnsafeApplyForUntypedEval(
+                      RunnableExpr.UnsafeLookupForUntypedEval(
+                        Identifier.FullyQualified([ "DB" ], "create")
+                        |> ResolvedIdentifier.FromIdentifier
+                      ),
+                      RunnableExpr.FromValue(
+                        entityDescriptor,
                         TypeValue.CreatePrimitive PrimitiveType.Unit,
                         Kind.Star
                       )
-                      RunnableExpr.FromValue(
-                        entityValue,
-                        TypeValue.CreatePrimitive PrimitiveType.Unit,
-                        Kind.Star
-                      ) ]
-                )
+                    ),
+                    RunnableExpr.UnsafeTupleConsForUntypedEval
+                      [ RunnableExpr.FromValue(
+                          idValue,
+                          TypeValue.CreatePrimitive PrimitiveType.Unit,
+                          Kind.Star
+                        )
+                        RunnableExpr.FromValue(
+                          entityValue,
+                          TypeValue.CreatePrimitive PrimitiveType.Unit,
+                          Kind.Star
+                        ) ]
+                  )
 
-              let! evalResult =
-                Expr.Eval(
-                  NonEmptyList.prependList
-                    languageContext.TypeCheckedPreludes
-                    (NonEmptyList.OfList(doUpdateExpr, []))
-                )
-                |> Reader.Run(
-                  evalContext |> context.PermissionHookInjector httpContext
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                match dataSource with
+                | Some ds ->
+                  let c = ds.OpenConnection()
+                  let t = c.BeginTransaction()
+                  conn.Value <- Some c
+                  txn.Value <- Some t
+                | None -> ()
 
-              let! result =
-                runDTOConverter languageContext (valueToDTO evalResult)
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! evalResult =
+                  Expr.Eval(
+                    NonEmptyList.prependList
+                      languageContext.TypeCheckedPreludes
+                      (NonEmptyList.OfList(doUpdateExpr, []))
+                  )
+                  |> Reader.Run(
+                    evalContext |> context.PermissionHookInjector httpContext
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              return result
-            }
+                txn.Value |> Option.iter (fun t -> t.Commit())
+                conn.Value |> Option.iter (fun c -> c.Dispose())
+                txn.Value <- None
+                conn.Value <- None
 
-          apiResponseFromSum result id)
+                let! result =
+                  runDTOConverter languageContext (valueToDTO evalResult)
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+
+                return result
+              }
+
+            apiResponseFromSum result (fun _ -> cleanup()) id
+          with ex ->
+            cleanup()
+            reraise())
     )
     |> ignore

--- a/backend/libraries/ballerina-api/Endpoints/Delete.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Delete.fs
@@ -21,6 +21,7 @@ module Delete =
   open Ballerina.DSL.Next.Extensions
   open Microsoft.AspNetCore.Http
   open Ballerina.DSL.Next.Serialization.ValueSerializer
+  open Npgsql
 
   let delete<'runtimeContext, 'db, 'customExtension, 'tenantId, 'schemaName
     when 'customExtension: comparison and 'db: comparison>
@@ -41,131 +42,154 @@ module Delete =
        >
         (fun httpContext tenantId schemaName entityName payload ->
           let entityId = payload
+          let txn : NpgsqlTransaction option ref = ref None
+          let conn : NpgsqlConnection option ref = ref None
+          let cleanup () =
+            txn.Value |> Option.iter (fun t -> try t.Rollback() with _ -> ())
+            conn.Value |> Option.iter (fun c -> try c.Dispose() with _ -> ())
+            txn.Value <- None
+            conn.Value <- None
+          try
+            let result =
+              sum {
+                let! dbio,
+                     languageContext,
+                     evalContext,
+                     typeCheckContext,
+                     typeCheckState,
+                     dataSource =
+                  getDbDescriptor tenantId schemaName context
 
-          let result =
-            sum {
-              let! dbio,
-                   languageContext,
-                   evalContext,
-                   typeCheckContext,
-                   typeCheckState =
-                getDbDescriptor tenantId schemaName context
-
-              let! _tableDescriptor =
-                dbio.Schema.Entities
-                |> OrderedMap.tryFind (entityName |> SchemaEntityName.Create)
-                |> Sum.fromOption (fun () ->
-                  Errors<Location>.Singleton Location.Unknown (fun () ->
-                    $"Entity {entityName} not found in schema {dbio.Schema}."))
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! _tableDescriptor =
+                  dbio.Schema.Entities
+                  |> OrderedMap.tryFind (entityName |> SchemaEntityName.Create)
+                  |> Sum.fromOption (fun () ->
+                    Errors<Location>.Singleton Location.Unknown (fun () ->
+                      $"Entity {entityName} not found in schema {dbio.Schema}."))
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
 
-              let! schema =
-                dbio.SchemaAsValue
-                |> Value.AsRecord
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                  >> APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
-                )
+                let! schema =
+                  dbio.SchemaAsValue
+                  |> Value.AsRecord
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                    >> APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+                  )
 
-              let! entities =
-                schema
-                |> Map.tryFindWithError
-                  ("Entities"
-                   |> Identifier.LocalScope
-                   |> ResolvedIdentifier.FromIdentifier)
-                  "schema"
-                  (fun () -> "Entities")
-                  Location.Unknown
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entities =
+                  schema
+                  |> Map.tryFindWithError
+                    ("Entities"
+                     |> Identifier.LocalScope
+                     |> ResolvedIdentifier.FromIdentifier)
+                    "schema"
+                    (fun () -> "Entities")
+                    Location.Unknown
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! entities =
-                entities
-                |> Value.AsRecord
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                  >> APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
-                )
+                let! entities =
+                  entities
+                  |> Value.AsRecord
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                    >> APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+                  )
 
-              let! entityDescriptor =
-                entities
-                |> Map.tryFindWithError
-                  (entityName
-                   |> Identifier.LocalScope
-                   |> ResolvedIdentifier.FromIdentifier)
-                  "schema"
-                  (fun () -> "Entities")
-                  Location.Unknown
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entityDescriptor =
+                  entities
+                  |> Map.tryFindWithError
+                    (entityName
+                     |> Identifier.LocalScope
+                     |> ResolvedIdentifier.FromIdentifier)
+                    "schema"
+                    (fun () -> "Entities")
+                    Location.Unknown
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! idValue =
-                runDTOConverter languageContext (valueFromDTO entityId)
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! idValue =
+                  runDTOConverter languageContext (valueFromDTO entityId)
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let idType = _tableDescriptor.Id
+                let idType = _tableDescriptor.Id
 
-              do!
-                typeCheckValue
-                  idValue
-                  idType
-                  languageContext
-                  typeCheckContext
-                  typeCheckState
+                do!
+                  typeCheckValue
+                    idValue
+                    idType
+                    languageContext
+                    typeCheckContext
+                    typeCheckState
 
-              let doDeleteExpr
-                : RunnableExpr<
-                    ValueExt<'runtimeContext, 'db, 'customExtension>
-                   > =
-                RunnableExpr.UnsafeApplyForUntypedEval(
+                let doDeleteExpr
+                  : RunnableExpr<
+                      ValueExt<'runtimeContext, 'db, 'customExtension>
+                     > =
                   RunnableExpr.UnsafeApplyForUntypedEval(
-                    RunnableExpr.UnsafeLookupForUntypedEval(
-                      Identifier.FullyQualified([ "DB" ], "delete")
-                      |> ResolvedIdentifier.FromIdentifier
+                    RunnableExpr.UnsafeApplyForUntypedEval(
+                      RunnableExpr.UnsafeLookupForUntypedEval(
+                        Identifier.FullyQualified([ "DB" ], "delete")
+                        |> ResolvedIdentifier.FromIdentifier
+                      ),
+                      RunnableExpr.FromValue(
+                        entityDescriptor,
+                        TypeValue.CreatePrimitive PrimitiveType.Unit,
+                        Kind.Star
+                      )
                     ),
                     RunnableExpr.FromValue(
-                      entityDescriptor,
+                      idValue,
                       TypeValue.CreatePrimitive PrimitiveType.Unit,
                       Kind.Star
                     )
-                  ),
-                  RunnableExpr.FromValue(
-                    idValue,
-                    TypeValue.CreatePrimitive PrimitiveType.Unit,
-                    Kind.Star
                   )
-                )
 
-              let! evalResult =
-                Expr.Eval(
-                  NonEmptyList.prependList
-                    languageContext.TypeCheckedPreludes
-                    (NonEmptyList.OfList(doDeleteExpr, []))
-                )
-                |> Reader.Run(
-                  evalContext |> context.PermissionHookInjector httpContext
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                match dataSource with
+                | Some ds ->
+                  let c = ds.OpenConnection()
+                  let t = c.BeginTransaction()
+                  conn.Value <- Some c
+                  txn.Value <- Some t
+                | None -> ()
 
-              return!
-                runDTOConverter languageContext (valueToDTO evalResult)
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
-            }
+                let! evalResult =
+                  Expr.Eval(
+                    NonEmptyList.prependList
+                      languageContext.TypeCheckedPreludes
+                      (NonEmptyList.OfList(doDeleteExpr, []))
+                  )
+                  |> Reader.Run(
+                    evalContext |> context.PermissionHookInjector httpContext
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-          apiResponseFromSum result id)
+                txn.Value |> Option.iter (fun t -> t.Commit())
+                conn.Value |> Option.iter (fun c -> c.Dispose())
+                txn.Value <- None
+                conn.Value <- None
+
+                return!
+                  runDTOConverter languageContext (valueToDTO evalResult)
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+              }
+            apiResponseFromSum result (fun _ -> cleanup()) id
+          with ex ->
+            cleanup()
+            reraise())
     )
     |> ignore
 
@@ -180,161 +204,185 @@ module Delete =
         IResult
        >
         (fun httpContext tenantId schemaName entityName payload ->
-          let result =
-            sum {
-              let ids = payload
+          let txn : NpgsqlTransaction option ref = ref None
+          let conn : NpgsqlConnection option ref = ref None
+          let cleanup () =
+            txn.Value |> Option.iter (fun t -> try t.Rollback() with _ -> ())
+            conn.Value |> Option.iter (fun c -> try c.Dispose() with _ -> ())
+            txn.Value <- None
+            conn.Value <- None
+          try
+            let result =
+              sum {
+                let ids = payload
 
-              let! dbio,
-                   languageContext,
-                   evalContext,
-                   typeCheckContext,
-                   typeCheckState =
-                getDbDescriptor tenantId schemaName context
+                let! dbio,
+                     languageContext,
+                     evalContext,
+                     typeCheckContext,
+                     typeCheckState,
+                     dataSource =
+                  getDbDescriptor tenantId schemaName context
 
-              let! _tableDescriptor =
-                dbio.Schema.Entities
-                |> OrderedMap.tryFind (entityName |> SchemaEntityName.Create)
-                |> Sum.fromOption (fun () ->
-                  Errors<Location>.Singleton Location.Unknown (fun () ->
-                    $"Entity {entityName} not found in schema {dbio.Schema}."))
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! _tableDescriptor =
+                  dbio.Schema.Entities
+                  |> OrderedMap.tryFind (entityName |> SchemaEntityName.Create)
+                  |> Sum.fromOption (fun () ->
+                    Errors<Location>.Singleton Location.Unknown (fun () ->
+                      $"Entity {entityName} not found in schema {dbio.Schema}."))
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! schema =
-                dbio.SchemaAsValue
-                |> Value.AsRecord
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                  >> APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
-                )
-
-              let! entities =
-                schema
-                |> Map.tryFindWithError
-                  ("Entities"
-                   |> Identifier.LocalScope
-                   |> ResolvedIdentifier.FromIdentifier)
-                  "schema"
-                  (fun () -> "Entities")
-                  Location.Unknown
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
-
-              let! entities =
-                entities
-                |> Value.AsRecord
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                  >> APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
-                )
-
-              let! entityDescriptor =
-                entities
-                |> Map.tryFindWithError
-                  (entityName
-                   |> Identifier.LocalScope
-                   |> ResolvedIdentifier.FromIdentifier)
-                  "schema"
-                  (fun () -> "Entities")
-                  Location.Unknown
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
-
-              let! deleters =
-                ids
-                |> Array.map (
-                  valueFromDTO
-                  >> reader.MapError(
+                let! schema =
+                  dbio.SchemaAsValue
+                  |> Value.AsRecord
+                  |> sum.MapError(
                     Errors.MapContext(replaceWith Location.Unknown)
+                    >> APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
                   )
-                )
-                |> reader.All
-                |> Reader.Run
-                  languageContext.SerializationContext.SerializationContext
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
 
-              let idType = _tableDescriptor.Id
+                let! entities =
+                  schema
+                  |> Map.tryFindWithError
+                    ("Entities"
+                     |> Identifier.LocalScope
+                     |> ResolvedIdentifier.FromIdentifier)
+                    "schema"
+                    (fun () -> "Entities")
+                    Location.Unknown
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              do!
-                deleters
-                |> List.map (fun deleter ->
-                  typeCheckValue
-                    deleter
-                    idType
-                    languageContext
-                    typeCheckContext
-                    typeCheckState)
-                |> Sum.All
-                |> Sum.map (fun _ -> ())
+                let! entities =
+                  entities
+                  |> Value.AsRecord
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                    >> APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+                  )
 
-              let deleters =
-                deleters
-                |> List.map (fun deleter ->
-                  deleter, Value.Primitive PrimitiveValue.Unit)
-                |> Map.ofList
-                |> Ballerina.DSL.Next.StdLib.Map.Model.MapValues.Map
-                |> MapExt.MapValues
-                |> Choice6Of7
-                |> ValueExt
+                let! entityDescriptor =
+                  entities
+                  |> Map.tryFindWithError
+                    (entityName
+                     |> Identifier.LocalScope
+                     |> ResolvedIdentifier.FromIdentifier)
+                    "schema"
+                    (fun () -> "Entities")
+                    Location.Unknown
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+
+                let! deleters =
+                  ids
+                  |> Array.map (
+                    valueFromDTO
+                    >> reader.MapError(
+                      Errors.MapContext(replaceWith Location.Unknown)
+                    )
+                  )
+                  |> reader.All
+                  |> Reader.Run
+                    languageContext.SerializationContext.SerializationContext
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+
+                let idType = _tableDescriptor.Id
+
+                do!
+                  deleters
+                  |> List.map (fun deleter ->
+                    typeCheckValue
+                      deleter
+                      idType
+                      languageContext
+                      typeCheckContext
+                      typeCheckState)
+                  |> Sum.All
+                  |> Sum.map (fun _ -> ())
+
+                let deleters =
+                  deleters
+                  |> List.map (fun deleter ->
+                    deleter, Value.Primitive PrimitiveValue.Unit)
+                  |> Map.ofList
+                  |> Ballerina.DSL.Next.StdLib.Map.Model.MapValues.Map
+                  |> MapExt.MapValues
+                  |> Choice6Of7
+                  |> ValueExt
 
 
-              let deleters
-                : Value<
-                    TypeValue<ValueExt<'runtimeContext, 'db, 'customExtension>>,
-                    ValueExt<'runtimeContext, 'db, 'customExtension>
-                   > =
-                Ext(deleters, None)
+                let deleters
+                  : Value<
+                      TypeValue<ValueExt<'runtimeContext, 'db, 'customExtension>>,
+                      ValueExt<'runtimeContext, 'db, 'customExtension>
+                     > =
+                  Ext(deleters, None)
 
-              let doUpdateExpr
-                : RunnableExpr<
-                    ValueExt<'runtimeContext, 'db, 'customExtension>
-                   > =
-                RunnableExpr.UnsafeApplyForUntypedEval(
+                let doUpdateExpr
+                  : RunnableExpr<
+                      ValueExt<'runtimeContext, 'db, 'customExtension>
+                     > =
                   RunnableExpr.UnsafeApplyForUntypedEval(
-                    RunnableExpr.UnsafeLookupForUntypedEval(
-                      Identifier.FullyQualified([ "DB" ], "deleteMany")
-                      |> ResolvedIdentifier.FromIdentifier
+                    RunnableExpr.UnsafeApplyForUntypedEval(
+                      RunnableExpr.UnsafeLookupForUntypedEval(
+                        Identifier.FullyQualified([ "DB" ], "deleteMany")
+                        |> ResolvedIdentifier.FromIdentifier
+                      ),
+                      RunnableExpr.FromValue(
+                        entityDescriptor,
+                        TypeValue.CreatePrimitive PrimitiveType.Unit,
+                        Kind.Star
+                      )
                     ),
                     RunnableExpr.FromValue(
-                      entityDescriptor,
+                      deleters,
                       TypeValue.CreatePrimitive PrimitiveType.Unit,
                       Kind.Star
                     )
-                  ),
-                  RunnableExpr.FromValue(
-                    deleters,
-                    TypeValue.CreatePrimitive PrimitiveType.Unit,
-                    Kind.Star
                   )
-                )
 
-              let! evalResult =
-                Expr.Eval(
-                  NonEmptyList.prependList
-                    languageContext.TypeCheckedPreludes
-                    (NonEmptyList.OfList(doUpdateExpr, []))
-                )
-                |> Reader.Run(
-                  evalContext |> context.PermissionHookInjector httpContext
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                match dataSource with
+                | Some ds ->
+                  let c = ds.OpenConnection()
+                  let t = c.BeginTransaction()
+                  conn.Value <- Some c
+                  txn.Value <- Some t
+                | None -> ()
 
-              return!
-                runDTOConverter languageContext (valueToDTO evalResult)
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
-            }
+                let! evalResult =
+                  Expr.Eval(
+                    NonEmptyList.prependList
+                      languageContext.TypeCheckedPreludes
+                      (NonEmptyList.OfList(doUpdateExpr, []))
+                  )
+                  |> Reader.Run(
+                    evalContext |> context.PermissionHookInjector httpContext
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-          apiResponseFromSum result id)
+                txn.Value |> Option.iter (fun t -> t.Commit())
+                conn.Value |> Option.iter (fun c -> c.Dispose())
+                txn.Value <- None
+                conn.Value <- None
+
+                return!
+                  runDTOConverter languageContext (valueToDTO evalResult)
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+              }
+            apiResponseFromSum result (fun _ -> cleanup()) id
+          with ex ->
+            cleanup()
+            reraise())
     )
     |> ignore

--- a/backend/libraries/ballerina-api/Endpoints/Filter.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Filter.fs
@@ -53,6 +53,6 @@ module Filter =
                      Value = r.JsonValue |})
             }
 
-          apiResponseFromSum result id)
+          apiResponseFromSum result (fun _ -> ()) id)
     )
     |> ignore

--- a/backend/libraries/ballerina-api/Endpoints/Linking.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Linking.fs
@@ -59,7 +59,7 @@ module Linking =
                    languageContext,
                    evalContext,
                    typeCheckContext,
-                   typeCheckState =
+                   typeCheckState, _ =
                 getDbDescriptor tenantId schemaName context
 
               let! fromIdValue =
@@ -223,7 +223,7 @@ module Linking =
                     .Create
             }
 
-          apiResponseFromSum result id)
+          apiResponseFromSum result (fun _ -> ()) id)
     )
     |> ignore
 
@@ -246,7 +246,7 @@ module Linking =
                    languageContext,
                    evalContext,
                    typeCheckContext,
-                   typeCheckState =
+                   typeCheckState, _ =
                 getDbDescriptor tenantId schemaName context
 
               let! fromIdValue =
@@ -409,7 +409,7 @@ module Linking =
                     .Create
             }
 
-          apiResponseFromSum result id)
+          apiResponseFromSum result (fun _ -> ()) id)
     )
     |> ignore
 
@@ -442,7 +442,7 @@ module Linking =
                    languageContext,
                    evalContext,
                    typeCheckContext,
-                   typeCheckState =
+                   typeCheckState, _ =
                 getDbDescriptor tenantId schemaName context
 
               let! fromIdValue =
@@ -624,7 +624,7 @@ module Linking =
                     .Create
             }
 
-          apiResponseFromSum result id)
+          apiResponseFromSum result (fun _ -> ()) id)
     )
     |> ignore
 
@@ -657,7 +657,7 @@ module Linking =
                    languageContext,
                    evalContext,
                    typeCheckContext,
-                   typeCheckState =
+                   typeCheckState, _ =
                 getDbDescriptor tenantId schemaName context
 
               let! fromIdValue =
@@ -840,7 +840,7 @@ module Linking =
                     .Create
             }
 
-          apiResponseFromSum result id)
+          apiResponseFromSum result (fun _ -> ()) id)
     )
     |> ignore
 

--- a/backend/libraries/ballerina-api/Endpoints/OpenAPI.fs
+++ b/backend/libraries/ballerina-api/Endpoints/OpenAPI.fs
@@ -25,7 +25,7 @@ module OpenAPI =
       Func<'tenantId, 'schemaName, IResult>(fun tenantId schemaName ->
         let result =
           sum {
-            let! dbio, _, _, typeCheckContext, typeCheckState = getDbDescriptor tenantId schemaName context
+            let! dbio, _, _, typeCheckContext, typeCheckState, _ = getDbDescriptor tenantId schemaName context
 
             let generationState: OpenAPIGenerationState =
               { DataModel = Map.empty

--- a/backend/libraries/ballerina-api/Endpoints/Read.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Read.fs
@@ -100,7 +100,7 @@ module Read =
 
           let result =
             sum {
-              let! dbio, languageContext, evalContext, typeCheckContext, typeCheckState =
+              let! dbio, languageContext, evalContext, typeCheckContext, typeCheckState, _ =
                 getDbDescriptor tenantId schemaName context
 
               let! idValue =
@@ -158,7 +158,7 @@ module Read =
               return idDTO, resultDTO
             }
 
-          apiResponseFromSum result id)
+          apiResponseFromSum result (fun _ -> ()) id)
     )
     |> ignore
 
@@ -168,7 +168,7 @@ module Read =
         (fun httpContext tenantId schemaName entityName (offset: int) (limit: int) ->
           let result =
             sum {
-              let! dbio, languageContext, evalContext, _, _ = getDbDescriptor tenantId schemaName context
+              let! dbio, languageContext, evalContext, _, _, _ = getDbDescriptor tenantId schemaName context
 
               let! entityDescriptor =
                 entityDescriptorFromDb dbio entityName
@@ -209,7 +209,7 @@ module Read =
               return resultDTO
             }
 
-          apiResponseFromSum result id)
+          apiResponseFromSum result (fun _ -> ()) id)
     )
     |> ignore
 
@@ -226,7 +226,7 @@ module Read =
 
           let result =
             sum {
-              let! dbio, languageContext, evalContext, typeCheckContext, typeCheckState =
+              let! dbio, languageContext, evalContext, typeCheckContext, typeCheckState, _ =
                 getDbDescriptor tenantId schemaName context
 
               let! idValue =
@@ -280,7 +280,7 @@ module Read =
               return resultDTO
             }
 
-          apiResponseFromSum result id)
+          apiResponseFromSum result (fun _ -> ()) id)
     )
     |> ignore
 
@@ -292,7 +292,7 @@ module Read =
           let result =
             sum {
 
-              let! dbio, languageContext, evalContext, typeCheckContext, typeCheckState =
+              let! dbio, languageContext, evalContext, typeCheckContext, typeCheckState, _ =
                 getDbDescriptor tenantId schemaName context
 
               let! idValue =
@@ -351,7 +351,7 @@ module Read =
               return resultDTO
             }
 
-          apiResponseFromSum result id)
+          apiResponseFromSum result (fun _ -> ()) id)
     )
     |> ignore
 
@@ -363,7 +363,7 @@ module Read =
           let result =
             sum {
 
-              let! dbio, languageContext, evalContext, typeCheckContext, typeCheckState =
+              let! dbio, languageContext, evalContext, typeCheckContext, typeCheckState, _ =
                 getDbDescriptor tenantId schemaName context
 
               let! idValue =
@@ -422,7 +422,7 @@ module Read =
               return resultDTO
             }
 
-          apiResponseFromSum result id)
+          apiResponseFromSum result (fun _ -> ()) id)
     )
     |> ignore
 
@@ -433,7 +433,7 @@ module Read =
 
           let result =
             sum {
-              let! dbio, languageContext, evalContext, typeCheckContext, typeCheckState =
+              let! dbio, languageContext, evalContext, typeCheckContext, typeCheckState, _ =
                 getDbDescriptor tenantId schemaName context
 
               let! idValue =
@@ -487,6 +487,6 @@ module Read =
               return resultDTO
             }
 
-          apiResponseFromSum result id)
+          apiResponseFromSum result (fun _ -> ()) id)
     )
     |> ignore

--- a/backend/libraries/ballerina-api/Endpoints/Update.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Update.fs
@@ -28,6 +28,7 @@ module Update =
   open Ballerina.Data.Delta.ToUpdater
   open Ballerina.Data.Delta
   open Ballerina.DSL.Next.StdLib.Updater.Model
+  open Npgsql
 
   [<NoComparison; NoEquality>]
   type UpdateDeltaWithId =
@@ -54,158 +55,182 @@ module Update =
           let entityId = payload.Id
           let delta = payload.Delta
 
-          let result =
-            sum {
-              let! dbio,
-                   languageContext,
-                   evalContext,
-                   typeCheckContext,
-                   typeCheckState =
-                getDbDescriptor tenantId schemaName context
+          let txn : NpgsqlTransaction option ref = ref None
+          let conn : NpgsqlConnection option ref = ref None
+          let cleanup () =
+            txn.Value |> Option.iter (fun t -> try t.Rollback() with _ -> ())
+            conn.Value |> Option.iter (fun c -> try c.Dispose() with _ -> ())
+            txn.Value <- None
+            conn.Value <- None
+          try
+            let result =
+              sum {
+                let! dbio,
+                     languageContext,
+                     evalContext,
+                     typeCheckContext,
+                     typeCheckState,
+                     dataSource =
+                  getDbDescriptor tenantId schemaName context
 
-              let! _tableDescriptor =
-                dbio.Schema.Entities
-                |> OrderedMap.tryFind (entityName |> SchemaEntityName.Create)
-                |> Sum.fromOption (fun () ->
-                  Errors.Singleton Location.Unknown (fun () ->
-                    $"Entity {entityName} not found in schema {dbio.Schema}."))
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! _tableDescriptor =
+                  dbio.Schema.Entities
+                  |> OrderedMap.tryFind (entityName |> SchemaEntityName.Create)
+                  |> Sum.fromOption (fun () ->
+                    Errors.Singleton Location.Unknown (fun () ->
+                      $"Entity {entityName} not found in schema {dbio.Schema}."))
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! schema =
-                dbio.SchemaAsValue
-                |> Value.AsRecord
-                |> toUknonwLocation
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! schema =
+                  dbio.SchemaAsValue
+                  |> Value.AsRecord
+                  |> toUknonwLocation
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! entities =
-                schema
-                |> Map.tryFindWithError
-                  ("Entities"
-                   |> Identifier.LocalScope
-                   |> ResolvedIdentifier.FromIdentifier)
-                  "schema"
-                  (fun () -> "Entities")
-                  Location.Unknown
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entities =
+                  schema
+                  |> Map.tryFindWithError
+                    ("Entities"
+                     |> Identifier.LocalScope
+                     |> ResolvedIdentifier.FromIdentifier)
+                    "schema"
+                    (fun () -> "Entities")
+                    Location.Unknown
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! entities =
-                entities
-                |> Value.AsRecord
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entities =
+                  entities
+                  |> Value.AsRecord
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! entityDescriptor =
-                entities
-                |> Map.tryFindWithError
-                  (entityName
-                   |> Identifier.LocalScope
-                   |> ResolvedIdentifier.FromIdentifier)
-                  "schema"
-                  (fun () -> "Entities")
-                  Location.Unknown
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entityDescriptor =
+                  entities
+                  |> Map.tryFindWithError
+                    (entityName
+                     |> Identifier.LocalScope
+                     |> ResolvedIdentifier.FromIdentifier)
+                    "schema"
+                    (fun () -> "Entities")
+                    Location.Unknown
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! idValue =
-                runDTOConverter languageContext (valueFromDTO entityId)
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! idValue =
+                  runDTOConverter languageContext (valueFromDTO entityId)
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let idType = _tableDescriptor.Id
+                let idType = _tableDescriptor.Id
 
-              do!
-                typeCheckValue
-                  idValue
-                  idType
-                  languageContext
-                  typeCheckContext
-                  typeCheckState
+                do!
+                  typeCheckValue
+                    idValue
+                    idType
+                    languageContext
+                    typeCheckContext
+                    typeCheckState
 
-              let! delta =
-                deltaFromDTO delta
-                |> Reader.Run languageContext.SerializationContext
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! delta =
+                  deltaFromDTO delta
+                  |> Reader.Run languageContext.SerializationContext
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! updaterLambda =
-                createUpdaterFromDelta delta
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! updaterLambda =
+                  createUpdaterFromDelta delta
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let doUpdateExpr
-                : RunnableExpr<
-                    ValueExt<'runtimeContext, 'db, 'customExtension>
-                   > =
+                let doUpdateExpr
+                  : RunnableExpr<
+                      ValueExt<'runtimeContext, 'db, 'customExtension>
+                     > =
 
-                RunnableExpr.UnsafeApplyForUntypedEval(
                   RunnableExpr.UnsafeApplyForUntypedEval(
-                    RunnableExpr.UnsafeLookupForUntypedEval(
-                      Identifier.FullyQualified([ "DB" ], "update")
-                      |> ResolvedIdentifier.FromIdentifier
-                    ),
-                    RunnableExpr.FromValue(
-                      entityDescriptor,
-                      TypeValue.CreatePrimitive PrimitiveType.Unit,
-                      Kind.Star
-                    )
-                  ),
-                  RunnableExpr.UnsafeTupleConsForUntypedEval
-                    [ RunnableExpr.FromValue(
-                        idValue,
+                    RunnableExpr.UnsafeApplyForUntypedEval(
+                      RunnableExpr.UnsafeLookupForUntypedEval(
+                        Identifier.FullyQualified([ "DB" ], "update")
+                        |> ResolvedIdentifier.FromIdentifier
+                      ),
+                      RunnableExpr.FromValue(
+                        entityDescriptor,
                         TypeValue.CreatePrimitive PrimitiveType.Unit,
                         Kind.Star
                       )
-                      RunnableExpr.UnsafeLambdaForUntypedEval(
-                        Var.Create "_",
-                        TypeValue.CreatePrimitive PrimitiveType.Unit,
-                        updaterLambda,
-                        TypeValue.CreatePrimitive PrimitiveType.Unit
-                      ) ]
-                )
+                    ),
+                    RunnableExpr.UnsafeTupleConsForUntypedEval
+                      [ RunnableExpr.FromValue(
+                          idValue,
+                          TypeValue.CreatePrimitive PrimitiveType.Unit,
+                          Kind.Star
+                        )
+                        RunnableExpr.UnsafeLambdaForUntypedEval(
+                          Var.Create "_",
+                          TypeValue.CreatePrimitive PrimitiveType.Unit,
+                          updaterLambda,
+                          TypeValue.CreatePrimitive PrimitiveType.Unit
+                        ) ]
+                  )
 
-              let! evalResult =
-                Expr.Eval(
-                  NonEmptyList.prependList
-                    languageContext.TypeCheckedPreludes
-                    (NonEmptyList.OfList(doUpdateExpr, []))
-                )
-                |> Reader.Run(
-                  evalContext |> context.PermissionHookInjector httpContext
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                match dataSource with
+                | Some ds ->
+                  let c = ds.OpenConnection()
+                  let t = c.BeginTransaction()
+                  conn.Value <- Some c
+                  txn.Value <- Some t
+                | None -> ()
 
-              let! result =
-                runDTOConverter languageContext (valueToDTO evalResult)
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! evalResult =
+                  Expr.Eval(
+                    NonEmptyList.prependList
+                      languageContext.TypeCheckedPreludes
+                      (NonEmptyList.OfList(doUpdateExpr, []))
+                  )
+                  |> Reader.Run(
+                    evalContext |> context.PermissionHookInjector httpContext
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              return result
-            }
+                txn.Value |> Option.iter (fun t -> t.Commit())
+                conn.Value |> Option.iter (fun c -> c.Dispose())
+                txn.Value <- None
+                conn.Value <- None
 
-          apiResponseFromSum result id)
+                let! result =
+                  runDTOConverter languageContext (valueToDTO evalResult)
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+
+                return result
+              }
+            apiResponseFromSum result (fun _ -> cleanup()) id
+          with ex ->
+            cleanup()
+            reraise())
     )
     |> ignore
 
@@ -220,170 +245,194 @@ module Update =
         IResult
        >
         (fun httpContext tenantId schemaName entityName payload ->
-          let result =
-            sum {
-              let! dbio,
-                   languageContext,
-                   evalContext,
-                   typeCheckContext,
-                   typeCheckState =
-                getDbDescriptor tenantId schemaName context
+          let txn : NpgsqlTransaction option ref = ref None
+          let conn : NpgsqlConnection option ref = ref None
+          let cleanup () =
+            txn.Value |> Option.iter (fun t -> try t.Rollback() with _ -> ())
+            conn.Value |> Option.iter (fun c -> try c.Dispose() with _ -> ())
+            txn.Value <- None
+            conn.Value <- None
+          try
+            let result =
+              sum {
+                let! dbio,
+                     languageContext,
+                     evalContext,
+                     typeCheckContext,
+                     typeCheckState,
+                     dataSource =
+                  getDbDescriptor tenantId schemaName context
 
-              let! _tableDescriptor =
-                dbio.Schema.Entities
-                |> OrderedMap.tryFind (entityName |> SchemaEntityName.Create)
-                |> Sum.fromOption (fun () ->
-                  Errors.Singleton Location.Unknown (fun () ->
-                    $"Entity {entityName} not found in schema {dbio.Schema}."))
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! _tableDescriptor =
+                  dbio.Schema.Entities
+                  |> OrderedMap.tryFind (entityName |> SchemaEntityName.Create)
+                  |> Sum.fromOption (fun () ->
+                    Errors.Singleton Location.Unknown (fun () ->
+                      $"Entity {entityName} not found in schema {dbio.Schema}."))
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! schema =
-                dbio.SchemaAsValue
-                |> Value.AsRecord
-                |> toUknonwLocation
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! schema =
+                  dbio.SchemaAsValue
+                  |> Value.AsRecord
+                  |> toUknonwLocation
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! entities =
-                schema
-                |> Map.tryFindWithError
-                  ("Entities"
-                   |> Identifier.LocalScope
-                   |> ResolvedIdentifier.FromIdentifier)
-                  "schema"
-                  (fun () -> "Entities")
-                  Location.Unknown
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entities =
+                  schema
+                  |> Map.tryFindWithError
+                    ("Entities"
+                     |> Identifier.LocalScope
+                     |> ResolvedIdentifier.FromIdentifier)
+                    "schema"
+                    (fun () -> "Entities")
+                    Location.Unknown
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! entities =
-                entities
-                |> Value.AsRecord
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entities =
+                  entities
+                  |> Value.AsRecord
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! entityDescriptor =
-                entities
-                |> Map.tryFindWithError
-                  (entityName
-                   |> Identifier.LocalScope
-                   |> ResolvedIdentifier.FromIdentifier)
-                  "schema"
-                  (fun () -> "Entities")
-                  Location.Unknown
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entityDescriptor =
+                  entities
+                  |> Map.tryFindWithError
+                    (entityName
+                     |> Identifier.LocalScope
+                     |> ResolvedIdentifier.FromIdentifier)
+                    "schema"
+                    (fun () -> "Entities")
+                    Location.Unknown
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! updaters =
-                payload
-                |> Array.map (fun updater ->
-                  reader {
-                    let! delta = deltaFromDTO updater.Delta
+                let! updaters =
+                  payload
+                  |> Array.map (fun updater ->
+                    reader {
+                      let! delta = deltaFromDTO updater.Delta
 
-                    let! idValue =
-                      valueFromDTO updater.Id
-                      |> reader.MapContext(fun deltaSerializationContext ->
-                        deltaSerializationContext.SerializationContext)
+                      let! idValue =
+                        valueFromDTO updater.Id
+                        |> reader.MapContext(fun deltaSerializationContext ->
+                          deltaSerializationContext.SerializationContext)
 
-                    let! updaterLambda =
-                      createUpdaterFromDelta delta |> reader.OfSum
+                      let! updaterLambda =
+                        createUpdaterFromDelta delta |> reader.OfSum
 
-                    return
-                      idValue,
-                      Value.Lambda(
-                        Var.Create "_",
-                        updaterLambda,
-                        Map.empty,
-                        TypeCheckScope.Empty
-                      )
-                  })
-                |> reader.All
-                |> Reader.Run languageContext.SerializationContext
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                      return
+                        idValue,
+                        Value.Lambda(
+                          Var.Create "_",
+                          updaterLambda,
+                          Map.empty,
+                          TypeCheckScope.Empty
+                        )
+                    })
+                  |> reader.All
+                  |> Reader.Run languageContext.SerializationContext
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let idType = _tableDescriptor.Id
+                let idType = _tableDescriptor.Id
 
-              do!
-                updaters
-                |> List.map (fun (idValue, _) ->
-                  typeCheckValue
-                    idValue
-                    idType
-                    languageContext
-                    typeCheckContext
-                    typeCheckState)
-                |> Sum.All
-                |> Sum.map (fun _ -> ())
+                do!
+                  updaters
+                  |> List.map (fun (idValue, _) ->
+                    typeCheckValue
+                      idValue
+                      idType
+                      languageContext
+                      typeCheckContext
+                      typeCheckState)
+                  |> Sum.All
+                  |> Sum.map (fun _ -> ())
 
-              let updaters =
-                updaters
-                |> Map.ofList
-                |> Ballerina.DSL.Next.StdLib.Map.Model.MapValues.Map
-                |> MapExt.MapValues
-                |> Choice6Of7
-                |> ValueExt
+                let updaters =
+                  updaters
+                  |> Map.ofList
+                  |> Ballerina.DSL.Next.StdLib.Map.Model.MapValues.Map
+                  |> MapExt.MapValues
+                  |> Choice6Of7
+                  |> ValueExt
 
-              let updaters = Value.Ext(updaters, None)
+                let updaters = Value.Ext(updaters, None)
 
-              let doUpdateExpr
-                : RunnableExpr<
-                    ValueExt<'runtimeContext, 'db, 'customExtension>
-                   > =
-                RunnableExpr.UnsafeApplyForUntypedEval(
+                let doUpdateExpr
+                  : RunnableExpr<
+                      ValueExt<'runtimeContext, 'db, 'customExtension>
+                     > =
                   RunnableExpr.UnsafeApplyForUntypedEval(
-                    RunnableExpr.UnsafeLookupForUntypedEval(
-                      Identifier.FullyQualified([ "DB" ], "updateMany")
-                      |> ResolvedIdentifier.FromIdentifier
+                    RunnableExpr.UnsafeApplyForUntypedEval(
+                      RunnableExpr.UnsafeLookupForUntypedEval(
+                        Identifier.FullyQualified([ "DB" ], "updateMany")
+                        |> ResolvedIdentifier.FromIdentifier
+                      ),
+                      RunnableExpr.FromValue(
+                        entityDescriptor,
+                        TypeValue.CreatePrimitive PrimitiveType.Unit,
+                        Kind.Star
+                      )
                     ),
                     RunnableExpr.FromValue(
-                      entityDescriptor,
+                      updaters,
                       TypeValue.CreatePrimitive PrimitiveType.Unit,
                       Kind.Star
                     )
-                  ),
-                  RunnableExpr.FromValue(
-                    updaters,
-                    TypeValue.CreatePrimitive PrimitiveType.Unit,
-                    Kind.Star
                   )
-                )
 
-              let! evalResult =
-                Expr.Eval(
-                  NonEmptyList.prependList
-                    languageContext.TypeCheckedPreludes
-                    (NonEmptyList.OfList(doUpdateExpr, []))
-                )
-                |> Reader.Run(
-                  evalContext |> context.PermissionHookInjector httpContext
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                match dataSource with
+                | Some ds ->
+                  let c = ds.OpenConnection()
+                  let t = c.BeginTransaction()
+                  conn.Value <- Some c
+                  txn.Value <- Some t
+                | None -> ()
 
-              let! result =
-                runDTOConverter languageContext (valueToDTO evalResult)
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! evalResult =
+                  Expr.Eval(
+                    NonEmptyList.prependList
+                      languageContext.TypeCheckedPreludes
+                      (NonEmptyList.OfList(doUpdateExpr, []))
+                  )
+                  |> Reader.Run(
+                    evalContext |> context.PermissionHookInjector httpContext
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              return result
-            }
+                txn.Value |> Option.iter (fun t -> t.Commit())
+                conn.Value |> Option.iter (fun c -> c.Dispose())
+                txn.Value <- None
+                conn.Value <- None
 
-          apiResponseFromSum result id)
+                let! result =
+                  runDTOConverter languageContext (valueToDTO evalResult)
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+
+                return result
+              }
+            apiResponseFromSum result (fun _ -> cleanup()) id
+          with ex ->
+            cleanup()
+            reraise())
     )
     |> ignore

--- a/backend/libraries/ballerina-api/Endpoints/Upsert.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Upsert.fs
@@ -24,6 +24,7 @@ module Upsert =
   open Ballerina.DSL.Next.StdLib.DB
   open Ballerina.Data.Delta.Serialization.DeltaDTO
   open Ballerina.Data.Delta.Serialization.DeltaDeserializer
+  open Npgsql
 
   [<NoComparison; NoEquality>]
   type EntityWithId =
@@ -49,177 +50,202 @@ module Upsert =
         IResult
        >
         (fun httpContext tenantId schemaName entityName payload ->
-          let result =
-            sum {
-              let id, entity, delta = payload.Id, payload.Entity, payload.Delta
+          let txn : NpgsqlTransaction option ref = ref None
+          let conn : NpgsqlConnection option ref = ref None
+          let cleanup () =
+            txn.Value |> Option.iter (fun t -> try t.Rollback() with _ -> ())
+            conn.Value |> Option.iter (fun c -> try c.Dispose() with _ -> ())
+            txn.Value <- None
+            conn.Value <- None
+          try
+            let result =
+              sum {
+                let id, entity, delta = payload.Id, payload.Entity, payload.Delta
 
-              let! dbio,
-                   languageContext,
-                   evalContext,
-                   typeCheckContext,
-                   typeCheckState =
-                getDbDescriptor tenantId schemaName context
+                let! dbio,
+                     languageContext,
+                     evalContext,
+                     typeCheckContext,
+                     typeCheckState,
+                     dataSource =
+                  getDbDescriptor tenantId schemaName context
 
-              let! _tableDescriptor =
-                dbio.Schema.Entities
-                |> OrderedMap.tryFind (entityName |> SchemaEntityName.Create)
-                |> Sum.fromOption (fun () ->
-                  Errors<Location>.Singleton Location.Unknown (fun () ->
-                    $"Entity {entityName} not found in schema {dbio.Schema}."))
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! _tableDescriptor =
+                  dbio.Schema.Entities
+                  |> OrderedMap.tryFind (entityName |> SchemaEntityName.Create)
+                  |> Sum.fromOption (fun () ->
+                    Errors<Location>.Singleton Location.Unknown (fun () ->
+                      $"Entity {entityName} not found in schema {dbio.Schema}."))
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! idValue =
-                valueFromDTO >> runDTOConverter languageContext <| id
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! idValue =
+                  valueFromDTO >> runDTOConverter languageContext <| id
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! entityValue =
-                valueFromDTO >> runDTOConverter languageContext <| entity
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entityValue =
+                  valueFromDTO >> runDTOConverter languageContext <| entity
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let idType, entityType =
-                _tableDescriptor.Id, _tableDescriptor.TypeOriginal
+                let idType, entityType =
+                  _tableDescriptor.Id, _tableDescriptor.TypeOriginal
 
-              do!
-                typeCheckValue
-                  idValue
-                  idType
-                  languageContext
-                  typeCheckContext
-                  typeCheckState
+                do!
+                  typeCheckValue
+                    idValue
+                    idType
+                    languageContext
+                    typeCheckContext
+                    typeCheckState
 
-              do!
-                typeCheckValue
-                  entityValue
-                  entityType
-                  languageContext
-                  typeCheckContext
-                  typeCheckState
+                do!
+                  typeCheckValue
+                    entityValue
+                    entityType
+                    languageContext
+                    typeCheckContext
+                    typeCheckState
 
-              let! delta =
-                deltaFromDTO delta
-                |> Reader.Run languageContext.SerializationContext
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! delta =
+                  deltaFromDTO delta
+                  |> Reader.Run languageContext.SerializationContext
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! updaterLambda =
-                createUpdaterFromDelta delta
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! updaterLambda =
+                  createUpdaterFromDelta delta
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! schema =
-                dbio.SchemaAsValue
-                |> Value.AsRecord
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                  >> APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
-                )
+                let! schema =
+                  dbio.SchemaAsValue
+                  |> Value.AsRecord
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                    >> APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+                  )
 
-              let! entities =
-                schema
-                |> Map.tryFindWithError
-                  ("Entities"
-                   |> Identifier.LocalScope
-                   |> ResolvedIdentifier.FromIdentifier)
-                  "schema"
-                  (fun () -> "Entities")
-                  Location.Unknown
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entities =
+                  schema
+                  |> Map.tryFindWithError
+                    ("Entities"
+                     |> Identifier.LocalScope
+                     |> ResolvedIdentifier.FromIdentifier)
+                    "schema"
+                    (fun () -> "Entities")
+                    Location.Unknown
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! entities =
-                entities
-                |> Value.AsRecord
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                  >> APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
-                )
+                let! entities =
+                  entities
+                  |> Value.AsRecord
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                    >> APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+                  )
 
-              let! entityDescriptor =
-                entities
-                |> Map.tryFindWithError
-                  (entityName
-                   |> Identifier.LocalScope
-                   |> ResolvedIdentifier.FromIdentifier)
-                  "schema"
-                  (fun () -> "Entities")
-                  Location.Unknown
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entityDescriptor =
+                  entities
+                  |> Map.tryFindWithError
+                    (entityName
+                     |> Identifier.LocalScope
+                     |> ResolvedIdentifier.FromIdentifier)
+                    "schema"
+                    (fun () -> "Entities")
+                    Location.Unknown
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let doUpsertExpr
-                : RunnableExpr<
-                    ValueExt<'runtimeContext, 'db, 'customExtension>
-                   > =
-                RunnableExpr.UnsafeApplyForUntypedEval(
+                let doUpsertExpr
+                  : RunnableExpr<
+                      ValueExt<'runtimeContext, 'db, 'customExtension>
+                     > =
                   RunnableExpr.UnsafeApplyForUntypedEval(
-                    RunnableExpr.UnsafeLookupForUntypedEval(
-                      Identifier.FullyQualified([ "DB" ], "upsert")
-                      |> ResolvedIdentifier.FromIdentifier
-                    ),
-                    RunnableExpr.FromValue(
-                      entityDescriptor,
-                      TypeValue.CreatePrimitive PrimitiveType.Unit,
-                      Kind.Star
-                    )
-                  ),
-                  RunnableExpr.UnsafeTupleConsForUntypedEval
-                    [ RunnableExpr.FromValue(
-                        idValue,
-                        TypeValue.CreatePrimitive PrimitiveType.Unit,
-                        Kind.Star
-                      )
+                    RunnableExpr.UnsafeApplyForUntypedEval(
+                      RunnableExpr.UnsafeLookupForUntypedEval(
+                        Identifier.FullyQualified([ "DB" ], "upsert")
+                        |> ResolvedIdentifier.FromIdentifier
+                      ),
                       RunnableExpr.FromValue(
-                        entityValue,
+                        entityDescriptor,
                         TypeValue.CreatePrimitive PrimitiveType.Unit,
                         Kind.Star
                       )
-                      RunnableExpr.UnsafeLambdaForUntypedEval(
-                        Var.Create "_",
-                        TypeValue.CreatePrimitive PrimitiveType.Unit,
-                        updaterLambda,
-                        TypeValue.CreatePrimitive PrimitiveType.Unit
-                      ) ]
-                )
+                    ),
+                    RunnableExpr.UnsafeTupleConsForUntypedEval
+                      [ RunnableExpr.FromValue(
+                          idValue,
+                          TypeValue.CreatePrimitive PrimitiveType.Unit,
+                          Kind.Star
+                        )
+                        RunnableExpr.FromValue(
+                          entityValue,
+                          TypeValue.CreatePrimitive PrimitiveType.Unit,
+                          Kind.Star
+                        )
+                        RunnableExpr.UnsafeLambdaForUntypedEval(
+                          Var.Create "_",
+                          TypeValue.CreatePrimitive PrimitiveType.Unit,
+                          updaterLambda,
+                          TypeValue.CreatePrimitive PrimitiveType.Unit
+                        ) ]
+                  )
 
-              let! evalResult =
-                Expr.Eval(
-                  NonEmptyList.prependList
-                    languageContext.TypeCheckedPreludes
-                    (NonEmptyList.OfList(doUpsertExpr, []))
-                )
-                |> Reader.Run(
-                  evalContext |> context.PermissionHookInjector httpContext
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                match dataSource with
+                | Some ds ->
+                  let c = ds.OpenConnection()
+                  let t = c.BeginTransaction()
+                  conn.Value <- Some c
+                  txn.Value <- Some t
+                | None -> ()
 
-              return!
-                valueToDTO >> runDTOConverter languageContext <| evalResult
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
-            }
+                let! evalResult =
+                  Expr.Eval(
+                    NonEmptyList.prependList
+                      languageContext.TypeCheckedPreludes
+                      (NonEmptyList.OfList(doUpsertExpr, []))
+                  )
+                  |> Reader.Run(
+                    evalContext |> context.PermissionHookInjector httpContext
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-          apiResponseFromSum result id)
+                txn.Value |> Option.iter (fun t -> t.Commit())
+                conn.Value |> Option.iter (fun c -> c.Dispose())
+                txn.Value <- None
+                conn.Value <- None
+
+                return!
+                  valueToDTO >> runDTOConverter languageContext <| evalResult
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+              }
+
+            apiResponseFromSum result (fun _ -> cleanup()) id
+          with ex ->
+            cleanup()
+            reraise())
     )
     |> ignore
 
@@ -234,204 +260,229 @@ module Upsert =
         IResult
        >
         (fun httpContext tenantId schemaName entityName payload ->
-          let result =
-            sum {
+          let txn : NpgsqlTransaction option ref = ref None
+          let conn : NpgsqlConnection option ref = ref None
+          let cleanup () =
+            txn.Value |> Option.iter (fun t -> try t.Rollback() with _ -> ())
+            conn.Value |> Option.iter (fun c -> try c.Dispose() with _ -> ())
+            txn.Value <- None
+            conn.Value <- None
+          try
+            let result =
+              sum {
 
-              let! dbio,
-                   languageContext,
-                   evalContext,
-                   typeCheckContext,
-                   typeCheckState =
-                getDbDescriptor tenantId schemaName context
+                let! dbio,
+                     languageContext,
+                     evalContext,
+                     typeCheckContext,
+                     typeCheckState,
+                     dataSource =
+                  getDbDescriptor tenantId schemaName context
 
-              let! _tableDescriptor =
-                dbio.Schema.Entities
-                |> OrderedMap.tryFind (entityName |> SchemaEntityName.Create)
-                |> Sum.fromOption (fun () ->
-                  Errors<Location>.Singleton Location.Unknown (fun () ->
-                    $"Entity {entityName} not found in schema {dbio.Schema}."))
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! _tableDescriptor =
+                  dbio.Schema.Entities
+                  |> OrderedMap.tryFind (entityName |> SchemaEntityName.Create)
+                  |> Sum.fromOption (fun () ->
+                    Errors<Location>.Singleton Location.Unknown (fun () ->
+                      $"Entity {entityName} not found in schema {dbio.Schema}."))
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! schema =
-                dbio.SchemaAsValue
-                |> Value.AsRecord
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                  >> APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
-                )
+                let! schema =
+                  dbio.SchemaAsValue
+                  |> Value.AsRecord
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                    >> APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+                  )
 
-              let! entities =
-                schema
-                |> Map.tryFindWithError
-                  ("Entities"
-                   |> Identifier.LocalScope
-                   |> ResolvedIdentifier.FromIdentifier)
-                  "schema"
-                  (fun () -> "Entities")
-                  Location.Unknown
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entities =
+                  schema
+                  |> Map.tryFindWithError
+                    ("Entities"
+                     |> Identifier.LocalScope
+                     |> ResolvedIdentifier.FromIdentifier)
+                    "schema"
+                    (fun () -> "Entities")
+                    Location.Unknown
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! entities =
-                entities
-                |> Value.AsRecord
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                  >> APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
-                )
+                let! entities =
+                  entities
+                  |> Value.AsRecord
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                    >> APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+                  )
 
-              let! entityDescriptor =
-                entities
-                |> Map.tryFindWithError
-                  (entityName
-                   |> Identifier.LocalScope
-                   |> ResolvedIdentifier.FromIdentifier)
-                  "schema"
-                  (fun () -> "Entities")
-                  Location.Unknown
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                let! entityDescriptor =
+                  entities
+                  |> Map.tryFindWithError
+                    (entityName
+                     |> Identifier.LocalScope
+                     |> ResolvedIdentifier.FromIdentifier)
+                    "schema"
+                    (fun () -> "Entities")
+                    Location.Unknown
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let! upserters =
-                payload
-                |> Array.map (fun entityWithId ->
-                  reader {
-                    let! delta = deltaFromDTO entityWithId.Delta
+                let! upserters =
+                  payload
+                  |> Array.map (fun entityWithId ->
+                    reader {
+                      let! delta = deltaFromDTO entityWithId.Delta
 
-                    let! idValue =
-                      valueFromDTO entityWithId.Id
-                      |> reader.MapContext(fun deltaSerializationContext ->
-                        deltaSerializationContext.SerializationContext)
+                      let! idValue =
+                        valueFromDTO entityWithId.Id
+                        |> reader.MapContext(fun deltaSerializationContext ->
+                          deltaSerializationContext.SerializationContext)
 
-                    let! entityValue =
-                      valueFromDTO entityWithId.Entity
-                      |> reader.MapContext(fun deltaSerializationContext ->
-                        deltaSerializationContext.SerializationContext)
+                      let! entityValue =
+                        valueFromDTO entityWithId.Entity
+                        |> reader.MapContext(fun deltaSerializationContext ->
+                          deltaSerializationContext.SerializationContext)
 
-                    let! updaterLambda =
-                      createUpdaterFromDelta delta |> reader.OfSum
+                      let! updaterLambda =
+                        createUpdaterFromDelta delta |> reader.OfSum
 
 
-                    return
-                      idValue,
-                      Value.Tuple
-                        [ entityValue
-                          Value.Lambda(
-                            Var.Create "_",
-                            updaterLambda,
-                            Map.empty,
-                            TypeCheckScope.Empty
-                          ) ]
-                  })
-                |> reader.All
-                |> Reader.Run languageContext.SerializationContext
-                |> sum.MapError(
-                  Errors.MapContext(replaceWith Location.Unknown)
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                      return
+                        idValue,
+                        Value.Tuple
+                          [ entityValue
+                            Value.Lambda(
+                              Var.Create "_",
+                              updaterLambda,
+                              Map.empty,
+                              TypeCheckScope.Empty
+                            ) ]
+                    })
+                  |> reader.All
+                  |> Reader.Run languageContext.SerializationContext
+                  |> sum.MapError(
+                    Errors.MapContext(replaceWith Location.Unknown)
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-              let idType, entityType =
-                _tableDescriptor.Id, _tableDescriptor.TypeOriginal
+                let idType, entityType =
+                  _tableDescriptor.Id, _tableDescriptor.TypeOriginal
 
-              do!
-                upserters
-                |> List.map (fun (idValue, ballerinaTuple) ->
-                  sum {
-                    match ballerinaTuple with
-                    | Value.Tuple(entityValue :: _) ->
-                      do!
-                        typeCheckValue
-                          idValue
-                          idType
-                          languageContext
-                          typeCheckContext
-                          typeCheckState
+                do!
+                  upserters
+                  |> List.map (fun (idValue, ballerinaTuple) ->
+                    sum {
+                      match ballerinaTuple with
+                      | Value.Tuple(entityValue :: _) ->
+                        do!
+                          typeCheckValue
+                            idValue
+                            idType
+                            languageContext
+                            typeCheckContext
+                            typeCheckState
 
-                      do!
-                        typeCheckValue
-                          entityValue
-                          entityType
-                          languageContext
-                          typeCheckContext
-                          typeCheckState
-                    | _ ->
-                      return!
-                        sum.Throw(
-                          Errors.Singleton Location.Unknown (fun _ ->
-                            "Malformed upsert lambda parameter.")
-                        )
-                        |> sum.MapError
-                          APIError<
-                            'runtimeContext,
-                            'db,
-                            'customExtension,
-                            Location
-                           >.Create
-                  })
-                |> Sum.All
-                |> Sum.map (fun _ -> ())
+                        do!
+                          typeCheckValue
+                            entityValue
+                            entityType
+                            languageContext
+                            typeCheckContext
+                            typeCheckState
+                      | _ ->
+                        return!
+                          sum.Throw(
+                            Errors.Singleton Location.Unknown (fun _ ->
+                              "Malformed upsert lambda parameter.")
+                          )
+                          |> sum.MapError
+                            APIError<
+                              'runtimeContext,
+                              'db,
+                              'customExtension,
+                              Location
+                             >.Create
+                    })
+                  |> Sum.All
+                  |> Sum.map (fun _ -> ())
 
-              let upserters =
-                upserters
-                |> Map.ofList
-                |> Ballerina.DSL.Next.StdLib.Map.Model.MapValues.Map
-                |> MapExt.MapValues
-                |> Choice6Of7
-                |> ValueExt
+                let upserters =
+                  upserters
+                  |> Map.ofList
+                  |> Ballerina.DSL.Next.StdLib.Map.Model.MapValues.Map
+                  |> MapExt.MapValues
+                  |> Choice6Of7
+                  |> ValueExt
 
-              let upserters = Value.Ext(upserters, None)
+                let upserters = Value.Ext(upserters, None)
 
-              let doUpdateExpr
-                : RunnableExpr<
-                    ValueExt<'runtimeContext, 'db, 'customExtension>
-                   > =
-                RunnableExpr.UnsafeApplyForUntypedEval(
+                let doUpdateExpr
+                  : RunnableExpr<
+                      ValueExt<'runtimeContext, 'db, 'customExtension>
+                     > =
                   RunnableExpr.UnsafeApplyForUntypedEval(
-                    RunnableExpr.UnsafeLookupForUntypedEval(
-                      Identifier.FullyQualified([ "DB" ], "upsertMany")
-                      |> ResolvedIdentifier.FromIdentifier
+                    RunnableExpr.UnsafeApplyForUntypedEval(
+                      RunnableExpr.UnsafeLookupForUntypedEval(
+                        Identifier.FullyQualified([ "DB" ], "upsertMany")
+                        |> ResolvedIdentifier.FromIdentifier
+                      ),
+                      RunnableExpr.FromValue(
+                        entityDescriptor,
+                        TypeValue.CreatePrimitive PrimitiveType.Unit,
+                        Kind.Star
+                      )
                     ),
                     RunnableExpr.FromValue(
-                      entityDescriptor,
+                      upserters,
                       TypeValue.CreatePrimitive PrimitiveType.Unit,
                       Kind.Star
                     )
-                  ),
-                  RunnableExpr.FromValue(
-                    upserters,
-                    TypeValue.CreatePrimitive PrimitiveType.Unit,
-                    Kind.Star
                   )
-                )
 
-              let! evalResult =
-                Expr.Eval(
-                  NonEmptyList.prependList
-                    languageContext.TypeCheckedPreludes
-                    (NonEmptyList.OfList(doUpdateExpr, []))
-                )
-                |> Reader.Run(
-                  evalContext |> context.PermissionHookInjector httpContext
-                )
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
+                match dataSource with
+                | Some ds ->
+                  let c = ds.OpenConnection()
+                  let t = c.BeginTransaction()
+                  conn.Value <- Some c
+                  txn.Value <- Some t
+                | None -> ()
 
-              return!
-                valueToDTO >> runDTOConverter languageContext <| evalResult
-                |> sum.MapError
-                  APIError<'runtimeContext, 'db, 'customExtension, Location>
-                    .Create
-            }
+                let! evalResult =
+                  Expr.Eval(
+                    NonEmptyList.prependList
+                      languageContext.TypeCheckedPreludes
+                      (NonEmptyList.OfList(doUpdateExpr, []))
+                  )
+                  |> Reader.Run(
+                    evalContext |> context.PermissionHookInjector httpContext
+                  )
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
 
-          apiResponseFromSum result id)
+                txn.Value |> Option.iter (fun t -> t.Commit())
+                conn.Value |> Option.iter (fun c -> c.Dispose())
+                txn.Value <- None
+                conn.Value <- None
+
+                return!
+                  valueToDTO >> runDTOConverter languageContext <| evalResult
+                  |> sum.MapError
+                    APIError<'runtimeContext, 'db, 'customExtension, Location>
+                      .Create
+              }
+
+            apiResponseFromSum result (fun _ -> cleanup()) id
+          with ex ->
+            cleanup()
+            reraise())
     )
     |> ignore

--- a/backend/libraries/ballerina-api/Model/Model.fs
+++ b/backend/libraries/ballerina-api/Model/Model.fs
@@ -13,6 +13,7 @@ open Ballerina.DSL.Next.Terms.Eval
 open Ballerina.DSL.Next.StdLib.DB
 open Ballerina.Fun
 open Microsoft.AspNetCore.Http
+open Npgsql
 
 [<NoComparison; NoEquality>]
 type APITypeError<'runtimeContext, 'db, 'customExtension
@@ -71,7 +72,8 @@ type DbDescriptor<'runtimeContext, 'db, 'customExtension
         ValueExtDTO,
         DeltaExt<'runtimeContext, 'db, 'customExtension>,
         DeltaExtDTO
-       > }
+       >
+    DataSource: Option<NpgsqlDataSource> }
 
 type TenantDescriptor<'tenantId, 'schemaName> =
   { TenantId: 'tenantId

--- a/backend/libraries/ballerina-api/ballerina-api.fsproj
+++ b/backend/libraries/ballerina-api/ballerina-api.fsproj
@@ -30,4 +30,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Npgsql" Version="10.0.2" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
- Add DataSource: Option<NpgsqlDataSource> to DbDescriptor
- Wrap create, update, delete, upsert endpoints in NpgsqlTransaction
- Add OnFail callback to apiResponseFromSum for transaction rollback
- Update getDbDescriptor to return 6-tuple with dataSource
- Add Npgsql 10.0.2 package reference
- Update MemoryDBFactory with DataSource = None
- Update non-mutation endpoints for new signatures