### PR TITLE
Simplify Co::show, add Co::mapContext and Co::mapState

### DIFF
--- a/backend/libraries/ballerina-lang/Next/Stdlib/Coroutine/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Coroutine/Extension.fs
@@ -14,6 +14,8 @@ module Extension =
     | Co_Show
     | Co_Until
     | Co_Ignore
+    | Co_MapContext
+    | Co_MapState
 
   let CoroutineExtension<'runtimeContext, 'ext, 'extDTO, 'deltaExt, 'deltaExtDTO
     when 'ext: comparison
@@ -66,14 +68,12 @@ module Extension =
           Arguments = [ schema; ctx; st; res ] }
 
     // --- Co::show ---
-    // show : Λschema::Schema. Λctx::*. Λst::*. Λi::*. Λs::*. Λo::*.
-    //   i -> s -> (s -> () + o) -> Frontend::View[schema][i][s] -> Co[schema][ctx][st][o]
+    // show : Λschema::Schema. Λctx::*. Λst::*. Λo::*.
+    //   (st -> () + o) -> Frontend::View[schema][ctx][st] -> Co[schema][ctx][st][o]
     let showId =
       Identifier.FullyQualified([ "Co" ], "show")
       |> TypeCheckScope.Empty.Resolve
 
-    let _iVar, iKind = TypeVar.Create("i"), Kind.Star
-    let _sVar, sKind = TypeVar.Create("s"), Kind.Star
     let _oVar, oKind = TypeVar.Create("o"), Kind.Star
 
     let showOperation
@@ -88,49 +88,37 @@ module Extension =
               TypeExpr.Lambda(
                 TypeParameter.Create("st", stKind),
                 TypeExpr.Lambda(
-                  TypeParameter.Create("i", iKind),
-                  TypeExpr.Lambda(
-                    TypeParameter.Create("s", sKind),
-                    TypeExpr.Lambda(
-                      TypeParameter.Create("o", oKind),
-                      TypeExpr.Arrow(
-                        TypeExpr.Lookup(Identifier.LocalScope "i"),
-                        TypeExpr.Arrow(
-                          TypeExpr.Lookup(Identifier.LocalScope "s"),
-                          TypeExpr.Arrow(
-                            TypeExpr.Arrow(
-                              TypeExpr.Lookup(Identifier.LocalScope "s"),
-                            TypeExpr.Sum
-                              [ TypeExpr.Primitive PrimitiveType.Unit
-                                TypeExpr.Lookup(Identifier.LocalScope "o") ]
+                  TypeParameter.Create("o", oKind),
+                  TypeExpr.Arrow(
+                    TypeExpr.Arrow(
+                      TypeExpr.Lookup(Identifier.LocalScope "st"),
+                      TypeExpr.Sum
+                        [ TypeExpr.Primitive PrimitiveType.Unit
+                          TypeExpr.Lookup(Identifier.LocalScope "o") ]
+                    ),
+                    TypeExpr.Arrow(
+                      TypeExpr.Apply(
+                        TypeExpr.Apply(
+                          TypeExpr.Apply(
+                            TypeExpr.Lookup viewTypeId,
+                            TypeExpr.Lookup(Identifier.LocalScope "schema")
+                          ),
+                          TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                        ),
+                        TypeExpr.Lookup(Identifier.LocalScope "st")
+                      ),
+                      TypeExpr.Apply(
+                        TypeExpr.Apply(
+                          TypeExpr.Apply(
+                            TypeExpr.Apply(
+                              TypeExpr.Lookup(Identifier.LocalScope "Co"),
+                              TypeExpr.Lookup(Identifier.LocalScope "schema")
                             ),
-                            TypeExpr.Arrow(
-                              TypeExpr.Apply(
-                                TypeExpr.Apply(
-                                  TypeExpr.Apply(
-                                    TypeExpr.Lookup viewTypeId,
-                                    TypeExpr.Lookup(Identifier.LocalScope "schema")
-                                  ),
-                                  TypeExpr.Lookup(Identifier.LocalScope "i")
-                                ),
-                                TypeExpr.Lookup(Identifier.LocalScope "s")
-                              ),
-                              TypeExpr.Apply(
-                                TypeExpr.Apply(
-                                  TypeExpr.Apply(
-                                    TypeExpr.Apply(
-                                      TypeExpr.Lookup(Identifier.LocalScope "Co"),
-                                      TypeExpr.Lookup(Identifier.LocalScope "schema")
-                                    ),
-                                    TypeExpr.Lookup(Identifier.LocalScope "ctx")
-                                  ),
-                                  TypeExpr.Lookup(Identifier.LocalScope "st")
-                                ),
-                                TypeExpr.Lookup(Identifier.LocalScope "o")
-                              )
-                            )
-                          )
-                        )
+                            TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                          ),
+                          TypeExpr.Lookup(Identifier.LocalScope "st")
+                        ),
+                        TypeExpr.Lookup(Identifier.LocalScope "o")
                       )
                     )
                   )
@@ -143,13 +131,7 @@ module Extension =
             Kind.Schema,
             Kind.Arrow(
               Kind.Star,
-              Kind.Arrow(
-                Kind.Star,
-                Kind.Arrow(
-                  Kind.Star,
-                  Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
-                )
-              )
+              Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
             )
           )
         Operation = Co_Show
@@ -324,6 +306,194 @@ module Extension =
                 |> reader.Throw
             } }
 
+    // --- Co::mapContext ---
+    // mapContext : Λschema::Schema. Λctx::*. Λctx2::*. Λst::*. Λo::*.
+    //   (ctx2 -> ctx) -> Co[schema][ctx][st][o] -> Co[schema][ctx2][st][o]
+    let mapContextId =
+      Identifier.FullyQualified([ "Co" ], "mapContext")
+      |> TypeCheckScope.Empty.Resolve
+
+    let _ctx2Var, ctx2Kind = TypeVar.Create("ctx2"), Kind.Star
+
+    let mapContextOperation
+      : ResolvedIdentifier *
+        TypeOperationExtension<'runtimeContext, 'ext, Unit, Unit, CoroutineOperations> =
+      mapContextId,
+      { Type =
+          TypeValue.CreateLambda(
+            TypeParameter.Create("schema", schemaKind),
+            TypeExpr.Lambda(
+              TypeParameter.Create("ctx", ctxKind),
+              TypeExpr.Lambda(
+                TypeParameter.Create("ctx2", ctx2Kind),
+                TypeExpr.Lambda(
+                  TypeParameter.Create("st", stKind),
+                  TypeExpr.Lambda(
+                    TypeParameter.Create("o", oKind),
+                    TypeExpr.Arrow(
+                      TypeExpr.Arrow(
+                        TypeExpr.Lookup(Identifier.LocalScope "ctx2"),
+                        TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                      ),
+                      TypeExpr.Arrow(
+                        TypeExpr.Apply(
+                          TypeExpr.Apply(
+                            TypeExpr.Apply(
+                              TypeExpr.Apply(
+                                TypeExpr.Lookup(Identifier.LocalScope "Co"),
+                                TypeExpr.Lookup(Identifier.LocalScope "schema")
+                              ),
+                              TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                            ),
+                            TypeExpr.Lookup(Identifier.LocalScope "st")
+                          ),
+                          TypeExpr.Lookup(Identifier.LocalScope "o")
+                        ),
+                        TypeExpr.Apply(
+                          TypeExpr.Apply(
+                            TypeExpr.Apply(
+                              TypeExpr.Apply(
+                                TypeExpr.Lookup(Identifier.LocalScope "Co"),
+                                TypeExpr.Lookup(Identifier.LocalScope "schema")
+                              ),
+                              TypeExpr.Lookup(Identifier.LocalScope "ctx2")
+                            ),
+                            TypeExpr.Lookup(Identifier.LocalScope "st")
+                          ),
+                          TypeExpr.Lookup(Identifier.LocalScope "o")
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        Kind =
+          Kind.Arrow(
+            Kind.Schema,
+            Kind.Arrow(
+              Kind.Star,
+              Kind.Arrow(
+                Kind.Star,
+                Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+              )
+            )
+          )
+        Operation = Co_MapContext
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | Co_MapContext -> Some Co_MapContext
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (_op, _v) ->
+            reader {
+              return!
+                Errors.Singleton loc0 (fun () -> "Co::mapContext is not yet implemented")
+                |> reader.Throw
+            } }
+
+    // --- Co::mapState ---
+    // mapState : Λschema::Schema. Λctx::*. Λst::*. Λst2::*. Λo::*.
+    //   (st2 -> st) -> ((st -> st) -> (st2 -> st2)) -> Co[schema][ctx][st][o] -> Co[schema][ctx][st2][o]
+    let mapStateId =
+      Identifier.FullyQualified([ "Co" ], "mapState")
+      |> TypeCheckScope.Empty.Resolve
+
+    let _st2Var, st2Kind = TypeVar.Create("st2"), Kind.Star
+
+    let mapStateOperation
+      : ResolvedIdentifier *
+        TypeOperationExtension<'runtimeContext, 'ext, Unit, Unit, CoroutineOperations> =
+      mapStateId,
+      { Type =
+          TypeValue.CreateLambda(
+            TypeParameter.Create("schema", schemaKind),
+            TypeExpr.Lambda(
+              TypeParameter.Create("ctx", ctxKind),
+              TypeExpr.Lambda(
+                TypeParameter.Create("st", stKind),
+                TypeExpr.Lambda(
+                  TypeParameter.Create("st2", st2Kind),
+                  TypeExpr.Lambda(
+                    TypeParameter.Create("o", oKind),
+                    TypeExpr.Arrow(
+                      TypeExpr.Arrow(
+                        TypeExpr.Lookup(Identifier.LocalScope "st2"),
+                        TypeExpr.Lookup(Identifier.LocalScope "st")
+                      ),
+                      TypeExpr.Arrow(
+                        TypeExpr.Arrow(
+                          TypeExpr.Arrow(
+                            TypeExpr.Lookup(Identifier.LocalScope "st"),
+                            TypeExpr.Lookup(Identifier.LocalScope "st")
+                          ),
+                          TypeExpr.Arrow(
+                            TypeExpr.Lookup(Identifier.LocalScope "st2"),
+                            TypeExpr.Lookup(Identifier.LocalScope "st2")
+                          )
+                        ),
+                        TypeExpr.Arrow(
+                          TypeExpr.Apply(
+                            TypeExpr.Apply(
+                              TypeExpr.Apply(
+                                TypeExpr.Apply(
+                                  TypeExpr.Lookup(Identifier.LocalScope "Co"),
+                                  TypeExpr.Lookup(Identifier.LocalScope "schema")
+                                ),
+                                TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                              ),
+                              TypeExpr.Lookup(Identifier.LocalScope "st")
+                            ),
+                            TypeExpr.Lookup(Identifier.LocalScope "o")
+                          ),
+                          TypeExpr.Apply(
+                            TypeExpr.Apply(
+                              TypeExpr.Apply(
+                                TypeExpr.Apply(
+                                  TypeExpr.Lookup(Identifier.LocalScope "Co"),
+                                  TypeExpr.Lookup(Identifier.LocalScope "schema")
+                                ),
+                                TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                              ),
+                              TypeExpr.Lookup(Identifier.LocalScope "st2")
+                            ),
+                            TypeExpr.Lookup(Identifier.LocalScope "o")
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        Kind =
+          Kind.Arrow(
+            Kind.Schema,
+            Kind.Arrow(
+              Kind.Star,
+              Kind.Arrow(
+                Kind.Star,
+                Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+              )
+            )
+          )
+        Operation = Co_MapState
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | Co_MapState -> Some Co_MapState
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (_op, _v) ->
+            reader {
+              return!
+                Errors.Singleton loc0 (fun () -> "Co::mapState is not yet implemented")
+                |> reader.Throw
+            } }
+
     let coExtension =
       { TypeName = coResolvedId, coSymbolId
         TypeVars =
@@ -333,7 +503,7 @@ module Extension =
             (resVar, resKind) ]
         Cases = Map.empty
         Operations =
-          [ showOperation; untilOperation; ignoreOperation ] |> Map.ofList
+          [ showOperation; untilOperation; ignoreOperation; mapContextOperation; mapStateOperation ] |> Map.ofList
         Serialization = None
         ExtTypeChecker = None }
 

--- a/samples/24-views.bl
+++ b/samples/24-views.bl
@@ -63,12 +63,18 @@
 //
 // The bridge between views and coroutines is `Co::show`:
 //
-//   Co::show : I -> S -> (S -> () + O) -> View[Schema][I][S] -> Co[Schema][Ctx][St][O]
+//   Co::show : (St -> () + O) -> View[Schema][Ctx][St] -> Co[Schema][Ctx][St][O]
 //
-// It instantiates a view with initial context `I` and state `S`, renders
-// it, and on every state change calls the predicate `(S -> () + O)`:
+// It renders a view whose context and state match the coroutine's own
+// `Ctx` and `St`. On every state change it calls the predicate `(St -> () + O)`:
 //   - `1Of2()` means "keep running" (the view stays on screen)
 //   - `2Of2(result)` means "done" (the coroutine yields `result`)
+//
+// To adapt a coroutine's context or state to a parent's types, use:
+//
+//   Co::mapContext : (Ctx2 -> Ctx) -> Co[S][Ctx][St][O] -> Co[S][Ctx2][St][O]
+//   Co::mapState   : (St2 -> St) -> ((St -> St) -> (St2 -> St2))
+//                    -> Co[S][Ctx][St][O] -> Co[S][Ctx][St2][O]
 //
 // This turns interactive UI into sequential code: show a form, wait for
 // submission, show a confirmation, call an API, show the result — all
@@ -242,35 +248,56 @@ let doneMessage = view (props:View::Props[TodoSchema][int32][unit]) ->
 // ── 8. Counter coroutine ─────────────────────────────────────────────────
 // Shows the counter view. When the count exceeds 10, the coroutine
 // finishes and yields the final count.
-// Type: Co[TodoSchema][unit][unit][int32]
+// Type: Co[TodoSchema][string][int32][int32]
 
 let counterFlow = co {
   let! finalCount =
     Co::show
-      "Click counter"    // initial context (I = string)
-      0                   // initial state   (S = int32)
-      (fun n ->           // predicate: S -> () + int32
+      (fun n ->
         if n > 10 then 2Of2(n)
         else 1Of2())
-      counter;            // the view to render
+      counter;
   return finalCount
 };
 
-// ── 9. Full page coroutine ───────────────────────────────────────────────
+// ── 9. Done message coroutine ────────────────────────────────────────────
+// Shows the done message view forever (never completes).
+// Type: Co[TodoSchema][int32][unit][unit]
+
+let doneMessageFlow = co {
+  do! Co::show
+    (replaceWith (1Of2()))
+    doneMessage;
+  return ()
+};
+
+// ── 10. Composite state for the home flow ────────────────────────────────
+// The home flow sequences two phases with different ctx/st types.
+// Its state is a superset that contains both phases' state.
+
+type HomeFlowState = {
+  CounterCount: int32;
+};
+
+// ── 11. Full page coroutine ──────────────────────────────────────────────
 // Sequences two phases: first the counter, then a "done" message.
-// Demonstrates how coroutines turn multi-step UI into straight-line code.
-// Type: Co[TodoSchema][unit][unit][unit]
+// Uses Co::mapContext and Co::mapState to adapt child coroutines to the
+// parent's composite state.
+// Type: Co[TodoSchema][unit][HomeFlowState][unit]
 
 let homeFlow = co {
   // Phase 1: show the counter until count > 10
-  let! finalCount = counterFlow;
+  let! finalCount =
+    counterFlow
+    |> Co::mapContext (replaceWith "Click counter")
+    |> Co::mapState
+      (fun st -> st.CounterCount)
+      (fun f st -> { st with HomeFlowState::CounterCount = f st.CounterCount });
 
   // Phase 2: show the done message forever (never completes)
-  do! Co::show
-    finalCount            // pass the final count as context
-    ()                    // no local state
-    (replaceWith (1Of2()))   // never done — stays on screen
-    doneMessage;
+  do! doneMessageFlow
+    |> Co::mapContext (replaceWith finalCount)
+    |> Co::mapState (replaceWith ()) (replaceWith id);
 
   return ()
 };
@@ -294,19 +321,24 @@ let main = fun (schema: TodoSchema) ->
 WebApp::run [TodoSchema] (DB::run [TodoSchema] main)
   |> WebApp::withRoute("/", co {
     do! Co::show
-      ()
-      { Todos = seed_todos; Count = 0 }
       (replaceWith (1Of2()))
-      homePage;
+      homePage
+    |> Co::mapState
+      (replaceWith { Todos = seed_todos; Count = 0 })
+      (replaceWith id);
     return ()
   })
-  |> WebApp::withRoute("/flow", homeFlow)
+  |> WebApp::withRoute("/flow", homeFlow
+    |> Co::mapState
+      (replaceWith { CounterCount = 0 })
+      (replaceWith id))
   |> WebApp::withRoute("/header", co {
     do! Co::show
-      { Title = "Header"; Subtitle = "Standalone page" }
-      ()
       (replaceWith (1Of2()))
-      pageHeader;
+      pageHeader
+    |> Co::mapContext
+      (replaceWith { Title = "Header"; Subtitle = "Standalone page" })
+    |> Co::mapState (replaceWith ()) (replaceWith id);
     return ()
   })
   |> WebApp::withComponent("counter", counter)


### PR DESCRIPTION
## Summary

Simplifies `Co::show` from 6 type lambdas to 4, and adds `Co::mapContext`/`Co::mapState` combinators that mirror the existing `View::mapContext`/`View::mapState`.

## Changes

### Co::show (simplified)
**Before:** `Λschema. Λctx. Λst. Λi. Λs. Λo. i → s → (s → () + o) → View[schema][i][s] → Co[schema][ctx][st][o]`
**After:** `Λschema. Λctx. Λst. Λo. (st → () + o) → View[schema][ctx][st] → Co[schema][ctx][st][o]`

- Drops `i` and `s` type lambdas (view ctx/st now unified with coroutine ctx/st)
- Drops initial value parameters (ctx/st come from the coroutine itself)

### Co::mapContext (new)
`(ctx2 → ctx) → Co[schema][ctx][st][o] → Co[schema][ctx2][st][o]`
Contravariant context mapping, same pattern as `View::mapContext`.

### Co::mapState (new)
`(st2 → st) → ((st → st) → (st2 → st2)) → Co[schema][ctx][st][o] → Co[schema][ctx][st2][o]`
Lens-like state mapping, same pattern as `View::mapState`.

### Sample 24
Rewritten to demonstrate the new combinators: composite state types + `Co::mapContext`/`Co::mapState` to focus child coroutines into parent state.

## Testing
- ✅ `dotnet build` — 0 errors, 0 warnings
- ✅ All 26 integration tests pass
- ✅ UScreen webshop compiles correctly