### PR TITLE
feat: grammar-annotated parsers with AnnotatedParser type and collecting module

### DIFF
--- a/backend/libraries/ballerina-cat/Grammar/Ebnf.fs
+++ b/backend/libraries/ballerina-cat/Grammar/Ebnf.fs
@@ -1,0 +1,32 @@
+namespace Ballerina.Grammar
+
+module Ebnf =
+  let private escapeTerminal (s: string) : string =
+    s.Replace("\\", "\\\\").Replace("\"", "\\\"")
+
+  let rec private serializeRule (rule: GrammarRule) : string =
+    match rule with
+    | Terminal s -> $"\"{escapeTerminal s}\""
+    | NonTerminal s -> s
+    | Seq rules ->
+      rules
+      |> List.map serializeRuleGrouped
+      |> String.concat " , "
+    | Alt rules ->
+      rules
+      |> List.map serializeRule
+      |> String.concat " | "
+    | Repeat rule -> "{ " + serializeRule rule + " }"
+    | Repeat1 rule -> serializeRule rule + " , { " + serializeRule rule + " }"
+    | Optional rule -> "[ " + serializeRule rule + " ]"
+    | Empty -> ""
+
+  and private serializeRuleGrouped (rule: GrammarRule) : string =
+    match rule with
+    | Alt _ -> "( " + serializeRule rule + " )"
+    | _ -> serializeRule rule
+
+  let serialize (rules: NamedRule list) : string =
+    rules
+    |> List.map (fun r -> $"{r.Name} = {serializeRule r.Rule} ;")
+    |> String.concat "\n"

--- a/backend/libraries/ballerina-cat/Grammar/Gbnf.fs
+++ b/backend/libraries/ballerina-cat/Grammar/Gbnf.fs
@@ -1,0 +1,35 @@
+namespace Ballerina.Grammar
+
+module Gbnf =
+  let private sanitizeName (s: string) : string =
+    s.Replace(" ", "-").Replace("::", "-").Replace(".", "-")
+
+  let private escapeTerminal (s: string) : string =
+    s.Replace("\\", "\\\\").Replace("\"", "\\\"")
+
+  let rec private serializeRule (rule: GrammarRule) : string =
+    match rule with
+    | Terminal s -> $"\"{escapeTerminal s}\""
+    | NonTerminal s -> sanitizeName s
+    | Seq rules ->
+      rules
+      |> List.map serializeRuleGrouped
+      |> String.concat " "
+    | Alt rules ->
+      rules
+      |> List.map serializeRule
+      |> String.concat " | "
+    | Repeat rule -> "(" + serializeRule rule + ")*"
+    | Repeat1 rule -> "(" + serializeRule rule + ")+"
+    | Optional rule -> "(" + serializeRule rule + ")?"
+    | Empty -> "\"\""
+
+  and private serializeRuleGrouped (rule: GrammarRule) : string =
+    match rule with
+    | Alt _ -> "(" + serializeRule rule + ")"
+    | _ -> serializeRule rule
+
+  let serialize (rules: NamedRule list) : string =
+    rules
+    |> List.map (fun r -> $"{sanitizeName r.Name} ::= {serializeRule r.Rule}")
+    |> String.concat "\n"

--- a/backend/libraries/ballerina-cat/Grammar/Model.fs
+++ b/backend/libraries/ballerina-cat/Grammar/Model.fs
@@ -1,0 +1,16 @@
+namespace Ballerina.Grammar
+
+[<AutoOpen>]
+module Model =
+
+  type GrammarRule =
+    | Terminal of string
+    | NonTerminal of string
+    | Seq of GrammarRule list
+    | Alt of GrammarRule list
+    | Repeat of GrammarRule
+    | Repeat1 of GrammarRule
+    | Optional of GrammarRule
+    | Empty
+
+  type NamedRule = { Name: string; Rule: GrammarRule }

--- a/backend/libraries/ballerina-cat/Parser/Model.fs
+++ b/backend/libraries/ballerina-cat/Parser/Model.fs
@@ -8,8 +8,9 @@ module Model =
   open Ballerina.Collections
   open Ballerina.Collections.NonEmptyList
   open Ballerina.Reader.WithError
+  open Ballerina.Grammar
   open Ballerina.Stackless.State.WithError.StacklessStateWithError
-
+  open Ballerina.Grammar
 
   open FSharp.Core
   open Ballerina.Collections.NonEmptyList
@@ -290,3 +291,78 @@ module Model =
 
         return! res |> parser.OfSum
       }
+
+  [<NoComparison; NoEquality>]
+  type AnnotatedParser<'a, 'sym, 'loc, 'err> =
+    { Parser: Parser<'a, 'sym, 'loc, 'err>
+      Rule: NamedRule option }
+
+  module AnnotatedParser =
+    let ofParser (p: Parser<'a, 'sym, 'loc, 'err>) : AnnotatedParser<'a, 'sym, 'loc, 'err> =
+      { Parser = p; Rule = None }
+
+    let withRule (name: string) (rule: GrammarRule) (p: Parser<'a, 'sym, 'loc, 'err>) : AnnotatedParser<'a, 'sym, 'loc, 'err> =
+      { Parser = p; Rule = Some { Name = name; Rule = rule } }
+
+    let withNamedRule (nr: NamedRule) (p: Parser<'a, 'sym, 'loc, 'err>) : AnnotatedParser<'a, 'sym, 'loc, 'err> =
+      { Parser = p; Rule = Some nr }
+
+    let grammar (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>) : NamedRule option =
+      ap.Rule
+
+    let parser (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>) : Parser<'a, 'sym, 'loc, 'err> =
+      ap.Parser
+
+    let collectRules (aps: AnnotatedParser<'a, 'sym, 'loc, 'err> list) : NamedRule list =
+      aps |> List.choose (fun ap -> ap.Rule)
+
+  // AnnotatedParser combinator extensions on ParserBuilder
+  type ParserBuilder<'sym, 'loc, 'err when 'sym: equality> with
+
+    member self.Any
+      (aps: List<AnnotatedParser<'a, 'sym, 'loc, 'err>>)
+      : Parser<'a, 'sym, 'loc, 'err> =
+      let ps: List<Parser<'a, 'sym, 'loc, 'err>> = aps |> List.map (fun ap -> ap.Parser)
+      self.Any(ps)
+
+    member self.All
+      (aps: List<AnnotatedParser<'a, 'sym, 'loc, 'err>>)
+      : Parser<List<'a>, 'sym, 'loc, 'err> =
+      let ps: List<Parser<'a, 'sym, 'loc, 'err>> = aps |> List.map (fun ap -> ap.Parser)
+      self.All(ps)
+
+    member self.Many
+      (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>)
+      : Parser<List<'a>, 'sym, 'loc, 'err> =
+      let p: Parser<'a, 'sym, 'loc, 'err> = ap.Parser
+      self.Many(p)
+
+    member self.AtLeastOne
+      (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>)
+      : Parser<NonEmptyList<'a>, 'sym, 'loc, 'err> =
+      let p: Parser<'a, 'sym, 'loc, 'err> = ap.Parser
+      self.AtLeastOne(p)
+
+    member self.Try
+      (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>)
+      : Parser<Sum<'a, 'err>, 'sym, 'loc, 'err> =
+      let p: Parser<'a, 'sym, 'loc, 'err> = ap.Parser
+      self.Try(p)
+
+    member self.Lookahead
+      (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>)
+      : Parser<'a, 'sym, 'loc, 'err> =
+      let p: Parser<'a, 'sym, 'loc, 'err> = ap.Parser
+      self.Lookahead(p)
+
+    member self.Not
+      (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>)
+      : Parser<Unit, 'sym, 'loc, 'err> =
+      let p: Parser<'a, 'sym, 'loc, 'err> = ap.Parser
+      self.Not(p)
+
+    member self.Ignore
+      (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>)
+      : Parser<Unit, 'sym, 'loc, 'err> =
+      let p: Parser<'a, 'sym, 'loc, 'err> = ap.Parser
+      self.Ignore(p)

--- a/backend/libraries/ballerina-cat/ballerina-cat.fsproj
+++ b/backend/libraries/ballerina-cat/ballerina-cat.fsproj
@@ -22,6 +22,9 @@
     <Compile Include="State/WithError/Seq/Model.fs" />
     <Compile Include="Coroutine/Model.fs" />
     <Compile Include="Coroutine/Runner.fs" />
+    <Compile Include="Grammar/Model.fs" />
+    <Compile Include="Grammar/Ebnf.fs" />
+    <Compile Include="Grammar/Gbnf.fs" />
     <Compile Include="Parser/Model.fs" />
   </ItemGroup>
 </Project>

--- a/backend/libraries/ballerina-lang-build/ProjectModel.fs
+++ b/backend/libraries/ballerina-lang-build/ProjectModel.fs
@@ -377,7 +377,7 @@ module ProjectModel =
             Location,
             Errors<Location>
            >) =
-          Parser.Expr.program ()
+          (Parser.Expr.program ()).Parser
           |> Parser.Run(actual, initialLocation)
           |> sum.MapError fst
 

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Common.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Common.fs
@@ -17,6 +17,7 @@ module Common =
   open Ballerina.DSL.Next.Syntax
   open Model
   open Ballerina
+  open Ballerina.Grammar
 
   let parseOperator op =
     parser.Exactly(fun t ->
@@ -93,6 +94,17 @@ module Common =
       | PipeGreaterThan -> "|>"
       | DoubleGreaterThan -> ">>"
 
+  let binaryExprOperatorRule =
+    { Name = "binary-expr-operator"
+      Rule =
+        Alt
+          [ Terminal "*"; Terminal "/"; Terminal "%"
+            Terminal "+"; Terminal "-"
+            Terminal "&&"; Terminal "||"
+            Terminal "=="; Terminal "!="
+            Terminal ">"; Terminal "<"; Terminal ">="; Terminal "<="
+            Terminal "|>"; Terminal ">>" ] }
+
   let binaryExprOperator =
     parser.Any
       [ parseOperator Operator.Times
@@ -125,6 +137,7 @@ module Common =
         |> parser.Map(fun () -> BinaryExprOperator.PipeGreaterThan)
         parseOperator Operator.DoubleGreaterThan
         |> parser.Map(fun () -> BinaryExprOperator.DoubleGreaterThan) ]
+    |> AnnotatedParser.withNamedRule binaryExprOperatorRule
 
   type BinaryTypeOperator =
     | Times
@@ -137,6 +150,10 @@ module Common =
       | Plus -> "+"
       | SingleArrow -> "->"
 
+  let binaryTypeOperatorRule =
+    { Name = "binary-type-operator"
+      Rule = Alt [ Terminal "*"; Terminal "+"; Terminal "->" ] }
+
   let binaryTypeOperator =
     parser.Any
       [ parseOperator Operator.Times
@@ -145,6 +162,7 @@ module Common =
         |> parser.Map(fun () -> BinaryTypeOperator.Plus)
         parseOperator Operator.SingleArrow
         |> parser.Map(fun () -> BinaryTypeOperator.SingleArrow) ]
+    |> AnnotatedParser.withNamedRule binaryTypeOperatorRule
 
   let parseKeyword kw =
     parser.Exactly(fun t ->
@@ -162,6 +180,9 @@ module Common =
   let ifKeyword = parseKeyword Keyword.If
   let thenKeyword = parseKeyword Keyword.Then
   let elseKeyword = parseKeyword Keyword.Else
+
+  let singleTermIdentifierRule =
+    { Name = "term-identifier"; Rule = Terminal "<term-identifier>" }
 
   let singleTermIdentifier =
     parser.Exactly(fun t ->
@@ -189,18 +210,27 @@ module Common =
       | Token.Keyword(Keyword.Descending) ->
         Keyword.Descending.ToString() |> Some
       | _ -> None)
+    |> AnnotatedParser.withNamedRule singleTermIdentifierRule
+
+  let singleIdentifierRule =
+    { Name = "identifier"; Rule = Terminal "<identifier>" }
 
   let singleIdentifier =
     parser.Exactly(fun t ->
       match t.Token with
       | Token.Identifier id -> Some id
       | _ -> None)
+    |> AnnotatedParser.withNamedRule singleIdentifierRule
+
+  let caseLiteralRule =
+    { Name = "case-literal"; Rule = Terminal "<case-literal>" }
 
   let caseLiteral () =
     parser.Exactly(fun t ->
       match t.Token with
       | Token.CaseLiteral(i, n) -> { Case = i; Count = n } |> Some
       | _ -> None)
+    |> AnnotatedParser.withNamedRule caseLiteralRule
 
   let softKeyword k =
     parser.Exactly(fun t ->
@@ -255,9 +285,13 @@ module Common =
   let caseKeyword = softKeyword "case"
   let itemKeyword = softKeyword "item"
 
+  let identifiersMatchRule =
+    { Name = "identifiers-match"
+      Rule = Seq [ NonTerminal "identifier"; Optional (Seq [ Terminal "::"; NonTerminal "identifiers-match" ]) ] }
+
   let rec identifiersMatch () =
     parser {
-      let! id = singleIdentifier
+      let! id = singleIdentifier.Parser
 
       return!
         parser.Any
@@ -267,7 +301,7 @@ module Common =
               return!
                 parser {
                   let! ids =
-                    identifiersMatch () |> parser.Map(NonEmptyList.ToList)
+                    (identifiersMatch ()).Parser |> parser.Map(NonEmptyList.ToList)
 
                   return NonEmptyList.OfList(id, ids)
                 }
@@ -277,11 +311,16 @@ module Common =
             }
             parser { return NonEmptyList.OfList(id, []) } ]
     }
+    |> AnnotatedParser.withNamedRule identifiersMatchRule
+
+  let identifierLocalOrFullyQualifiedRule =
+    { Name = "identifier-local-or-fully-qualified"
+      Rule = Alt [ NonTerminal "identifiers-match"; NonTerminal "identifier" ] }
 
   let identifierLocalOrFullyQualified () =
     parser.Any
       [ parser {
-          let! ids = identifiersMatch ()
+          let! ids = (identifiersMatch ()).Parser
           let ids = ids |> NonEmptyList.rev
 
           match ids.Tail with
@@ -289,25 +328,31 @@ module Common =
           | _ -> return Identifier.FullyQualified(ids.Tail, ids.Head)
         }
         parser {
-          let! id = singleIdentifier
+          let! id = singleIdentifier.Parser
           return Identifier.LocalScope id
         } ]
+    |> AnnotatedParser.withNamedRule identifierLocalOrFullyQualifiedRule
+
+  let identifierWithLookupsRule =
+    { Name = "identifier-with-lookups"
+      Rule = Seq [ NonTerminal "identifier-local-or-fully-qualified"; Repeat (Seq [ Terminal "."; NonTerminal "identifier" ]) ] }
 
   let identifierWithLookups () =
     parser {
-      let! id = identifierLocalOrFullyQualified ()
+      let! id = (identifierLocalOrFullyQualified ()).Parser
 
       let! lookups =
         parser.Many(
           parser {
             do! dotOperator
-            let! prop = singleIdentifier
+            let! prop = singleIdentifier.Parser
             return prop
           }
         )
 
       return id, lookups
     }
+    |> AnnotatedParser.withNamedRule identifierWithLookupsRule
 
   let betweenBrackets p =
     parser {
@@ -347,8 +392,23 @@ module Common =
     }
     |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
 
+  let intLiteralTokenRule =
+    { Name = "int-literal"; Rule = Terminal "<int-literal>" }
+
   let intLiteralToken () =
     parser.Exactly(fun t ->
       match t.Token with
       | Token.IntLiteral s -> s |> Some
       | _ -> None)
+    |> AnnotatedParser.withNamedRule intLiteralTokenRule
+
+  let grammarRules: NamedRule list =
+    [ binaryExprOperatorRule
+      binaryTypeOperatorRule
+      singleTermIdentifierRule
+      singleIdentifierRule
+      caseLiteralRule
+      intLiteralTokenRule
+      identifiersMatchRule
+      identifierLocalOrFullyQualifiedRule
+      identifierWithLookupsRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Expr.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Expr.fs
@@ -23,6 +23,7 @@ module Expr =
   open Type
   open Ballerina.DSL.Next.Syntax
   open Ballerina
+  open Ballerina.Grammar
 
   type ComplexExpressionKind =
     | ScopedIdentifier
@@ -60,24 +61,31 @@ module Expr =
 
   let private parseNoComplexShapes: Set<ComplexExpressionKind> = Set.empty
 
+  let exprRule: NamedRule =
+    { Name = "expr"
+      Rule =
+        Alt
+          [ NonTerminal "string-literal"; NonTerminal "int-literal"; NonTerminal "int64-literal"
+            NonTerminal "decimal-literal"; NonTerminal "float32-literal"; NonTerminal "float64-literal"
+            NonTerminal "bool-literal"; NonTerminal "unit-literal"
+            NonTerminal "match-expr"; NonTerminal "lambda-expr"
+            NonTerminal "let-expr"; NonTerminal "do-expr"
+            NonTerminal "conditional-expr"; NonTerminal "record-cons"
+            NonTerminal "type-let"; NonTerminal "identifier-lookup"
+            NonTerminal "application" ] }
+
   let rec expr
     (depth: int)
     (parseComplexShapes: Set<ComplexExpressionKind>)
-    : Parser<
-        Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
 
     let expr = expr (depth + 1)
     let singleIdentifier = singleTermIdentifier
 
-    let typeDecl v = typeDecl (expr parseAllComplexShapes) v
+    let typeDecl v = typeDecl ((expr parseAllComplexShapes).Parser) v
 
     let parseBoundBody () =
-      expr parseAllComplexShapes
+      (expr parseAllComplexShapes).Parser
       |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
     // let indent = "--"
@@ -181,7 +189,7 @@ module Expr =
 
         return!
           parser {
-            let! matchedExpr = expr parseAllComplexShapes
+            let! matchedExpr = (expr parseAllComplexShapes).Parser
             do! parseKeyword Keyword.With
 
             let! cases =
@@ -191,14 +199,14 @@ module Expr =
 
                   let! id =
                     parser.Any
-                      [ identifierLocalOrFullyQualified () |> parser.Map Left
-                        caseLiteral () |> parser.Map Right ]
+                      [ (identifierLocalOrFullyQualified ()).Parser |> parser.Map Left
+                        (caseLiteral ()).Parser |> parser.Map Right ]
 
                   let pattern =
                     parser {
                       let! paramName =
                         parser.Any
-                          [ singleIdentifier |> parser.Map Some
+                          [ singleIdentifier.Parser |> parser.Map Some
                             unitLiteral () |> parser.Map(fun _ -> None)
                             parser.Lookahead(parseOperator Operator.SingleArrow)
                             |> parser.Map("@anonymous" |> Some |> replaceWith)
@@ -217,7 +225,7 @@ module Expr =
                         |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
                       do! parseOperator Operator.SingleArrow
-                      let! body = expr parseAllComplexShapes
+                      let! body = (expr parseAllComplexShapes).Parser
                       return id, (paramName |> Option.map Var.Create, body)
                     }
 
@@ -235,7 +243,7 @@ module Expr =
                 do! timesOperator
 
                 do! parseOperator Operator.SingleArrow
-                let! body = expr parseAllComplexShapes
+                let! body = (expr parseAllComplexShapes).Parser
                 do! closeRoundBracketOperator
                 return body
               }
@@ -291,14 +299,14 @@ module Expr =
       parser.Any
         [ parser {
             do! openRoundBracketOperator
-            let! paramName = singleIdentifier
+            let! paramName = singleIdentifier.Parser
             do! colonOperator
-            let! typeDecl = typeDecl parseAllComplexTypeShapes
+            let! typeDecl = (typeDecl parseAllComplexTypeShapes).Parser
             do! closeRoundBracketOperator
             return paramName, typeDecl |> Some
           }
           parser {
-            let! paramName = singleIdentifier
+            let! paramName = singleIdentifier.Parser
             return paramName, None
           } ]
 
@@ -313,7 +321,7 @@ module Expr =
             let! pars =
               parser.AtLeastOne(
                 parser.Any
-                  [ typeParam |> parser.Map Left
+                  [ typeParam.Parser |> parser.Map Left
                     termParam |> parser.Map Right ]
               )
 
@@ -324,15 +332,15 @@ module Expr =
             let! bodyType =
               match colon with
               | Left _ ->
-                typeDecl (
+                (typeDecl (
                   parseAllComplexTypeShapes
                   |> Set.remove ComplexTypeKind.BinaryExpressionChain
-                )
+                )).Parser
                 |> parser.Map Some
               | Right _ -> parser { return None }
 
             do! parseOperator Operator.SingleArrow
-            let! body = expr parseAllComplexShapes
+            let! body = (expr parseAllComplexShapes).Parser
 
             return
               (body, true)
@@ -369,12 +377,12 @@ module Expr =
           parser.Any
             [ parser {
                 do! openRoundBracketOperator
-                let! paramName = singleIdentifier
+                let! paramName = singleIdentifier.Parser
                 do! colonOperator
 
                 return!
                   parser {
-                    let! typeDecl = typeDecl parseAllComplexTypeShapes
+                    let! typeDecl = (typeDecl parseAllComplexTypeShapes).Parser
                     do! closeRoundBracketOperator
                     return paramName, typeDecl |> Some
                   }
@@ -383,7 +391,7 @@ module Expr =
                   )
               }
               parser {
-                let! paramName = singleIdentifier
+                let! paramName = singleIdentifier.Parser
 
                 let! paramType =
                   parser.Any
@@ -392,7 +400,7 @@ module Expr =
 
                         return!
                           parser {
-                            let! typeDecl = typeDecl parseAllComplexTypeShapes
+                            let! typeDecl = (typeDecl parseAllComplexTypeShapes).Parser
                             return typeDecl |> Some
                           }
                           |> parser.MapError(
@@ -415,7 +423,7 @@ module Expr =
         let! loc' = parser.Location
 
         let! value =
-          expr parseAllComplexShapes
+          (expr parseAllComplexShapes).Parser
           |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
         do!
@@ -449,7 +457,7 @@ module Expr =
         let! loc = parser.Location
 
         let! value =
-          expr parseAllComplexShapes
+          (expr parseAllComplexShapes).Parser
           |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
         do!
@@ -463,7 +471,7 @@ module Expr =
           |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
         let! body =
-          expr parseAllComplexShapes
+          (expr parseAllComplexShapes).Parser
           |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
         return Expr.Do(value, body, loc, TypeCheckScope.Empty)
@@ -477,11 +485,11 @@ module Expr =
 
         return!
           parser {
-            let! cond = expr parseAllComplexShapes
+            let! cond = (expr parseAllComplexShapes).Parser
             do! thenKeyword
-            let! thenBranch = expr parseAllComplexShapes
+            let! thenBranch = (expr parseAllComplexShapes).Parser
             do! elseKeyword
-            let! elseBranch = expr parseAllComplexShapes
+            let! elseBranch = (expr parseAllComplexShapes).Parser
 
             return
               Expr.If(cond, thenBranch, elseBranch, loc, TypeCheckScope.Empty)
@@ -586,7 +594,7 @@ module Expr =
             | Left _ ->
               return mkListLiteral []
             | Right _ ->
-              let! firstExpr = expr parseAllComplexShapes
+              let! firstExpr = (expr parseAllComplexShapes).Parser
 
               let firstLookupId =
                 match firstExpr.Expr with
@@ -599,7 +607,7 @@ module Expr =
                     parser.ManyIndex(fun _ ->
                       parser {
                         do! semicolonOperator
-                        let! value = expr parseAllComplexShapes
+                        let! value = (expr parseAllComplexShapes).Parser
                         return value
                       })
 
@@ -618,9 +626,9 @@ module Expr =
                         if i > 0 then
                           do! semicolonOperator
 
-                        let! id = identifierLocalOrFullyQualified ()
+                        let! id = (identifierLocalOrFullyQualified ()).Parser
                         do! equalsOperator
-                        let! value = expr parseAllComplexShapes
+                        let! value = (expr parseAllComplexShapes).Parser
                         return (id, value)
                       })
 
@@ -634,15 +642,15 @@ module Expr =
                 : Parser<_, _, _, _> =
                 parser {
                   do! equalsOperator
-                  let! firstValue = expr parseAllComplexShapes
+                  let! firstValue = (expr parseAllComplexShapes).Parser
 
                   let! fields =
                     parser.ManyIndex(fun _ ->
                       parser {
                         do! semicolonOperator
-                        let! id = identifierLocalOrFullyQualified ()
+                        let! id = (identifierLocalOrFullyQualified ()).Parser
                         do! equalsOperator
-                        let! value = expr parseAllComplexShapes
+                        let! value = (expr parseAllComplexShapes).Parser
                         return (id, value)
                       })
 
@@ -662,15 +670,15 @@ module Expr =
                 : Parser<_, _, _, _> =
                 parser {
                   do! singleArrowOperator
-                  let! firstValue = expr parseAllComplexShapes
+                  let! firstValue = (expr parseAllComplexShapes).Parser
 
                   let! entries =
                     parser.ManyIndex(fun _ ->
                       parser {
                         do! semicolonOperator
-                        let! key = identifierLocalOrFullyQualified ()
+                        let! key = (identifierLocalOrFullyQualified ()).Parser
                         do! singleArrowOperator
-                        let! value = expr parseAllComplexShapes
+                        let! value = (expr parseAllComplexShapes).Parser
                         return (key, value)
                       })
 
@@ -707,10 +715,10 @@ module Expr =
                   do! commaOperator
 
                   let! value =
-                    expr (
+                    (expr (
                       parseComplexShapes
                       |> Set.remove ComplexExpressionKind.TupleCons
-                    )
+                    )).Parser
 
                   return value
                 }
@@ -732,8 +740,8 @@ module Expr =
 
             let! firstFieldOrRecover =
               parser.Any
-                [ singleIdentifier |> parser.Map(Left >> Some)
-                  intLiteralToken () |> parser.Map(Right >> Some)
+                [ singleIdentifier.Parser |> parser.Map(Left >> Some)
+                  (intLiteralToken ()).Parser |> parser.Map(Right >> Some)
                   parser { return None } ]
 
             match firstFieldOrRecover with
@@ -745,8 +753,8 @@ module Expr =
 
                     return!
                       parser.Any
-                        [ singleIdentifier |> parser.Map Left
-                          intLiteralToken () |> parser.Map Right ]
+                        [ singleIdentifier.Parser |> parser.Map Left
+                          (intLiteralToken ()).Parser |> parser.Map Right ]
                   }
                 )
                 |> parser.Try
@@ -769,7 +777,7 @@ module Expr =
         let! loc = parser.Location
 
         let! id =
-          singleIdentifier
+          singleIdentifier.Parser
           |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
           |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
 
@@ -777,7 +785,7 @@ module Expr =
 
         let! typeDecl =
           parser.Any
-            [ typeDecl parseAllComplexTypeShapes
+            [ (typeDecl parseAllComplexTypeShapes).Parser
               |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.Low))
               (fun () ->
                 $"Malformed type declaration for '{id}' at {loc}")
@@ -855,7 +863,7 @@ module Expr =
       parser {
         let! id =
           parser.Any
-            [ singleIdentifier
+            [ singleIdentifier.Parser
               schemaKeyword |> parser.Map(replaceWith "schema")
               entityKeyword |> parser.Map(replaceWith "entity")
               relationKeyword |> parser.Map(replaceWith "relation") ]
@@ -876,7 +884,7 @@ module Expr =
 
             let! firstIdOrNone =
               parser.Any
-                [ singleIdentifier |> parser.Map Some
+                [ singleIdentifier.Parser |> parser.Map Some
                   parser { return None } ]
 
             match firstIdOrNone with
@@ -887,7 +895,7 @@ module Expr =
                 parser.AtLeastOne(
                   parser {
                     do! doubleColonOperator
-                    return! singleIdentifier
+                    return! singleIdentifier.Parser
                   }
                 )
                 |> parser.Try
@@ -911,13 +919,13 @@ module Expr =
             let! fields =
               parser.AtLeastOne(
                 parser {
-                  let! op = binaryExprOperator
+                  let! op = binaryExprOperator.Parser
 
                   let! value =
-                    expr (
+                    (expr (
                       parseComplexShapes
                       |> Set.remove ComplexExpressionKind.BinaryExpressionChain
-                    )
+                    )).Parser
 
                   return op, value
                 }
@@ -932,9 +940,9 @@ module Expr =
       parser {
         let! res =
           parser.Any
-            [ expr (Set.singleton ComplexExpressionKind.RecordDes)
+            [ (expr (Set.singleton ComplexExpressionKind.RecordDes)).Parser
               |> parser.Map Sum.Left
-              (fun () -> typeDecl parseAllComplexTypeShapes)
+              (fun () -> (typeDecl parseAllComplexTypeShapes).Parser)
               |> betweenSquareBrackets
               |> parser.Map(Sum.Right) ]
           |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
@@ -981,27 +989,27 @@ module Expr =
       | Token.StringLiteral _ -> [ stringLiteral () ]
       | Token.IntLiteral _ -> [ intLiteral () ]
       | Token.Int64Literal _ -> [ int64Literal () ]
-      | Token.CaseLiteral _ -> [ caseLiteral () |> parser.Map Expr.SumCons ]
+      | Token.CaseLiteral _ -> [ (caseLiteral ()).Parser |> parser.Map Expr.SumCons ]
       | Token.DecimalLiteral _ -> [ decimalLiteral () ]
       | Token.Float32Literal _ -> [ float32Literal () ]
       | Token.Float64Literal _ -> [ float64Literal () ]
       | Token.BoolLiteral _ -> [ boolLiteral () ]
       | Token.Operator(Operator.RoundBracket Bracket.Open) ->
         [ unitLiteral ()
-          betweenBrackets (fun () -> expr parseAllComplexShapes) ]
+          betweenBrackets (fun () -> (expr parseAllComplexShapes).Parser) ]
       | Token.Keyword Keyword.Fun -> [ exprLambda () ]
       | Token.Keyword Keyword.If -> [ exprConditional () ]
       | Token.Operator(Operator.CurlyBracket Bracket.Open) -> [ recordCons () ]
       | Token.Keyword Keyword.Type -> [ typeLet () ]
       | Token.Keyword Keyword.Match -> [ matchWith () ]
       | Token.Keyword Keyword.Query ->
-        [ query (fun () -> expr parseAllComplexShapes) () ]
+        [ (query (fun () -> (expr parseAllComplexShapes).Parser) ()).Parser ]
       | Token.Keyword Keyword.View ->
         [ // Try View::name first, then fall back to view expression
           parser {
             do! parseKeyword Keyword.View
             do! doubleColonOperator
-            let! name = singleIdentifier
+            let! name = singleIdentifier.Parser
             let! loc = parser.Location
             match ViewOperationKind.TryParse name with
             | Some op ->
@@ -1015,13 +1023,13 @@ module Expr =
                 |> Errors.Singleton loc
                 |> parser.Throw
           }
-          viewExpr (fun () -> expr parseAllComplexShapes) () ]
+          (viewExpr (fun () -> (expr parseAllComplexShapes).Parser) ()).Parser ]
       | Token.Keyword Keyword.Co ->
         [ // Try Co::name first, then fall back to co expression
           parser {
             do! parseKeyword Keyword.Co
             do! doubleColonOperator
-            let! name = singleIdentifier
+            let! name = singleIdentifier.Parser
             let! loc = parser.Location
             match CoOperationKind.TryParse name with
             | Some op ->
@@ -1035,9 +1043,9 @@ module Expr =
                 |> Errors.Singleton loc
                 |> parser.Throw
           }
-          coExpr (fun () -> expr parseAllComplexShapes) () ]
+          (coExpr (fun () -> (expr parseAllComplexShapes).Parser) ()).Parser ]
       | Token.Operator Operator.LessThan ->
-        [ viewNodeExpr (fun () -> expr parseAllComplexShapes) () ]
+        [ (viewNodeExpr (fun () -> (expr parseAllComplexShapes).Parser) ()).Parser ]
       | Token.Identifier _
       | Token.Keyword Keyword.Schema
       | Token.Keyword Keyword.Entity
@@ -1089,7 +1097,7 @@ module Expr =
         //   )
 
         // do Console.ReadLine() |> ignore
-        let! e = expr parseNoComplexShapes
+        let! e = (expr parseNoComplexShapes).Parser
         // do Console.Write $"{e.ToFSharpString}"
         // do Console.WriteLine $"included = {parseComplexShapes.ToFSharpString}"
         // do Console.ReadLine() |> ignore
@@ -1392,12 +1400,18 @@ module Expr =
         | Sum.Right e -> return! e |> parser.Throw
         | Sum.Left res -> return res
     }
+    |> AnnotatedParser.withNamedRule exprRule
+
+  let programRule: NamedRule =
+    { Name = "program"
+      Rule = Seq [ NonTerminal "expr"; Terminal "<eof>" ] }
 
   let program<'valueExt>
     ()
-    : Parser<Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>, _, _, _> =
+    : AnnotatedParser<Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>>
+    =
     parser {
-      let! e = expr 0 parseAllComplexShapes
+      let! e = (expr 0 parseAllComplexShapes).Parser
 
       let! loc = parser.Location
 
@@ -1412,3 +1426,6 @@ module Expr =
       do! parser.EndOfStream()
       return e
     }
+    |> AnnotatedParser.withNamedRule programRule
+
+  let grammarRules: NamedRule list = [ exprRule; programRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Grammar.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Grammar.fs
@@ -1,0 +1,15 @@
+namespace Ballerina.DSL.Next.Syntax.Parser
+
+open Ballerina.Grammar
+
+module Grammar =
+
+  let allRules: NamedRule list =
+    Common.grammarRules
+    @ Kind.grammarRules
+    @ TypeHooksAndProperties.grammarRules
+    @ TypeSchema.grammarRules
+    @ Type.grammarRules
+    @ Query.grammarRules
+    @ View.grammarRules
+    @ Expr.grammarRules

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Kind.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Kind.fs
@@ -14,6 +14,13 @@ module Kind =
   open Ballerina.LocalizedErrors
   open Ballerina.Errors
   open Ballerina.DSL.Next.Terms
+  open Ballerina.Grammar
+
+  let kindDeclRule =
+    { Name = "kind"
+      Rule =
+        Seq [ Alt [ Terminal "*"; Seq [ Terminal "("; NonTerminal "kind"; Terminal ")" ] ]
+              Optional (Seq [ Terminal "->"; NonTerminal "kind" ]) ] }
 
   let rec kindDecl () =
     parser {
@@ -22,7 +29,7 @@ module Kind =
           [ (starOperator |> parser.Map(fun _ -> Kind.Star))
             (parser {
               do! openRoundBracketOperator
-              let! res = kindDecl ()
+              let! res = (kindDecl ()).Parser
               do! closeRoundBracketOperator
               return res
             }) ]
@@ -32,6 +39,9 @@ module Kind =
       match singleArrow with
       | Right _ -> return Kind.Star
       | _ ->
-        let! rest = kindDecl ()
+        let! rest = (kindDecl ()).Parser
         return Kind.Arrow(first, rest)
     }
+    |> AnnotatedParser.withNamedRule kindDeclRule
+
+  let grammarRules: NamedRule list = [ kindDeclRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Query.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Query.fs
@@ -23,6 +23,7 @@ module Query =
   open Type
   open Ballerina.DSL.Next.Syntax
   open Ballerina
+  open Ballerina.Grammar
 
   type ComplexExpressionKind =
     | ScopedIdentifier
@@ -54,16 +55,19 @@ module Query =
 
   let private parseNoComplexShapes: Set<ComplexExpressionKind> = Set.empty
 
+  let queryExprRule: NamedRule =
+    { Name = "query-expr"
+      Rule =
+        Alt
+          [ NonTerminal "string-literal"; NonTerminal "int-literal"
+            NonTerminal "decimal-literal"; NonTerminal "bool-literal"
+            NonTerminal "conditional-expr"; NonTerminal "identifier-lookup"
+            NonTerminal "application" ] }
+
   let rec queryexpr<'valueExt>
     (query: unit -> _)
     (depth: int)
     (parseComplexShapes: Set<ComplexExpressionKind>)
-    : Parser<
-        ExprQueryExpr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
 
     let expr = queryexpr query (depth + 1)
@@ -159,11 +163,11 @@ module Query =
 
         return!
           parser {
-            let! cond = expr parseAllComplexShapes
+            let! cond = (expr parseAllComplexShapes).Parser
             do! thenKeyword
-            let! thenBranch = expr parseAllComplexShapes
+            let! thenBranch = (expr parseAllComplexShapes).Parser
             do! elseKeyword
-            let! elseBranch = expr parseAllComplexShapes
+            let! elseBranch = (expr parseAllComplexShapes).Parser
 
             return
               ExprQueryExprRec.QueryConditional(cond, thenBranch, elseBranch)
@@ -179,7 +183,7 @@ module Query =
 
         return!
           parser {
-            let! q = query ()
+            let! q = (query ()).Parser
 
             return ExprQueryExprRec.QueryCount(q) |> ExprQueryExpr.Create loc
           }
@@ -193,7 +197,7 @@ module Query =
 
         return!
           parser {
-            let! q = query ()
+            let! q = (query ()).Parser
 
             return ExprQueryExprRec.QueryExists(q) |> ExprQueryExpr.Create loc
           }
@@ -207,7 +211,7 @@ module Query =
 
         return!
           parser {
-            let! q = query ()
+            let! q = (query ()).Parser
 
             return ExprQueryExprRec.QueryArray(q) |> ExprQueryExpr.Create loc
           }
@@ -226,10 +230,10 @@ module Query =
                   do! commaOperator
 
                   let! value =
-                    expr (
+                    (expr (
                       parseComplexShapes
                       |> Set.remove ComplexExpressionKind.TupleCons
-                    )
+                    )).Parser
 
                   return value
                 }
@@ -254,7 +258,7 @@ module Query =
                   return!
                     parser.Any
                       [ singleIdentifier |> parser.Map Left
-                        intLiteralToken () |> parser.Map Right ]
+                        (intLiteralToken ()).Parser |> parser.Map Right ]
                 }
               )
 
@@ -320,13 +324,13 @@ module Query =
             let! fields =
               parser.AtLeastOne(
                 parser {
-                  let! op = binaryExprOperator
+                  let! op = binaryExprOperator.Parser
 
                   let! value =
-                    expr (
+                    (expr (
                       parseComplexShapes
                       |> Set.remove ComplexExpressionKind.BinaryExpressionChain
-                    )
+                    )).Parser
 
                   return op, value
                 }
@@ -338,7 +342,7 @@ module Query =
       }
 
     let argExpr () =
-      expr parseNoComplexShapes
+      (expr parseNoComplexShapes).Parser
       |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
 
     let application () =
@@ -356,7 +360,7 @@ module Query =
         decimalLiteral ()
         boolLiteral ()
         unitLiteral ()
-        betweenBrackets (fun () -> expr parseAllComplexShapes)
+        betweenBrackets (fun () -> (expr parseAllComplexShapes).Parser)
         exprConditional ()
         exprCount ()
         exprExists ()
@@ -388,7 +392,7 @@ module Query =
         //   )
 
         // do Console.ReadLine() |> ignore
-        let! e = expr parseNoComplexShapes
+        let! e = (expr parseNoComplexShapes).Parser
         // do Console.Write $"{e.ToFSharpString}"
         // do Console.WriteLine $"included = {parseComplexShapes.ToFSharpString}"
         // do Console.ReadLine() |> ignore
@@ -619,7 +623,13 @@ module Query =
         | Sum.Right e -> return! e |> parser.Throw
         | Sum.Left res -> return res
     }
+    |> AnnotatedParser.withNamedRule queryExprRule
 
+
+  let queryIteratorsRule: NamedRule =
+    { Name = "query-iterators"
+      Rule =
+        Repeat1 (Seq [ Terminal "from"; NonTerminal "identifier"; Terminal "in"; NonTerminal "expr" ]) }
 
   let rec private query_iterators_and_datasources<'valueExt>
     (expr:
@@ -639,7 +649,7 @@ module Query =
         parser {
 
           let! loc = parser.Location
-          let! _iterators = queryexpr<'valueExt> query 0 parseAllComplexShapes
+          let! _iterators = (queryexpr<'valueExt> query 0 parseAllComplexShapes).Parser
 
           let! _iterators =
             [ parser {
@@ -744,6 +754,12 @@ module Query =
         }
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule queryIteratorsRule
+
+  let queryJoinsRule: NamedRule =
+    { Name = "query-joins"
+      Rule =
+        Repeat (Seq [ Terminal "join"; NonTerminal "identifier"; Terminal "in"; NonTerminal "expr"; Terminal "on"; NonTerminal "expr"; Terminal "="; NonTerminal "expr" ]) }
 
   let private query_joins<'valueExt> query =
     parser {
@@ -764,7 +780,7 @@ module Query =
                     do! andKeyword
 
                   let! join_terms =
-                    queryexpr<'valueExt> query 0 parseAllComplexShapes
+                    (queryexpr<'valueExt> query 0 parseAllComplexShapes).Parser
 
                   let! join_terms =
                     join_terms
@@ -800,6 +816,12 @@ module Query =
           }
           |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule queryJoinsRule
+
+  let queryWhereRule: NamedRule =
+    { Name = "query-where"
+      Rule =
+        Optional (Seq [ Terminal "where"; NonTerminal "expr" ]) }
 
   let private query_where<'valueExt> query =
     parser {
@@ -810,20 +832,32 @@ module Query =
       | Left _ ->
         return!
           parser {
-            let! predicate = queryexpr<'valueExt> query 0 parseAllComplexShapes
+            let! predicate = (queryexpr<'valueExt> query 0 parseAllComplexShapes).Parser
             return Some predicate
           }
           |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule queryWhereRule
+
+  let querySelectRule: NamedRule =
+    { Name = "query-select"
+      Rule =
+        Seq [ Terminal "select"; NonTerminal "expr" ] }
 
   let private query_select<'valueExt> query =
     parser {
       do! selectKeyword
 
       return!
-        queryexpr<'valueExt> query 0 parseAllComplexShapes
+        (queryexpr<'valueExt> query 0 parseAllComplexShapes).Parser
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule querySelectRule
+
+  let queryOrderbyRule: NamedRule =
+    { Name = "query-orderby"
+      Rule =
+        Optional (Seq [ Terminal "orderBy"; NonTerminal "expr"; Alt [ Terminal "ascending"; Terminal "descending" ] ]) }
 
   let private query_orderby<'valueExt> query =
     parser {
@@ -834,7 +868,7 @@ module Query =
           match starts_with_orderby with
           | Right _ -> return None
           | Left _ ->
-            let! predicate = queryexpr<'valueExt> query 0 parseAllComplexShapes
+            let! predicate = (queryexpr<'valueExt> query 0 parseAllComplexShapes).Parser
             let! is_ascending = ascendingKeyword |> parser.Try
 
             if is_ascending.IsLeft then
@@ -855,6 +889,12 @@ module Query =
         }
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule queryOrderbyRule
+
+  let queryDistinctRule: NamedRule =
+    { Name = "query-distinct"
+      Rule =
+        Optional (Terminal "distinct") }
 
   let private query_distinct<'valueExt> (query) =
     parser {
@@ -868,7 +908,7 @@ module Query =
             return!
               parser {
                 let! distinction =
-                  queryexpr<'valueExt> query 0 parseAllComplexShapes
+                  (queryexpr<'valueExt> query 0 parseAllComplexShapes).Parser
 
                 return Some distinction
               }
@@ -878,6 +918,12 @@ module Query =
         }
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule queryDistinctRule
+
+  let queryBodyRule: NamedRule =
+    { Name = "query-body"
+      Rule =
+        Seq [ NonTerminal "query-iterators"; NonTerminal "query-joins"; NonTerminal "query-where"; NonTerminal "query-select"; NonTerminal "query-orderby"; NonTerminal "query-distinct" ] }
 
   let rec private query'<'valueExt>
     (expr:
@@ -889,12 +935,6 @@ module Query =
           Errors<Location>
          >)
     ()
-    : Parser<
-        ExprQuery<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     parser {
       let! hasBracket =
@@ -910,13 +950,13 @@ module Query =
           do! openCurlyBracketOperator
 
           let! iterators_with_datasources =
-            query_iterators_and_datasources expr (query expr)
+            (query_iterators_and_datasources expr (query expr)).Parser
 
-          let! joins = query_joins (query expr)
-          let! where_ = query_where (query expr)
-          let! select_expr = query_select<'valueExt> (query expr)
-          let! orderby_ = query_orderby (query expr)
-          let! distinct_ = query_distinct (query expr)
+          let! joins = (query_joins (query expr)).Parser
+          let! where_ = (query_where (query expr)).Parser
+          let! select_expr = (query_select<'valueExt> (query expr)).Parser
+          let! orderby_ = (query_orderby (query expr)).Parser
+          let! distinct_ = (query_distinct (query expr)).Parser
 
           do! closeCurlyBracketOperator
 
@@ -940,6 +980,12 @@ module Query =
         }
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule queryBodyRule
+
+  let queryRule: NamedRule =
+    { Name = "query"
+      Rule =
+        Seq [ Terminal "query"; Terminal "{"; NonTerminal "query-body"; Terminal "}" ] }
 
   let query<'valueExt>
     (expr:
@@ -951,17 +997,16 @@ module Query =
           Errors<Location>
          >)
     ()
-    : Parser<
-        Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     parser {
       let! loc = parser.Location
 
-      let! q = query' expr ()
+      let! q = (query' expr ()).Parser
       let res = Expr.Query(q, loc, TypeCheckScope.Empty)
       return res
     }
+    |> AnnotatedParser.withNamedRule queryRule
+
+  let grammarRules: NamedRule list =
+    [ queryExprRule; queryIteratorsRule; queryJoinsRule; queryWhereRule
+      querySelectRule; queryOrderbyRule; queryDistinctRule; queryBodyRule; queryRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type.fs
@@ -18,6 +18,7 @@ module Type =
   open Ballerina.DSL.Next.Terms
   open Ballerina
   open Ballerina.DSL.Next.Syntax.Parser.TypeSchema
+  open Ballerina.Grammar
 
   type ComplexTypeKind =
     | ScopedIdentifier
@@ -41,15 +42,34 @@ module Type =
 
   let parseNoComplexTypeShapes: Set<ComplexTypeKind> = Set.empty
 
+  let typeParamRule =
+    { Name = "type-param"
+      Rule =
+        Seq [ Terminal "["; NonTerminal "identifier"; Terminal ":"; NonTerminal "kind"; Terminal "]" ] }
+
   let typeParam =
     parser {
       do! openSquareBracketOperator
-      let! paramName = singleIdentifier
+      let! paramName = singleIdentifier.Parser
       do! colonOperator
-      let! kind = kindDecl ()
+      let! kind = (kindDecl ()).Parser
       do! closeSquareBracketOperator
       return paramName, kind
     }
+    |> AnnotatedParser.withNamedRule typeParamRule
+
+  let typeDeclRule =
+    { Name = "type-decl"
+      Rule =
+        Alt
+          [ NonTerminal "type-param"
+            Terminal "bool"; Terminal "int"; Terminal "int64"
+            Terminal "float32"; Terminal "float64"; Terminal "decimal"
+            Terminal "string"; Terminal "guid"; Terminal "dateTime"
+            Terminal "dateOnly"; Terminal "timeSpan"; Terminal "vector"
+            Terminal "FromQueryRow"; Seq [ Terminal "("; Terminal ")" ]
+            NonTerminal "schema-decl"; NonTerminal "record-type"
+            NonTerminal "union-type"; NonTerminal "identifier" ] }
 
   let rec typeDecl
     (parseExpr:
@@ -60,16 +80,16 @@ module Type =
         Errors<Location>
        >)
     (parseComplexShapes: Set<ComplexTypeKind>)
-    : Parser<TypeExpr<'valueExt>, _, _, Errors<Location>> =
+    =
     let lookupTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
         return TypeExpr.Lookup(Identifier.LocalScope id)
       }
 
     let boolTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "boolean" -> return TypeExpr.Primitive PrimitiveType.Bool
@@ -85,7 +105,7 @@ module Type =
 
     let int32TypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "int" -> return TypeExpr.Primitive PrimitiveType.Int32
@@ -102,7 +122,7 @@ module Type =
 
     let int64TypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "int64" -> return TypeExpr.Primitive PrimitiveType.Int64
@@ -117,7 +137,7 @@ module Type =
 
     let float32TypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "float32" -> return TypeExpr.Primitive PrimitiveType.Float32
@@ -132,7 +152,7 @@ module Type =
 
     let float64TypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "float64" -> return TypeExpr.Primitive PrimitiveType.Float64
@@ -147,7 +167,7 @@ module Type =
 
     let decimalTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "decimal" -> return TypeExpr.Primitive PrimitiveType.Decimal
@@ -162,7 +182,7 @@ module Type =
 
     let stringTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "string" -> return TypeExpr.Primitive PrimitiveType.String
@@ -177,7 +197,7 @@ module Type =
 
     let guidTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "guid" -> return TypeExpr.Primitive PrimitiveType.Guid
@@ -192,7 +212,7 @@ module Type =
 
     let dateTimeTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "dateTime" -> return TypeExpr.Primitive PrimitiveType.DateTime
@@ -207,7 +227,7 @@ module Type =
 
     let dateOnlyTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "date" -> return TypeExpr.Primitive PrimitiveType.DateOnly
@@ -223,7 +243,7 @@ module Type =
 
     let timeSpanTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "timeSpan" -> return TypeExpr.Primitive PrimitiveType.TimeSpan
@@ -238,7 +258,7 @@ module Type =
 
     let vectorTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "vector" -> return TypeExpr.Primitive PrimitiveType.Vector
@@ -253,7 +273,7 @@ module Type =
 
     let fromQueryRowTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "FromQueryRow" -> return TypeExpr.FromQueryRow
@@ -274,10 +294,10 @@ module Type =
       }
 
     let schema () =
-      TypeSchema.schema
+      (TypeSchema.schema
         parseExpr
-        (fun () -> typeDecl parseExpr parseAllComplexTypeShapes)
-        ()
+        (fun () -> (typeDecl parseExpr parseAllComplexTypeShapes).Parser)
+        ()).Parser
 
     let record () =
       parser {
@@ -291,7 +311,7 @@ module Type =
                   if i > 0 then
                     do! semicolonOperator
 
-                  let! id = singleIdentifier
+                  let! id = singleIdentifier.Parser
                   let! fieldLoc = parser.Location
 
                   do!
@@ -307,7 +327,7 @@ module Type =
                   return!
                     parser {
                       let! typeDecl =
-                        typeDecl parseExpr parseAllComplexTypeShapes
+                        (typeDecl parseExpr parseAllComplexTypeShapes).Parser
 
                       return (id, typeDecl)
                     }
@@ -345,11 +365,11 @@ module Type =
 
                   return!
                     parser {
-                      let! id = singleIdentifier
+                      let! id = singleIdentifier.Parser
                       do! ofKeyword
 
                       let! typeDecl =
-                        typeDecl parseExpr parseAllComplexTypeShapes
+                        (typeDecl parseExpr parseAllComplexTypeShapes).Parser
 
                       return (id, typeDecl)
                     }
@@ -381,7 +401,7 @@ module Type =
               parser.AtLeastOne(
                 parser {
                   do! doubleColonOperator
-                  return! singleIdentifier
+                  return! singleIdentifier.Parser
                 }
               )
 
@@ -400,13 +420,13 @@ module Type =
             let! fields =
               parser.AtLeastOne(
                 parser {
-                  let! op = binaryTypeOperator
+                  let! op = binaryTypeOperator.Parser
 
                   let! value =
-                    typeDecl
+                    (typeDecl
                       parseExpr
                       (parseComplexShapes
-                       |> Set.remove ComplexTypeKind.BinaryExpressionChain)
+                       |> Set.remove ComplexTypeKind.BinaryExpressionChain)).Parser
 
                   return op, value
                 }
@@ -431,8 +451,8 @@ module Type =
 
                   return!
                     parser.Any
-                      [ singleIdentifier |> parser.Map Left
-                        intLiteralToken () |> parser.Map Right ]
+                      [ singleIdentifier.Parser |> parser.Map Left
+                        (intLiteralToken ()).Parser |> parser.Map Right ]
                 }
               )
 
@@ -447,7 +467,7 @@ module Type =
       parser {
         let! args =
           parser.AtLeastOne(
-            (fun () -> typeDecl parseExpr parseAllComplexTypeShapes)
+            (fun () -> (typeDecl parseExpr parseAllComplexTypeShapes).Parser)
             |> betweenSquareBrackets
           )
 
@@ -456,10 +476,10 @@ module Type =
 
     let typeLambda () =
       parser {
-        let! pars = parser.AtLeastOne typeParam
+        let! pars = parser.AtLeastOne typeParam.Parser
         do! parseOperator Operator.SingleArrow
         let pars = pars |> NonEmptyList.ToSeq
-        let! body = typeDecl parseExpr parseAllComplexTypeShapes
+        let! body = (typeDecl parseExpr parseAllComplexTypeShapes).Parser
 
         return
           Seq.foldBack
@@ -470,7 +490,7 @@ module Type =
       }
 
     let simpleShapes =
-      [ (fun () -> typeDecl parseExpr parseAllComplexTypeShapes)
+      [ (fun () -> (typeDecl parseExpr parseAllComplexTypeShapes).Parser)
         |> betweenBrackets
         typeLambda ()
         schema ()
@@ -516,7 +536,7 @@ module Type =
         //   )
 
         // do Console.ReadLine() |> ignore
-        let! e = typeDecl parseExpr parseNoComplexTypeShapes
+        let! e = (typeDecl parseExpr parseNoComplexTypeShapes).Parser
         // do Console.Write $"{e.ToFSharpString}"
         // do Console.WriteLine $"included = {parseComplexShapes.ToFSharpString}"
         // do Console.ReadLine() |> ignore
@@ -711,3 +731,6 @@ module Type =
         | Sum.Right e -> return! e |> parser.Throw
         | Sum.Left(res, _) -> return res
     }
+    |> AnnotatedParser.withNamedRule typeDeclRule
+
+  let grammarRules: NamedRule list = [ typeParamRule; typeDeclRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type/HooksAndProperties.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type/HooksAndProperties.fs
@@ -12,6 +12,7 @@ module TypeHooksAndProperties =
   open Ballerina.LocalizedErrors
   open Ballerina.Errors
   open Ballerina
+  open Ballerina.Grammar
 
   type TypeExprParser<'valueExt> =
     Parser<
@@ -23,6 +24,10 @@ module TypeHooksAndProperties =
 
   type TypeDeclParser<'valueExt> =
     Parser<TypeExpr<'valueExt>, LocalizedToken, Location, Errors<Location>>
+
+  let relationHooksRule =
+    { Name = "relation-hooks"
+      Rule = Repeat (Seq [ Terminal "let"; Terminal "on"; Alt [ Terminal "linking"; Terminal "linked"; Terminal "unlinking"; Terminal "unlinked" ]; Terminal "="; NonTerminal "expr" ]) }
 
   let relation_hooks (parseExpr: TypeExprParser<'valueExt>) () =
     let onHook (hookKeyword, hookKeywordParser) =
@@ -57,6 +62,11 @@ module TypeHooksAndProperties =
     |> parser.Any
     |> parser.Many
     |> parser.Map(Map.ofList)
+    |> AnnotatedParser.withNamedRule relationHooksRule
+
+  let entityHooksRule =
+    { Name = "entity-hooks"
+      Rule = Repeat (Seq [ Terminal "let"; Alt [ Terminal "on"; Terminal "can" ]; Alt [ Terminal "creating"; Terminal "created"; Terminal "updating"; Terminal "updated"; Terminal "deleting"; Terminal "deleted"; Terminal "background"; Terminal "create"; Terminal "read"; Terminal "update"; Terminal "delete" ]; Terminal "="; NonTerminal "expr" ]) }
 
   let entity_hooks (parseExpr: TypeExprParser<'valueExt>) () =
     let onHook (preHookKeyword) (hookKeyword, hookKeywordParser) =
@@ -98,25 +108,24 @@ module TypeHooksAndProperties =
     |> parser.Any
     |> parser.Many
     |> parser.Map(Map.ofList)
+    |> AnnotatedParser.withNamedRule entityHooksRule
+
+  let entityPropertiesRule =
+    { Name = "entity-properties"
+      Rule = Repeat (Seq [ Terminal "let"; Terminal "property"; Optional (NonTerminal "schema-path"); NonTerminal "identifier"; Terminal ":"; NonTerminal "type-decl"; Terminal "="; NonTerminal "expr" ]) }
 
   let entity_properties
     (parseExpr: TypeExprParser<'valueExt>)
     parseSchemaPath
     (parseTypeDecl: unit -> TypeDeclParser<'valueExt>)
     ()
-    : Parser<
-        SchemaEntityPropertyExpr<'valueExt> list,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     parser.Many(
       parser {
         do! letKeyword
         do! propertyKeyword
         let! path = parseSchemaPath ()
-        let! propertyName = singleIdentifier
+        let! propertyName = singleIdentifier.Parser
         do! colonOperator
         let! propertyType = parseTypeDecl ()
         do! equalsOperator
@@ -130,16 +139,15 @@ module TypeHooksAndProperties =
       }
     )
     |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
+    |> AnnotatedParser.withNamedRule entityPropertiesRule
+
+  let entityVectorsRule =
+    { Name = "entity-vectors"
+      Rule = Repeat (Seq [ Terminal "let"; Terminal "vector"; NonTerminal "identifier"; Terminal "="; NonTerminal "expr" ]) }
 
   let entity_vectors
     (parseExpr: TypeExprParser<'valueExt>)
     ()
-    : Parser<
-        SchemaEntityVectorExpr<'valueExt> list,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     parser.Many(
       parser {
@@ -158,7 +166,7 @@ module TypeHooksAndProperties =
           |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
           |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
 
-        let! vectorName = singleIdentifier
+        let! vectorName = singleIdentifier.Parser
         do! equalsOperator
         let! vectorBody = parseExpr
 
@@ -168,3 +176,6 @@ module TypeHooksAndProperties =
       }
     )
     |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
+    |> AnnotatedParser.withNamedRule entityVectorsRule
+
+  let grammarRules: NamedRule list = [ relationHooksRule; entityHooksRule; entityPropertiesRule; entityVectorsRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type/Schema.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type/Schema.fs
@@ -12,6 +12,7 @@ module TypeSchema =
   open Ballerina.LocalizedErrors
   open Ballerina.Errors
   open Ballerina
+  open Ballerina.Grammar
 
   type TypeExprParser<'valueExt> =
     Parser<
@@ -24,10 +25,14 @@ module TypeSchema =
   type TypeDeclParser<'valueExt> =
     Parser<TypeExpr<'valueExt>, LocalizedToken, Location, Errors<Location>>
 
+  let cardinalityRule =
+    { Name = "cardinality"
+      Rule = Alt [ Terminal "0"; Terminal "1"; Terminal "*" ] }
+
   let cardinality () =
     parser.Any
       [ parser {
-          let! v = intLiteralToken ()
+          let! v = (intLiteralToken ()).Parser
 
           if v = 0 then
             return Cardinality.Zero
@@ -56,6 +61,11 @@ module TypeSchema =
         }
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High)) ]
     |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
+    |> AnnotatedParser.withNamedRule cardinalityRule
+
+  let schemaPathRule =
+    { Name = "schema-path"
+      Rule = Optional (Seq [ Terminal "["; NonTerminal "schema-path-segments"; Terminal "]" ]) }
 
   let rec schemaPath () =
     parser {
@@ -64,12 +74,17 @@ module TypeSchema =
       | Left _ ->
         return!
           parser {
-            let! segments = schemaPathSegments ()
+            let! segments = (schemaPathSegments ()).Parser
             do! closeSquareBracketOperator
             return Some segments
           }
           |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule schemaPathRule
+
+  and schemaPathSegmentsRule =
+    { Name = "schema-path-segments"
+      Rule = Repeat (Seq [ Optional (Seq [ Terminal "let"; NonTerminal "identifier"; Terminal ":" ]); Alt [ Seq [ Terminal "field"; NonTerminal "identifier" ]; Seq [ Terminal "case"; NonTerminal "identifier" ]; Seq [ Terminal "item"; NonTerminal "int-literal" ]; Seq [ Terminal "iterator"; Terminal "("; NonTerminal "identifier"; Terminal ","; NonTerminal "identifier"; Terminal ","; NonTerminal "identifier"; Terminal ")" ] ] ]) }
 
   and schemaPathSegments () =
     parser.ManyIndex(fun i ->
@@ -84,7 +99,7 @@ module TypeSchema =
             match no_binding with
             | Right _ -> return None
             | Left _ ->
-              let! id = singleIdentifier
+              let! id = singleIdentifier.Parser
               do! colonOperator
               let id = id |> LocalIdentifier.Create
               return id |> Some
@@ -95,35 +110,35 @@ module TypeSchema =
             [ afterKeyword
                 fieldKeyword
                 (parser {
-                  let! id = identifierLocalOrFullyQualified ()
+                  let! id = (identifierLocalOrFullyQualified ()).Parser
                   return SchemaPathTypeDecompositionExpr.Field id
                 })
               afterKeyword
                 caseKeyword
                 (parser.Any
                   [ parser {
-                      let! id = identifierLocalOrFullyQualified ()
+                      let! id = (identifierLocalOrFullyQualified ()).Parser
                       return SchemaPathTypeDecompositionExpr.UnionCase id
                     }
                     parser {
-                      let! case = caseLiteral ()
+                      let! case = (caseLiteral ()).Parser
                       return SchemaPathTypeDecompositionExpr.SumCase case
                     } ])
               afterKeyword
                 itemKeyword
                 (parser {
-                  let! item = intLiteralToken ()
+                  let! item = (intLiteralToken ()).Parser
                   return SchemaPathTypeDecompositionExpr.Item { Index = item }
                 })
               afterKeyword
                 iteratorKeyword
                 (parser {
                   do! openRoundBracketOperator
-                  let! mapper = identifierLocalOrFullyQualified ()
+                  let! mapper = (identifierLocalOrFullyQualified ()).Parser
                   do! commaOperator
-                  let! containerType = identifierLocalOrFullyQualified ()
+                  let! containerType = (identifierLocalOrFullyQualified ()).Parser
                   do! commaOperator
-                  let! typeDef = identifierLocalOrFullyQualified ()
+                  let! typeDef = (identifierLocalOrFullyQualified ()).Parser
                   do! closeRoundBracketOperator
 
                   return
@@ -137,24 +152,23 @@ module TypeSchema =
         return var, res
       })
     |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
+    |> AnnotatedParser.withNamedRule schemaPathSegmentsRule
+
+  let relationExtensionRule =
+    { Name = "relation-extension"
+      Rule = Seq [ Terminal "relation"; NonTerminal "identifier"; Terminal "{"; NonTerminal "relation-hooks"; Terminal "}" ] }
 
   let relation_extension
     (parseExpr: TypeExprParser<'valueExt>)
     ()
-    : Parser<
-        (SchemaRelationName * SchemaRelationHooksExpr<'valueExt>),
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     afterKeyword
       relationKeyword
       (parser {
-        let! relationName = singleIdentifier
+        let! relationName = singleIdentifier.Parser
         do! openCurlyBracketOperator
 
-        let! hooks = TypeHooksAndProperties.relation_hooks parseExpr ()
+        let! hooks = (TypeHooksAndProperties.relation_hooks parseExpr ()).Parser
 
         let onLinking = hooks |> Map.tryFind SchemaRelationHook.Linking
         let onLinked = hooks |> Map.tryFind SchemaRelationHook.Linked
@@ -171,16 +185,15 @@ module TypeSchema =
 
         return { SchemaRelationName.Name = relationName }, relationHooksExpr
       })
+    |> AnnotatedParser.withNamedRule relationExtensionRule
+
+  let relationRule =
+    { Name = "relation"
+      Rule = Seq [ Terminal "relation"; NonTerminal "identifier"; Terminal "{"; Terminal "from"; NonTerminal "identifier"; Optional (NonTerminal "schema-path"); Terminal "to"; NonTerminal "identifier"; Optional (NonTerminal "schema-path"); Optional (Seq [ Terminal "cardinality"; NonTerminal "cardinality"; Terminal ".."; NonTerminal "cardinality" ]); NonTerminal "relation-hooks"; Terminal "}" ] }
 
   let relation
     (parseExpr: TypeExprParser<'valueExt>)
     ()
-    : Parser<
-        SchemaRelationExpr<'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     parser {
       let! loc_fallback = parser.Location
@@ -196,15 +209,15 @@ module TypeSchema =
 
       return!
         (parser {
-          let! relationName = singleIdentifier
+          let! relationName = singleIdentifier.Parser
           do! openCurlyBracketOperator
           do! fromKeyword
-          let! fromEntity = identifierLocalOrFullyQualified ()
-          let! fromPath = schemaPath ()
+          let! fromEntity = (identifierLocalOrFullyQualified ()).Parser
+          let! fromPath = (schemaPath ()).Parser
 
           do! toKeyword
-          let! toEntity = identifierLocalOrFullyQualified ()
-          let! toPath = schemaPath ()
+          let! toEntity = (identifierLocalOrFullyQualified ()).Parser
+          let! toPath = (schemaPath ()).Parser
 
           let! hasCardinality = cardinalityKeyword |> parser.Try
 
@@ -213,9 +226,9 @@ module TypeSchema =
             | Right _ -> parser { return None }
             | Left() ->
               parser {
-                let! from = cardinality ()
+                let! from = (cardinality ()).Parser
                 do! doubleDotOperator
-                let! to_ = cardinality ()
+                let! to_ = (cardinality ()).Parser
 
                 return
                   Some(
@@ -225,7 +238,7 @@ module TypeSchema =
               }
 
 
-          let! hooks = TypeHooksAndProperties.relation_hooks parseExpr ()
+          let! hooks = (TypeHooksAndProperties.relation_hooks parseExpr ()).Parser
 
           let onLinking = hooks |> Map.tryFind SchemaRelationHook.Linking
           let onLinked = hooks |> Map.tryFind SchemaRelationHook.Linked
@@ -250,17 +263,16 @@ module TypeSchema =
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
     |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
+    |> AnnotatedParser.withNamedRule relationRule
+
+  let entityRule =
+    { Name = "entity"
+      Rule = Seq [ Terminal "entity"; NonTerminal "identifier"; Terminal "{"; Terminal "type"; NonTerminal "type-decl"; NonTerminal "type-decl"; NonTerminal "entity-properties"; NonTerminal "entity-vectors"; NonTerminal "entity-hooks"; Terminal "}" ] }
 
   let entity
     (parseExpr: TypeExprParser<'valueExt>)
     (parseTypeDecl: unit -> TypeDeclParser<'valueExt>)
     ()
-    : Parser<
-        SchemaEntityExpr<'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     parser {
       let! loc_fallback = parser.Location
@@ -276,7 +288,7 @@ module TypeSchema =
 
       return!
         (parser {
-          let! entityName = singleIdentifier
+          let! entityName = singleIdentifier.Parser
           do! openCurlyBracketOperator
 
           do!
@@ -290,15 +302,15 @@ module TypeSchema =
           let! idType = parseTypeDecl ()
 
           let! properties =
-            TypeHooksAndProperties.entity_properties
+            (TypeHooksAndProperties.entity_properties
               parseExpr
-              schemaPath
+              (fun () -> (schemaPath ()).Parser)
               parseTypeDecl
-              ()
+              ()).Parser
 
-          let! vectors = TypeHooksAndProperties.entity_vectors parseExpr ()
+          let! vectors = (TypeHooksAndProperties.entity_vectors parseExpr ()).Parser
 
-          let! hooks = TypeHooksAndProperties.entity_hooks parseExpr ()
+          let! hooks = (TypeHooksAndProperties.entity_hooks parseExpr ()).Parser
           let onCreating = hooks |> Map.tryFind SchemaEntityHook.Creating
           let onCreated = hooks |> Map.tryFind SchemaEntityHook.Created
           let onUpdating = hooks |> Map.tryFind SchemaEntityHook.Updating
@@ -358,24 +370,23 @@ module TypeSchema =
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
     |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
+    |> AnnotatedParser.withNamedRule entityRule
+
+  let entityExtensionRule =
+    { Name = "entity-extension"
+      Rule = Seq [ Terminal "entity"; NonTerminal "identifier"; Terminal "{"; NonTerminal "entity-hooks"; Terminal "}" ] }
 
   let entity_extension
     (parseExpr: TypeExprParser<'valueExt>)
     ()
-    : Parser<
-        (SchemaEntityName * SchemaEntityHooksExpr<'valueExt>),
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     afterKeyword
       entityKeyword
       (parser {
-        let! entityName = singleIdentifier
+        let! entityName = singleIdentifier.Parser
         do! openCurlyBracketOperator
 
-        let! hooks = TypeHooksAndProperties.entity_hooks parseExpr ()
+        let! hooks = (TypeHooksAndProperties.entity_hooks parseExpr ()).Parser
         let onCreating = hooks |> Map.tryFind SchemaEntityHook.Creating
         let onCreated = hooks |> Map.tryFind SchemaEntityHook.Created
         let onUpdating = hooks |> Map.tryFind SchemaEntityHook.Updating
@@ -405,12 +416,17 @@ module TypeSchema =
 
         return { SchemaEntityName.Name = entityName }, entityHooksExpr
       })
+    |> AnnotatedParser.withNamedRule entityExtensionRule
+
+  let schemaRule =
+    { Name = "schema-decl"
+      Rule = Seq [ Terminal "schema"; Terminal "{"; Optional (Seq [ Terminal "include"; NonTerminal "identifier"; Optional (Seq [ Terminal "with"; Terminal "{"; Repeat (Alt [ NonTerminal "entity-extension"; NonTerminal "relation-extension" ]); Terminal "}" ]) ]); Repeat (Alt [ NonTerminal "entity"; NonTerminal "relation" ]); Terminal "}" ] }
 
   let schema
     (parseExpr: TypeExprParser<'valueExt>)
     (parseTypeDecl: unit -> TypeDeclParser<'valueExt>)
     ()
-    : Parser<TypeExpr<'valueExt>, LocalizedToken, Location, Errors<Location>> =
+    =
     afterKeyword
       schemaKeyword
       (parser {
@@ -430,7 +446,7 @@ module TypeSchema =
                   match isEntity with
                   | Left _ ->
                     return!
-                      entity_extension parseExpr ()
+                      (entity_extension parseExpr ()).Parser
                       |> parser.Map Sum.Left
                       |> parser.MapError(
                         Errors<Location>.FilterHighestPriorityOnly
@@ -442,7 +458,7 @@ module TypeSchema =
                     match isRelation with
                     | Left _ ->
                       return!
-                        relation_extension parseExpr ()
+                        (relation_extension parseExpr ()).Parser
                         |> parser.Map Sum.Right
                         |> parser.MapError(
                           Errors<Location>.FilterHighestPriorityOnly
@@ -485,7 +501,7 @@ module TypeSchema =
                   match isEntity with
                   | Left _ ->
                     return!
-                      entity parseExpr parseTypeDecl ()
+                      (entity parseExpr parseTypeDecl ()).Parser
                       |> parser.Map Sum.Left
                       |> parser.MapError(
                         Errors<Location>.FilterHighestPriorityOnly
@@ -497,7 +513,7 @@ module TypeSchema =
                     match isRelation with
                     | Left _ ->
                       return!
-                        relation parseExpr ()
+                        (relation parseExpr ()).Parser
                         |> parser.Map Sum.Right
                         |> parser.MapError(
                           Errors<Location>.FilterHighestPriorityOnly
@@ -534,7 +550,7 @@ module TypeSchema =
             match hasInclude with
             | Right _ -> return None
             | Left() ->
-              let! schemaName = singleIdentifier
+              let! schemaName = singleIdentifier.Parser
               let! hasWith = withKeyword |> parser.Try
 
               let! entities, relations =
@@ -592,3 +608,6 @@ module TypeSchema =
               Entities = entities
               Relations = relations }
       })
+    |> AnnotatedParser.withNamedRule schemaRule
+
+  let grammarRules: NamedRule list = [ cardinalityRule; schemaPathRule; schemaPathSegmentsRule; relationExtensionRule; relationRule; entityRule; entityExtensionRule; schemaRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/View.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/View.fs
@@ -18,21 +18,32 @@ module View =
   open Type
   open Ballerina.DSL.Next.Syntax
   open Ballerina
+  open Ballerina.Grammar
 
   // ═══════════════════════════════════════════════════════════════════════════
   // JSX View Parser
   // ═══════════════════════════════════════════════════════════════════════════
 
-  let private lessThanOperator = parseOperator Operator.LessThan
-  let private greaterThanOperator = parseOperator Operator.GreaterThan
-  let private tagSelfCloseOperator = parseOperator Operator.TagSelfClose
-  let private tagCloseOperator = parseOperator Operator.TagClose
+  let lessThanOpRule = { Name = "less-than-op"; Rule = Terminal "<" }
+  let greaterThanOpRule = { Name = "greater-than-op"; Rule = Terminal ">" }
+  let tagSelfCloseOpRule = { Name = "tag-self-close-op"; Rule = Terminal "/>" }
+  let tagCloseOpRule = { Name = "tag-close-op"; Rule = Terminal "</" }
+
+  let private lessThanOperator = parseOperator Operator.LessThan |> AnnotatedParser.withNamedRule lessThanOpRule
+  let private greaterThanOperator = parseOperator Operator.GreaterThan |> AnnotatedParser.withNamedRule greaterThanOpRule
+  let private tagSelfCloseOperator = parseOperator Operator.TagSelfClose |> AnnotatedParser.withNamedRule tagSelfCloseOpRule
+  let private tagCloseOperator = parseOperator Operator.TagClose |> AnnotatedParser.withNamedRule tagCloseOpRule
+
+  let tagIdentifierRule = { Name = "tag-identifier"; Rule = Terminal "<tag-identifier>" }
 
   let private tagIdentifier =
     parser.Exactly(fun t ->
       match t.Token with
       | Token.Identifier id -> Some id
       | _ -> None)
+    |> AnnotatedParser.withNamedRule tagIdentifierRule
+
+  let attrIdentifierRule = { Name = "attr-identifier"; Rule = Terminal "<attr-identifier>" }
 
   /// Attribute name parser: accepts identifiers and keywords (e.g. type, for)
   let private attrIdentifier =
@@ -41,6 +52,9 @@ module View =
       | Token.Identifier id -> Some id
       | Token.Keyword k -> Some (k.ToString().ToLowerInvariant())
       | _ -> None)
+    |> AnnotatedParser.withNamedRule attrIdentifierRule
+
+  let stringAttrValueRule = { Name = "string-attr-value"; Rule = Terminal "<string-literal>" }
 
   /// Parse a string attribute value: attr="value"
   let private stringAttrValue =
@@ -48,6 +62,11 @@ module View =
       match t.Token with
       | Token.StringLiteral s -> Some s
       | _ -> None)
+    |> AnnotatedParser.withNamedRule stringAttrValueRule
+
+  let viewExprRule =
+    { Name = "view-expr"
+      Rule = Alt [ NonTerminal "view-element"; NonTerminal "view-fragment"; NonTerminal "view-expr-container"; NonTerminal "view-text-node" ] }
 
   let viewExpr<'valueExt>
     (expr:
@@ -59,12 +78,6 @@ module View =
           Errors<Location>
          >)
     ()
-    : Parser<
-        Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
 
     let rec viewNode () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
@@ -78,15 +91,15 @@ module View =
     and viewElement () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {
         let! loc = parser.Location
-        do! lessThanOperator
-        let! tag = tagIdentifier
+        do! lessThanOperator.Parser
+        let! tag = tagIdentifier.Parser
         let! attrs = viewAttributes () |> parser.Many
 
         return!
           parser.Any
             [ // Self-closing: <tag attrs />
               parser {
-                do! tagSelfCloseOperator
+                do! tagSelfCloseOperator.Parser
                 return
                   { Location = loc
                     Node =
@@ -98,11 +111,11 @@ module View =
               }
               // Opening tag: <tag attrs>children</tag>
               parser {
-                do! greaterThanOperator
+                do! greaterThanOperator.Parser
                 let! children = viewChildren ()
-                do! tagCloseOperator
-                let! _closeTag = tagIdentifier
-                do! greaterThanOperator
+                do! tagCloseOperator.Parser
+                let! _closeTag = tagIdentifier.Parser
+                do! greaterThanOperator.Parser
                 return
                   { Location = loc
                     Node =
@@ -119,13 +132,13 @@ module View =
       parser {
         let! loc = parser.Location
         // <>
-        do! lessThanOperator
-        do! greaterThanOperator
+        do! lessThanOperator.Parser
+        do! greaterThanOperator.Parser
         // children
         let! children = viewChildren ()
         // </>
-        do! tagCloseOperator
-        do! greaterThanOperator
+        do! tagCloseOperator.Parser
+        do! greaterThanOperator.Parser
         return
           { Location = loc
             Node = ExprViewNodeRec.ViewFragment children }
@@ -173,13 +186,13 @@ module View =
 
     and viewAttributes () : Parser<ExprViewAttribute<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {
-        let! name = attrIdentifier
+        let! name = attrIdentifier.Parser
         do! equalsOperator
         return!
           parser.Any
             [ // String value: attr="value"
               parser {
-                let! value = stringAttrValue
+                let! value = stringAttrValue.Parser
                 return ExprViewAttribute.ViewAttrStringValue(name, value)
               }
               // Expression value: attr={expr}
@@ -202,14 +215,14 @@ module View =
         parser.Any
           [ parser {
               do! openRoundBracketOperator
-              let! paramName = singleIdentifier
+              let! paramName = singleIdentifier.Parser
               do! colonOperator
-              let! typeDecl = typeDecl (expr ()) parseAllComplexTypeShapes
+              let! typeDecl = (typeDecl (expr ()) parseAllComplexTypeShapes).Parser
               do! closeRoundBracketOperator
               return paramName, Some typeDecl
             }
             parser {
-              let! paramName = singleIdentifier
+              let! paramName = singleIdentifier.Parser
               return paramName, None
             } ]
         |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
@@ -227,6 +240,11 @@ module View =
           Location = loc
           Scope = TypeCheckScope.Empty }
     }
+    |> AnnotatedParser.withNamedRule viewExprRule
+
+  let viewNodeExprRule =
+    { Name = "view-node-expr"
+      Rule = Alt [ NonTerminal "view-element"; NonTerminal "view-fragment"; NonTerminal "view-expr-container"; NonTerminal "view-text-node" ] }
 
   /// Standalone JSX element expression: <tag .../> or <tag ...>children</tag>
   /// Used when JSX elements appear inside expression contexts (e.g. lambda bodies).
@@ -241,12 +259,6 @@ module View =
           Errors<Location>
          >)
     ()
-    : Parser<
-        Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
 
     let rec viewNode () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
@@ -260,14 +272,14 @@ module View =
     and viewElement () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {
         let! loc = parser.Location
-        do! lessThanOperator
-        let! tag = tagIdentifier
+        do! lessThanOperator.Parser
+        let! tag = tagIdentifier.Parser
         let! attrs = viewAttributes () |> parser.Many
 
         return!
           parser.Any
             [ parser {
-                do! tagSelfCloseOperator
+                do! tagSelfCloseOperator.Parser
                 return
                   { Location = loc
                     Node =
@@ -278,11 +290,11 @@ module View =
                           SelfClosing = true } }
               }
               parser {
-                do! greaterThanOperator
+                do! greaterThanOperator.Parser
                 let! children = viewChildren ()
-                do! tagCloseOperator
-                let! _closeTag = tagIdentifier
-                do! greaterThanOperator
+                do! tagCloseOperator.Parser
+                let! _closeTag = tagIdentifier.Parser
+                do! greaterThanOperator.Parser
                 return
                   { Location = loc
                     Node =
@@ -298,11 +310,11 @@ module View =
     and viewFragment () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {
         let! loc = parser.Location
-        do! lessThanOperator
-        do! greaterThanOperator
+        do! lessThanOperator.Parser
+        do! greaterThanOperator.Parser
         let! children = viewChildren ()
-        do! tagCloseOperator
-        do! greaterThanOperator
+        do! tagCloseOperator.Parser
+        do! greaterThanOperator.Parser
         return
           { Location = loc
             Node = ExprViewNodeRec.ViewFragment children }
@@ -350,12 +362,12 @@ module View =
 
     and viewAttributes () : Parser<ExprViewAttribute<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {
-        let! name = attrIdentifier
+        let! name = attrIdentifier.Parser
         do! equalsOperator
         return!
           parser.Any
             [ parser {
-                let! value = stringAttrValue
+                let! value = stringAttrValue.Parser
                 return ExprViewAttribute.ViewAttrStringValue(name, value)
               }
               parser {
@@ -380,6 +392,11 @@ module View =
           Location = loc
           Scope = TypeCheckScope.Empty }
     }
+    |> AnnotatedParser.withNamedRule viewNodeExprRule
+
+  let coExprRule =
+    { Name = "co-expr"
+      Rule = Seq [ Terminal "co"; Terminal "{"; Repeat (Alt [ NonTerminal "co-let-bang"; NonTerminal "co-do-bang"; NonTerminal "co-return"; NonTerminal "co-return-bang"; NonTerminal "co-let" ]); Terminal "}" ] }
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Coroutine Parser (co { ... })
@@ -395,12 +412,6 @@ module View =
           Errors<Location>
          >)
     ()
-    : Parser<
-        Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
 
     let rec coStep () : Parser<ExprCoStep<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
@@ -417,7 +428,7 @@ module View =
         let! loc = parser.Location
         do! parseKeyword Keyword.Let
         do! parseOperator Operator.Bang
-        let! varName = singleIdentifier
+        let! varName = singleIdentifier.Parser
         do! equalsOperator
         let! value = expr ()
         do! semicolonOperator
@@ -431,7 +442,7 @@ module View =
       parser {
         let! loc = parser.Location
         do! parseKeyword Keyword.Let
-        let! varName = singleIdentifier
+        let! varName = singleIdentifier.Parser
         do! equalsOperator
         let! value = expr ()
         do! semicolonOperator
@@ -499,3 +510,9 @@ module View =
           Location = loc
           Scope = TypeCheckScope.Empty }
     }
+    |> AnnotatedParser.withNamedRule coExprRule
+
+  let grammarRules: NamedRule list =
+    [ lessThanOpRule; greaterThanOpRule; tagSelfCloseOpRule; tagCloseOpRule
+      tagIdentifierRule; attrIdentifierRule; stringAttrValueRule
+      viewExprRule; viewNodeExprRule; coExprRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/ballerina-lang-parser.fsproj
+++ b/backend/libraries/ballerina-lang/Next/Syntax/ballerina-lang-parser.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="Parser/Query.fs" />
     <Compile Include="Parser/View.fs" />
     <Compile Include="Parser/Expr.fs" />
+    <Compile Include="Parser/Grammar.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Data" Version="6.6.0" />


### PR DESCRIPTION
## Summary

Add grammar annotation infrastructure to the parser for LLM-powered GBNF-constrained code generation.

### Changes

**New files (ballerina-cat/Grammar/)**
- `Model.fs` — `GrammarRule` DU, `NamedRule` record (no parser dependency)
- `Ebnf.fs` — ISO 14977 EBNF serializer
- `Gbnf.fs` — llama.cpp GBNF serializer

**New file (ballerina-lang-parser)**
- `Parser/Grammar.fs` — collecting module aggregating `grammarRules` from all parser modules into `Grammar.allRules: NamedRule list`

**AnnotatedParser type (ballerina-cat/Parser/Model.fs)**
- `AnnotatedParser<'a, 'sym, 'loc, 'err>` pairs a `Parser` with an optional `NamedRule`
- 8 combinator overloads on `ParserBuilder` (Any, All, Many, AtLeastOne, Try, Lookahead, Not, Ignore)
- `.Parser` extraction at CE call sites (Source/Bind/ReturnFrom cause F# CE ambiguity)

**33 production-level parsers annotated across 8 files**
| File | Rules |
|------|------:|
| Common.fs | 9 |
| Kind.fs | 1 |
| Type.fs | 2 |
| HooksAndProperties.fs | 4 |
| Schema.fs | 8 |
| Expr.fs | 2 |
| Query.fs | 9 |
| View.fs | 10 |

Each module exports `grammarRules: NamedRule list` with standalone `NamedRule` values referenced via `AnnotatedParser.withNamedRule`.

### Testing
- 26/26 sample integration tests pass
- UScreen typecheck passes