### PR TITLE
feat: add Co::getContext/getState/setState and WebApp extension

### DIFF
--- a/backend/libraries/ballerina-lang/Next/Stdlib/Coroutine/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/Coroutine/Extension.fs
@@ -16,6 +16,9 @@ module Extension =
     | Co_Ignore
     | Co_MapContext
     | Co_MapState
+    | Co_GetContext
+    | Co_GetState
+    | Co_SetState
 
   let CoroutineExtension<'runtimeContext, 'ext, 'extDTO, 'deltaExt, 'deltaExtDTO
     when 'ext: comparison
@@ -494,6 +497,171 @@ module Extension =
                 |> reader.Throw
             } }
 
+    // --- Co::getContext ---
+    // getContext : Λschema::Schema. Λctx::*. Λst::*.
+    //   Co[schema][ctx][st][ctx]
+    let getContextId =
+      Identifier.FullyQualified([ "Co" ], "getContext")
+      |> TypeCheckScope.Empty.Resolve
+
+    let getContextOperation
+      : ResolvedIdentifier *
+        TypeOperationExtension<'runtimeContext, 'ext, Unit, Unit, CoroutineOperations> =
+      getContextId,
+      { Type =
+          TypeValue.CreateLambda(
+            TypeParameter.Create("schema", schemaKind),
+            TypeExpr.Lambda(
+              TypeParameter.Create("ctx", ctxKind),
+              TypeExpr.Lambda(
+                TypeParameter.Create("st", stKind),
+                TypeExpr.Apply(
+                  TypeExpr.Apply(
+                    TypeExpr.Apply(
+                      TypeExpr.Apply(
+                        TypeExpr.Lookup(Identifier.LocalScope "Co"),
+                        TypeExpr.Lookup(Identifier.LocalScope "schema")
+                      ),
+                      TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                    ),
+                    TypeExpr.Lookup(Identifier.LocalScope "st")
+                  ),
+                  TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                )
+              )
+            )
+          )
+        Kind =
+          Kind.Arrow(
+            Kind.Schema,
+            Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+          )
+        Operation = Co_GetContext
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | Co_GetContext -> Some Co_GetContext
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (_op, _v) ->
+            reader {
+              return!
+                Errors.Singleton loc0 (fun () -> "Co::getContext is not yet implemented")
+                |> reader.Throw
+            } }
+
+    // --- Co::getState ---
+    // getState : Λschema::Schema. Λctx::*. Λst::*.
+    //   Co[schema][ctx][st][st]
+    let getStateId =
+      Identifier.FullyQualified([ "Co" ], "getState")
+      |> TypeCheckScope.Empty.Resolve
+
+    let getStateOperation
+      : ResolvedIdentifier *
+        TypeOperationExtension<'runtimeContext, 'ext, Unit, Unit, CoroutineOperations> =
+      getStateId,
+      { Type =
+          TypeValue.CreateLambda(
+            TypeParameter.Create("schema", schemaKind),
+            TypeExpr.Lambda(
+              TypeParameter.Create("ctx", ctxKind),
+              TypeExpr.Lambda(
+                TypeParameter.Create("st", stKind),
+                TypeExpr.Apply(
+                  TypeExpr.Apply(
+                    TypeExpr.Apply(
+                      TypeExpr.Apply(
+                        TypeExpr.Lookup(Identifier.LocalScope "Co"),
+                        TypeExpr.Lookup(Identifier.LocalScope "schema")
+                      ),
+                      TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                    ),
+                    TypeExpr.Lookup(Identifier.LocalScope "st")
+                  ),
+                  TypeExpr.Lookup(Identifier.LocalScope "st")
+                )
+              )
+            )
+          )
+        Kind =
+          Kind.Arrow(
+            Kind.Schema,
+            Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+          )
+        Operation = Co_GetState
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | Co_GetState -> Some Co_GetState
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (_op, _v) ->
+            reader {
+              return!
+                Errors.Singleton loc0 (fun () -> "Co::getState is not yet implemented")
+                |> reader.Throw
+            } }
+
+    // --- Co::setState ---
+    // setState : Λschema::Schema. Λctx::*. Λst::*.
+    //   (st -> st) -> Co[schema][ctx][st][()]
+    let setStateId =
+      Identifier.FullyQualified([ "Co" ], "setState")
+      |> TypeCheckScope.Empty.Resolve
+
+    let setStateOperation
+      : ResolvedIdentifier *
+        TypeOperationExtension<'runtimeContext, 'ext, Unit, Unit, CoroutineOperations> =
+      setStateId,
+      { Type =
+          TypeValue.CreateLambda(
+            TypeParameter.Create("schema", schemaKind),
+            TypeExpr.Lambda(
+              TypeParameter.Create("ctx", ctxKind),
+              TypeExpr.Lambda(
+                TypeParameter.Create("st", stKind),
+                TypeExpr.Arrow(
+                  TypeExpr.Arrow(
+                    TypeExpr.Lookup(Identifier.LocalScope "st"),
+                    TypeExpr.Lookup(Identifier.LocalScope "st")
+                  ),
+                  TypeExpr.Apply(
+                    TypeExpr.Apply(
+                      TypeExpr.Apply(
+                        TypeExpr.Apply(
+                          TypeExpr.Lookup(Identifier.LocalScope "Co"),
+                          TypeExpr.Lookup(Identifier.LocalScope "schema")
+                        ),
+                        TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                      ),
+                      TypeExpr.Lookup(Identifier.LocalScope "st")
+                    ),
+                    TypeExpr.Primitive PrimitiveType.Unit
+                  )
+                )
+              )
+            )
+          )
+        Kind =
+          Kind.Arrow(
+            Kind.Schema,
+            Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+          )
+        Operation = Co_SetState
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | Co_SetState -> Some Co_SetState
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (_op, _v) ->
+            reader {
+              return!
+                Errors.Singleton loc0 (fun () -> "Co::setState is not yet implemented")
+                |> reader.Throw
+            } }
+
     let coExtension =
       { TypeName = coResolvedId, coSymbolId
         TypeVars =
@@ -503,7 +671,9 @@ module Extension =
             (resVar, resKind) ]
         Cases = Map.empty
         Operations =
-          [ showOperation; untilOperation; ignoreOperation; mapContextOperation; mapStateOperation ] |> Map.ofList
+          [ showOperation; untilOperation; ignoreOperation
+            mapContextOperation; mapStateOperation
+            getContextOperation; getStateOperation; setStateOperation ] |> Map.ofList
         Serialization = None
         ExtTypeChecker = None }
 

--- a/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
@@ -19,6 +19,7 @@ open Ballerina.DSL.Next.Types.TypeChecker.Model
 open Ballerina.DSL.Next.StdLib.DB.Extension.DBRun
 open Ballerina.DSL.Next.StdLib.View.Extension
 open Ballerina.DSL.Next.StdLib.Coroutine.Extension
+open Ballerina.DSL.Next.StdLib.WebApp.Extension
 
 type ValueExt<'runtimeContext, 'db, 'customExtension
   when 'db: comparison and 'customExtension: comparison> =
@@ -29,6 +30,7 @@ type ValueExt<'runtimeContext, 'db, 'customExtension
   | VComposite of CompositeTypeExt<'runtimeContext, 'db, 'customExtension>
   | VDB of DBExt<'runtimeContext, 'db, 'customExtension>
   | VMap of MapExt<'runtimeContext, 'db, 'customExtension>
+  | VWebApp of WebAppOperations
   | VCustom of 'customExtension
 
   override self.ToString() =
@@ -40,6 +42,7 @@ type ValueExt<'runtimeContext, 'db, 'customExtension
     | VComposite ext -> ext.ToString()
     | VDB ext -> ext.ToString()
     | VMap ext -> ext.ToString()
+    | VWebApp ext -> ext.ToString()
     | VCustom ext -> ext.ToString()
 
 and [<NoComparison; NoEquality>] ValueExtDTO =
@@ -733,6 +736,21 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
       (typeCheckingConfig |> Option.map (fun cfg -> cfg.CoTypeSymbol))
       (Identifier.FullyQualified([ "Frontend" ], "View"))
 
+  let webAppIOExtension, webAppRunExtension, _webapp_sym, _mk_webapp_io_type =
+    WebApp.Extension.WebAppExtension<
+      'runtimeContext,
+      ValueExt<'runtimeContext, 'db, 'customExtension>,
+      ValueExtDTO,
+      DeltaExt<'runtimeContext, 'db, 'customExtension>,
+      DeltaExtDTO
+     >
+      { Get = function | VWebApp x -> Some x | _ -> None
+        Set = VWebApp }
+      None
+      (Identifier.FullyQualified([ "Frontend" ], "View"))
+      (Identifier.LocalScope "Co")
+      (Identifier.LocalScope "DBIO")
+
   let dateOnlyExtension =
     DateOnly.Extension.DateOnlyExtension<
       'runtimeContext,
@@ -949,6 +967,8 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
     |> (viewExtension |> TypeExtension.RegisterLanguageContext)
     |> (viewPropsExtension |> TypeExtension.RegisterLanguageContext)
     |> (coroutineExtension |> TypeExtension.RegisterLanguageContext)
+    |> (webAppIOExtension |> TypeExtension.RegisterLanguageContext)
+    |> (webAppRunExtension |> TypeLambdaExtension.RegisterLanguageContext)
     |> (dateOnlyExtension |> OperationsExtension.RegisterLanguageContext)
     |> (dateTimeExtension |> OperationsExtension.RegisterLanguageContext)
     |> (guidExtension |> OperationsExtension.RegisterLanguageContext)

--- a/backend/libraries/ballerina-lang/Next/Stdlib/WebApp/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/WebApp/Extension.fs
@@ -1,0 +1,255 @@
+namespace Ballerina.DSL.Next.StdLib.WebApp
+
+module Extension =
+  open Ballerina.DSL.Next.Types.Model
+  open Ballerina.DSL.Next.Types.Patterns
+  open Ballerina.DSL.Next.Types.TypeChecker.Model
+  open Ballerina.DSL.Next.Extensions
+  open Ballerina.Collections.Sum
+  open Ballerina.Errors
+  open Ballerina.Reader.WithError
+  open Ballerina.Lenses
+
+  type WebAppOperations =
+    | WebApp_WithRoute
+    | WebApp_WithComponent
+
+  let WebAppExtension<'runtimeContext, 'ext, 'extDTO, 'deltaExt, 'deltaExtDTO
+    when 'ext: comparison
+    and 'extDTO: not null
+    and 'extDTO: not struct
+    and 'deltaExtDTO: not null
+    and 'deltaExtDTO: not struct>
+    (operationLens: PartialLens<'ext, WebAppOperations>)
+    (webAppIOTypeSymbol: Option<TypeSymbol>)
+    (viewTypeId: Identifier)
+    (coTypeId: Identifier)
+    (dbIOTypeId: Identifier)
+    : TypeExtension<
+        'runtimeContext,
+        'ext,
+        'extDTO,
+        'deltaExt,
+        'deltaExtDTO,
+        Unit,
+        Unit,
+        WebAppOperations
+       > *
+      TypeLambdaExtension<'runtimeContext, 'ext, 'extDTO, WebAppOperations> *
+      TypeSymbol *
+      (TypeValue<'ext> -> TypeValue<'ext>)
+    =
+    // --- WebAppIO[schema] type ---
+    let webAppIOId = Identifier.FullyQualified([ "WebApp" ], "IO")
+    let webAppIOResolvedId = webAppIOId |> TypeCheckScope.Empty.Resolve
+
+    let webAppIOSymbolId =
+      webAppIOTypeSymbol |> Option.defaultWith (fun () -> webAppIOId |> TypeSymbol.Create)
+
+    let schemaVar, schemaKind = TypeVar.Create("schema"), Kind.Schema
+    let _ctxVar, ctxKind = TypeVar.Create("ctx"), Kind.Star
+    let _stVar, stKind = TypeVar.Create("st"), Kind.Star
+
+    let make_webAppIOType (schema: TypeValue<'ext>) =
+      TypeValue.Imported
+        { Id = webAppIOResolvedId
+          Sym = webAppIOSymbolId
+          Parameters = []
+          Arguments = [ schema ] }
+
+    // --- WebApp::withRoute ---
+    // withRoute : Λschema::Schema. Λctx::*. Λst::*.
+    //   string -> Co[schema][ctx][st][()] -> WebAppIO[schema] -> WebAppIO[schema]
+    let withRouteId =
+      Identifier.FullyQualified([ "WebApp" ], "withRoute")
+      |> TypeCheckScope.Empty.Resolve
+
+    let withRouteOperation
+      : ResolvedIdentifier *
+        TypeOperationExtension<'runtimeContext, 'ext, Unit, Unit, WebAppOperations> =
+      withRouteId,
+      { Type =
+          TypeValue.CreateLambda(
+            TypeParameter.Create("schema", schemaKind),
+            TypeExpr.Lambda(
+              TypeParameter.Create("ctx", ctxKind),
+              TypeExpr.Lambda(
+                TypeParameter.Create("st", stKind),
+                TypeExpr.Arrow(
+                  TypeExpr.Primitive PrimitiveType.String,
+                  TypeExpr.Arrow(
+                    TypeExpr.Apply(
+                      TypeExpr.Apply(
+                        TypeExpr.Apply(
+                          TypeExpr.Apply(
+                            TypeExpr.Lookup coTypeId,
+                            TypeExpr.Lookup(Identifier.LocalScope "schema")
+                          ),
+                          TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                        ),
+                        TypeExpr.Lookup(Identifier.LocalScope "st")
+                      ),
+                      TypeExpr.Primitive PrimitiveType.Unit
+                    ),
+                    TypeExpr.Arrow(
+                      TypeExpr.Apply(
+                        TypeExpr.Lookup webAppIOId,
+                        TypeExpr.Lookup(Identifier.LocalScope "schema")
+                      ),
+                      TypeExpr.Apply(
+                        TypeExpr.Lookup webAppIOId,
+                        TypeExpr.Lookup(Identifier.LocalScope "schema")
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        Kind =
+          Kind.Arrow(
+            Kind.Schema,
+            Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+          )
+        Operation = WebApp_WithRoute
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | WebApp_WithRoute -> Some WebApp_WithRoute
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (_op, _v) ->
+            reader {
+              return!
+                Errors.Singleton loc0 (fun () -> "WebApp::withRoute is not yet implemented")
+                |> reader.Throw
+            } }
+
+    // --- WebApp::withComponent ---
+    // withComponent : Λschema::Schema. Λctx::*. Λst::*.
+    //   string -> Frontend::View[schema][ctx][st] -> WebAppIO[schema] -> WebAppIO[schema]
+    let withComponentId =
+      Identifier.FullyQualified([ "WebApp" ], "withComponent")
+      |> TypeCheckScope.Empty.Resolve
+
+    let withComponentOperation
+      : ResolvedIdentifier *
+        TypeOperationExtension<'runtimeContext, 'ext, Unit, Unit, WebAppOperations> =
+      withComponentId,
+      { Type =
+          TypeValue.CreateLambda(
+            TypeParameter.Create("schema", schemaKind),
+            TypeExpr.Lambda(
+              TypeParameter.Create("ctx", ctxKind),
+              TypeExpr.Lambda(
+                TypeParameter.Create("st", stKind),
+                TypeExpr.Arrow(
+                  TypeExpr.Primitive PrimitiveType.String,
+                  TypeExpr.Arrow(
+                    TypeExpr.Apply(
+                      TypeExpr.Apply(
+                        TypeExpr.Apply(
+                          TypeExpr.Lookup viewTypeId,
+                          TypeExpr.Lookup(Identifier.LocalScope "schema")
+                        ),
+                        TypeExpr.Lookup(Identifier.LocalScope "ctx")
+                      ),
+                      TypeExpr.Lookup(Identifier.LocalScope "st")
+                    ),
+                    TypeExpr.Arrow(
+                      TypeExpr.Apply(
+                        TypeExpr.Lookup webAppIOId,
+                        TypeExpr.Lookup(Identifier.LocalScope "schema")
+                      ),
+                      TypeExpr.Apply(
+                        TypeExpr.Lookup webAppIOId,
+                        TypeExpr.Lookup(Identifier.LocalScope "schema")
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        Kind =
+          Kind.Arrow(
+            Kind.Schema,
+            Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+          )
+        Operation = WebApp_WithComponent
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | WebApp_WithComponent -> Some WebApp_WithComponent
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (_op, _v) ->
+            reader {
+              return!
+                Errors.Singleton loc0 (fun () -> "WebApp::withComponent is not yet implemented")
+                |> reader.Throw
+            } }
+
+    let webAppIOExtension =
+      { TypeName = webAppIOResolvedId, webAppIOSymbolId
+        TypeVars = [ (schemaVar, schemaKind) ]
+        Cases = Map.empty
+        Operations =
+          [ withRouteOperation; withComponentOperation ] |> Map.ofList
+        Serialization = None
+        ExtTypeChecker = None }
+
+    // --- WebApp::run ---
+    // run : Λschema::Schema. Λresult::*.
+    //   DBIO[schema][result] -> WebAppIO[schema]
+    let webAppRunId =
+      Identifier.FullyQualified([ "WebApp" ], "run")
+      |> TypeCheckScope.Empty.Resolve
+
+    let _resVar, resKind = TypeVar.Create("result"), Kind.Star
+
+    let webAppRunType =
+      TypeValue.CreateLambda(
+        TypeParameter.Create("schema", schemaKind),
+        TypeExpr.Lambda(
+          TypeParameter.Create("result", resKind),
+          TypeExpr.Arrow(
+            TypeExpr.Apply(
+              TypeExpr.Apply(
+                TypeExpr.Lookup dbIOTypeId,
+                TypeExpr.Lookup(Identifier.LocalScope "schema")
+              ),
+              TypeExpr.Lookup(Identifier.LocalScope "result")
+            ),
+            TypeExpr.Apply(
+              TypeExpr.Lookup webAppIOId,
+              TypeExpr.Lookup(Identifier.LocalScope "schema")
+            )
+          )
+        )
+      )
+
+    let webAppRunKind =
+      Kind.Arrow(Kind.Schema, Kind.Arrow(Kind.Star, Kind.Star))
+
+    let webAppRunExtension: TypeLambdaExtension<'runtimeContext, 'ext, 'extDTO, WebAppOperations> =
+      { ExtensionType = webAppRunId, webAppRunType, webAppRunKind
+        ExtraBindings = Map.empty
+        Value = WebApp_WithRoute // sentinel value — not meaningful, just needs to exist
+        ValueLens = operationLens
+        EvalToTypeApplicable =
+          fun loc0 _rest _v ->
+            reader {
+              return!
+                Errors.Singleton loc0 (fun () -> "WebApp::run is not yet implemented")
+                |> reader.Throw
+            }
+        EvalToApplicable =
+          fun loc0 _rest _v ->
+            reader {
+              return!
+                Errors.Singleton loc0 (fun () -> "WebApp::run is not yet implemented")
+                |> reader.Throw
+            } }
+
+    webAppIOExtension, webAppRunExtension, webAppIOSymbolId, make_webAppIOType

--- a/backend/libraries/ballerina-lang/Next/Stdlib/ballerina-lang-stdlib.fsproj
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/ballerina-lang-stdlib.fsproj
@@ -79,6 +79,7 @@
     <Compile Include="Updater/Extension.fs" />
     <Compile Include="View/Extension.fs" />
     <Compile Include="Coroutine/Extension.fs" />
+    <Compile Include="WebApp/Extension.fs" />
     <Compile Include="StdExtensions.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/24-views.bl
+++ b/samples/24-views.bl
@@ -76,6 +76,12 @@
 //   Co::mapState   : (St2 -> St) -> ((St -> St) -> (St2 -> St2))
 //                    -> Co[S][Ctx][St][O] -> Co[S][Ctx][St2][O]
 //
+// Coroutines can also access their ambient context and state directly:
+//
+//   Co::getContext : Co[Schema][Ctx][St][Ctx]
+//   Co::getState  : Co[Schema][Ctx][St][St]
+//   Co::setState  : (St -> St) -> Co[Schema][Ctx][St][()]
+//
 // This turns interactive UI into sequential code: show a form, wait for
 // submission, show a confirmation, call an API, show the result — all
 // as straight-line statements in a `co { }` block.
@@ -271,7 +277,26 @@ let doneMessageFlow = co {
   return ()
 };
 
-// ── 10. Composite state for the home flow ────────────────────────────────
+// ── 10. Coroutine state access ───────────────────────────────────────────
+// Demonstrates Co::getContext, Co::getState, Co::setState.
+// These operations access the coroutine's ambient context and state
+// without needing to show a view.
+// Type: Co[TodoSchema][string][int32][string]
+
+let stateAccessDemo = co {
+  // Read the ambient context (a string label)
+  let! label = Co::getContext;
+
+  // Read the current state (an int32 counter)
+  let! current = Co::getState;
+
+  // Update the state with an updater function
+  do! Co::setState (fun n -> n + 1);
+
+  return label
+};
+
+// ── 11. Composite state for the home flow ────────────────────────────────
 // The home flow sequences two phases with different ctx/st types.
 // Its state is a superset that contains both phases' state.
 
@@ -279,7 +304,7 @@ type HomeFlowState = {
   CounterCount: int32;
 };
 
-// ── 11. Full page coroutine ──────────────────────────────────────────────
+// ── 12. Full page coroutine ──────────────────────────────────────────────
 // Sequences two phases: first the counter, then a "done" message.
 // Uses Co::mapContext and Co::mapState to adapt child coroutines to the
 // parent's composite state.


### PR DESCRIPTION
## Summary

Add coroutine state/context access operations and the WebApp extension type.

### Co operations (Coroutine/Extension.fs)
- **`Co::getContext`**: `Co[schema][ctx][st][ctx]` — zero-arg value, returns ambient context
- **`Co::getState`**: `Co[schema][ctx][st][st]` — zero-arg value, returns current state
- **`Co::setState`**: `(st → st) → Co[schema][ctx][st][()]` — takes an updater function

### WebApp extension (new WebApp/Extension.fs)
- **`WebAppIO[schema]`** — new type with 1 type parameter
- **`WebApp::withRoute`**: `string → Co[s][ctx][st][()] → WebAppIO[s] → WebAppIO[s]`
- **`WebApp::withComponent`**: `string → View[s][ctx][st] → WebAppIO[s] → WebAppIO[s]`
- **`WebApp::run`**: `DBIO[s][result] → WebAppIO[s]` (TypeLambdaExtension)

### Wiring (StdExtensions.fs)
- Added `VWebApp` DU case to `ValueExt`
- Registered `webAppIOExtension` (TypeExtension) and `webAppRunExtension` (TypeLambdaExtension)

### Sample (24-views.bl)
- Added `stateAccessDemo` coroutine demonstrating `Co::getContext`, `Co::getState`, `Co::setState`
- Updated header docs with new Co operation signatures

### Testing
- ✅ `dotnet build backend.sln` — 0 errors
- ✅ Integration tests — 26/26 passed
- ✅ UScreen .blproj compilation — all .bl files compile (port-in-use on serve step only)

> Note: All `Apply`/`EvalToApplicable`/`EvalToTypeApplicable` implementations are stubs (`failwith "not yet implemented"`) — runtime evaluation will follow in a future PR.