### PR TITLE
feat: add List::any, View::memo, and inline style support

### DIFF
--- a/backend/libraries/ballerina-cat/Grammar/Ebnf.fs
+++ b/backend/libraries/ballerina-cat/Grammar/Ebnf.fs
@@ -1,0 +1,32 @@
+namespace Ballerina.Grammar
+
+module Ebnf =
+  let private escapeTerminal (s: string) : string =
+    s.Replace("\\", "\\\\").Replace("\"", "\\\"")
+
+  let rec private serializeRule (rule: GrammarRule) : string =
+    match rule with
+    | Terminal s -> $"\"{escapeTerminal s}\""
+    | NonTerminal s -> s
+    | Seq rules ->
+      rules
+      |> List.map serializeRuleGrouped
+      |> String.concat " , "
+    | Alt rules ->
+      rules
+      |> List.map serializeRule
+      |> String.concat " | "
+    | Repeat rule -> "{ " + serializeRule rule + " }"
+    | Repeat1 rule -> serializeRule rule + " , { " + serializeRule rule + " }"
+    | Optional rule -> "[ " + serializeRule rule + " ]"
+    | Empty -> ""
+
+  and private serializeRuleGrouped (rule: GrammarRule) : string =
+    match rule with
+    | Alt _ -> "( " + serializeRule rule + " )"
+    | _ -> serializeRule rule
+
+  let serialize (rules: NamedRule list) : string =
+    rules
+    |> List.map (fun r -> $"{r.Name} = {serializeRule r.Rule} ;")
+    |> String.concat "\n"

--- a/backend/libraries/ballerina-cat/Grammar/Gbnf.fs
+++ b/backend/libraries/ballerina-cat/Grammar/Gbnf.fs
@@ -1,0 +1,35 @@
+namespace Ballerina.Grammar
+
+module Gbnf =
+  let private sanitizeName (s: string) : string =
+    s.Replace(" ", "-").Replace("::", "-").Replace(".", "-")
+
+  let private escapeTerminal (s: string) : string =
+    s.Replace("\\", "\\\\").Replace("\"", "\\\"")
+
+  let rec private serializeRule (rule: GrammarRule) : string =
+    match rule with
+    | Terminal s -> $"\"{escapeTerminal s}\""
+    | NonTerminal s -> sanitizeName s
+    | Seq rules ->
+      rules
+      |> List.map serializeRuleGrouped
+      |> String.concat " "
+    | Alt rules ->
+      rules
+      |> List.map serializeRule
+      |> String.concat " | "
+    | Repeat rule -> "(" + serializeRule rule + ")*"
+    | Repeat1 rule -> "(" + serializeRule rule + ")+"
+    | Optional rule -> "(" + serializeRule rule + ")?"
+    | Empty -> "\"\""
+
+  and private serializeRuleGrouped (rule: GrammarRule) : string =
+    match rule with
+    | Alt _ -> "(" + serializeRule rule + ")"
+    | _ -> serializeRule rule
+
+  let serialize (rules: NamedRule list) : string =
+    rules
+    |> List.map (fun r -> $"{sanitizeName r.Name} ::= {serializeRule r.Rule}")
+    |> String.concat "\n"

--- a/backend/libraries/ballerina-cat/Grammar/Model.fs
+++ b/backend/libraries/ballerina-cat/Grammar/Model.fs
@@ -1,0 +1,16 @@
+namespace Ballerina.Grammar
+
+[<AutoOpen>]
+module Model =
+
+  type GrammarRule =
+    | Terminal of string
+    | NonTerminal of string
+    | Seq of GrammarRule list
+    | Alt of GrammarRule list
+    | Repeat of GrammarRule
+    | Repeat1 of GrammarRule
+    | Optional of GrammarRule
+    | Empty
+
+  type NamedRule = { Name: string; Rule: GrammarRule }

--- a/backend/libraries/ballerina-cat/Parser/Model.fs
+++ b/backend/libraries/ballerina-cat/Parser/Model.fs
@@ -8,8 +8,9 @@ module Model =
   open Ballerina.Collections
   open Ballerina.Collections.NonEmptyList
   open Ballerina.Reader.WithError
+  open Ballerina.Grammar
   open Ballerina.Stackless.State.WithError.StacklessStateWithError
-
+  open Ballerina.Grammar
 
   open FSharp.Core
   open Ballerina.Collections.NonEmptyList
@@ -290,3 +291,78 @@ module Model =
 
         return! res |> parser.OfSum
       }
+
+  [<NoComparison; NoEquality>]
+  type AnnotatedParser<'a, 'sym, 'loc, 'err> =
+    { Parser: Parser<'a, 'sym, 'loc, 'err>
+      Rule: NamedRule option }
+
+  module AnnotatedParser =
+    let ofParser (p: Parser<'a, 'sym, 'loc, 'err>) : AnnotatedParser<'a, 'sym, 'loc, 'err> =
+      { Parser = p; Rule = None }
+
+    let withRule (name: string) (rule: GrammarRule) (p: Parser<'a, 'sym, 'loc, 'err>) : AnnotatedParser<'a, 'sym, 'loc, 'err> =
+      { Parser = p; Rule = Some { Name = name; Rule = rule } }
+
+    let withNamedRule (nr: NamedRule) (p: Parser<'a, 'sym, 'loc, 'err>) : AnnotatedParser<'a, 'sym, 'loc, 'err> =
+      { Parser = p; Rule = Some nr }
+
+    let grammar (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>) : NamedRule option =
+      ap.Rule
+
+    let parser (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>) : Parser<'a, 'sym, 'loc, 'err> =
+      ap.Parser
+
+    let collectRules (aps: AnnotatedParser<'a, 'sym, 'loc, 'err> list) : NamedRule list =
+      aps |> List.choose (fun ap -> ap.Rule)
+
+  // AnnotatedParser combinator extensions on ParserBuilder
+  type ParserBuilder<'sym, 'loc, 'err when 'sym: equality> with
+
+    member self.Any
+      (aps: List<AnnotatedParser<'a, 'sym, 'loc, 'err>>)
+      : Parser<'a, 'sym, 'loc, 'err> =
+      let ps: List<Parser<'a, 'sym, 'loc, 'err>> = aps |> List.map (fun ap -> ap.Parser)
+      self.Any(ps)
+
+    member self.All
+      (aps: List<AnnotatedParser<'a, 'sym, 'loc, 'err>>)
+      : Parser<List<'a>, 'sym, 'loc, 'err> =
+      let ps: List<Parser<'a, 'sym, 'loc, 'err>> = aps |> List.map (fun ap -> ap.Parser)
+      self.All(ps)
+
+    member self.Many
+      (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>)
+      : Parser<List<'a>, 'sym, 'loc, 'err> =
+      let p: Parser<'a, 'sym, 'loc, 'err> = ap.Parser
+      self.Many(p)
+
+    member self.AtLeastOne
+      (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>)
+      : Parser<NonEmptyList<'a>, 'sym, 'loc, 'err> =
+      let p: Parser<'a, 'sym, 'loc, 'err> = ap.Parser
+      self.AtLeastOne(p)
+
+    member self.Try
+      (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>)
+      : Parser<Sum<'a, 'err>, 'sym, 'loc, 'err> =
+      let p: Parser<'a, 'sym, 'loc, 'err> = ap.Parser
+      self.Try(p)
+
+    member self.Lookahead
+      (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>)
+      : Parser<'a, 'sym, 'loc, 'err> =
+      let p: Parser<'a, 'sym, 'loc, 'err> = ap.Parser
+      self.Lookahead(p)
+
+    member self.Not
+      (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>)
+      : Parser<Unit, 'sym, 'loc, 'err> =
+      let p: Parser<'a, 'sym, 'loc, 'err> = ap.Parser
+      self.Not(p)
+
+    member self.Ignore
+      (ap: AnnotatedParser<'a, 'sym, 'loc, 'err>)
+      : Parser<Unit, 'sym, 'loc, 'err> =
+      let p: Parser<'a, 'sym, 'loc, 'err> = ap.Parser
+      self.Ignore(p)

--- a/backend/libraries/ballerina-cat/ballerina-cat.fsproj
+++ b/backend/libraries/ballerina-cat/ballerina-cat.fsproj
@@ -22,6 +22,9 @@
     <Compile Include="State/WithError/Seq/Model.fs" />
     <Compile Include="Coroutine/Model.fs" />
     <Compile Include="Coroutine/Runner.fs" />
+    <Compile Include="Grammar/Model.fs" />
+    <Compile Include="Grammar/Ebnf.fs" />
+    <Compile Include="Grammar/Gbnf.fs" />
     <Compile Include="Parser/Model.fs" />
   </ItemGroup>
 </Project>

--- a/backend/libraries/ballerina-lang-build/ProjectModel.fs
+++ b/backend/libraries/ballerina-lang-build/ProjectModel.fs
@@ -377,7 +377,7 @@ module ProjectModel =
             Location,
             Errors<Location>
            >) =
-          Parser.Expr.program ()
+          (Parser.Expr.program ()).Parser
           |> Parser.Run(actual, initialLocation)
           |> sum.MapError fst
 

--- a/backend/libraries/ballerina-lang/Next/Models/Types.fs
+++ b/backend/libraries/ballerina-lang/Next/Models/Types.fs
@@ -1679,20 +1679,21 @@ module Model =
   and [<RequireQualifiedAccess>] ViewOperationKind =
     | MapContext
     | MapState
+    | Memo
 
     member self.Name =
       match self with
-      | MapContext -> "mapContext" | MapState -> "mapState"
+      | MapContext -> "mapContext" | MapState -> "mapState" | Memo -> "memo"
 
     member self.Arity =
       match self with
-      | MapContext -> 2 | MapState -> 3
+      | MapContext -> 2 | MapState -> 3 | Memo -> 2
 
     override self.ToString() = $"View::{self.Name}"
 
     static member TryParse(name: string) =
       match name with
-      | "mapContext" -> Some MapContext | "mapState" -> Some MapState
+      | "mapContext" -> Some MapContext | "mapState" -> Some MapState | "memo" -> Some Memo
       | _ -> None
 
   and ExprRec<'T, 'Id, 'valueExt when 'Id: comparison> =

--- a/backend/libraries/ballerina-lang/Next/Stdlib/List/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/List/Extension.fs
@@ -118,6 +118,10 @@ module Extension =
       Identifier.FullyQualified([ "List" ], "decompose")
       |> TypeCheckScope.Empty.Resolve
 
+    let listAnyId =
+      Identifier.FullyQualified([ "List" ], "any")
+      |> TypeCheckScope.Empty.Resolve
+
     let getValueAsList
       (v: Value<TypeValue<'ext>, 'ext>)
       : Sum<List<Value<TypeValue<'ext>, 'ext>>, Errors<Unit>> =
@@ -408,6 +412,110 @@ module Extension =
                   |> Ext
             } //: 'runtimeContext * 'extOperations * Value<TypeValue<'ext>, 'ext> -> ExprEvaluator<'runtimeContext, 'ext, 'extValues> }
       }
+
+    let anyOperation
+      : ResolvedIdentifier *
+        TypeOperationExtension<
+          'runtimeContext,
+          'ext,
+          Unit,
+          ListValues<'ext>,
+          ListOperations<'ext>
+         > =
+      listAnyId,
+      { Type =
+          TypeValue.CreateLambda(
+            TypeParameter.Create("a", aKind),
+            TypeExpr.Lambda(
+              TypeParameter.Create("b", Kind.Star),
+              TypeExpr.Arrow(
+                TypeExpr.Arrow(
+                  TypeExpr.Lookup(Identifier.LocalScope "a"),
+                  TypeExpr.Sum
+                    [ TypeExpr.Primitive PrimitiveType.Unit
+                      TypeExpr.Lookup(Identifier.LocalScope "b") ]
+                ),
+                TypeExpr.Arrow(
+                  TypeExpr.Apply(
+                    TypeExpr.Lookup(Identifier.LocalScope "List"),
+                    TypeExpr.Lookup(Identifier.LocalScope "a")
+                  ),
+                  TypeExpr.Sum
+                    [ TypeExpr.Primitive PrimitiveType.Unit
+                      TypeExpr.Lookup(Identifier.LocalScope "b") ]
+                )
+              )
+            )
+          )
+        Kind = Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+        Operation = List_Any {| f = None |}
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | List_Any v -> Some(List_Any v)
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (op, v) ->
+            reader {
+              let! op =
+                op
+                |> ListOperations.AsAny
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              match op with
+              | None -> // first step: store the predicate function
+                return
+                  (ListOperations.List_Any({| f = Some v |})
+                   |> operationLens.Set,
+                   Some listAnyId)
+                  |> Ext
+              | Some predicate -> // second step: iterate list, short-circuit on first 2Of2
+                let! v, _ =
+                  v
+                  |> Value.AsExt
+                  |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                  |> reader.OfSum
+
+                let! v =
+                  valueLens.Get v
+                  |> sum.OfOption(
+                    (fun () -> "cannot get list value")
+                    |> Errors.Singleton loc0
+                  )
+                  |> reader.OfSum
+
+                let! v =
+                  v
+                  |> ListValues.AsList
+                  |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                  |> reader.OfSum
+
+                // Apply predicate to each element and collect (item, tag) pairs
+                let! results =
+                  v
+                  |> List.map (fun item ->
+                    reader {
+                      let! res = Expr.EvalApply loc0 [] (predicate, item)
+
+                      let! tag, _value =
+                        res
+                        |> Value.AsSum
+                        |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                        |> reader.OfSum
+
+                      return tag, res
+                    })
+                  |> reader.All
+
+                // Find the first 2Of2 result
+                let selector2Of2 = { Case = 2; Count = 2 }
+                match results |> List.tryFind (fun (tag, _) -> tag = selector2Of2) with
+                | Some (_, found) -> return found
+                | None ->
+                  let selector1Of2 = { Case = 1; Count = 2 }
+                  return Value.Sum(selector1Of2, Value.Primitive PrimitiveValue.Unit)
+            } }
 
     let mapOperation
       : ResolvedIdentifier *
@@ -1061,6 +1169,7 @@ module Extension =
           [ lengthOperation
             foldOperation
             filterOperation
+            anyOperation
             mapOperation
             orderByOperation
             appendOperation

--- a/backend/libraries/ballerina-lang/Next/Stdlib/List/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/List/Model.fs
@@ -24,6 +24,7 @@ module Model =
     | List_Length
     | List_Decompose
     | List_OrderBy of {| f: Option<Value<TypeValue<'ext>, 'ext>> |}
+    | List_Any of {| f: Option<Value<TypeValue<'ext>, 'ext>> |}
 
     override self.ToString() : string =
       match self with
@@ -36,6 +37,7 @@ module Model =
       | List_Length -> "List::length"
       | List_Decompose -> "List::decompose"
       | List_OrderBy _ -> "List::orderBy"
+      | List_Any _ -> "List::any"
 
   type ListValues<'ext> =
     | List of List<Value<TypeValue<'ext>, 'ext>>

--- a/backend/libraries/ballerina-lang/Next/Stdlib/List/Patterns.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/List/Patterns.fs
@@ -100,6 +100,16 @@ module Patterns =
         |> Errors.Singleton()
         |> sum.Throw
 
+    static member AsAny
+      (op: ListOperations<'ext>)
+      : Sum<Option<Value<TypeValue<'ext>, 'ext>>, Errors<Unit>> =
+      match op with
+      | List_Any v -> v.f |> sum.Return
+      | _ ->
+        (fun () -> $"Error: Expected List_Any, found {op}")
+        |> Errors.Singleton()
+        |> sum.Throw
+
   type ListValues<'ext> with
     static member AsList
       (op: ListValues<'ext>)

--- a/backend/libraries/ballerina-lang/Next/Stdlib/View/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/View/Extension.fs
@@ -18,6 +18,8 @@ module Extension =
     | View_MapState of
       {| mapDown: Option<Value<TypeValue<'ext>, 'ext>>
          mapUp: Option<Value<TypeValue<'ext>, 'ext>> |}
+    | View_Memo of
+      {| deps: Option<Value<TypeValue<'ext>, 'ext>> |}
 
   let ViewExtension<'runtimeContext, 'ext, 'extDTO, 'deltaExt, 'deltaExtDTO
     when 'ext: comparison
@@ -395,12 +397,66 @@ module Extension =
                   |> reader.Throw
             } }
 
+    // --- View::memo ---
+    // memo : Λdeps. Λresult. deps → result → result
+    // At runtime, ignores deps and returns the computed value.
+    // The TsxGenerator emits useMemo(() => compute, [deps...]) for React.
+    let memoId =
+      Identifier.FullyQualified([ "View" ], "memo")
+      |> TypeCheckScope.Empty.Resolve
+
+    let _depsVar, depsKind = TypeVar.Create("deps"), Kind.Star
+    let _resultVar, resultKind = TypeVar.Create("result"), Kind.Star
+
+    let memoOperation
+      : ResolvedIdentifier *
+        TypeOperationExtension<'runtimeContext, 'ext, Unit, Unit, ViewPropsOperations<'ext>> =
+      memoId,
+      { Type =
+          TypeValue.CreateLambda(
+            TypeParameter.Create("deps", depsKind),
+            TypeExpr.Lambda(
+              TypeParameter.Create("result", resultKind),
+              TypeExpr.Arrow(
+                TypeExpr.Lookup(Identifier.LocalScope "deps"),
+                TypeExpr.Arrow(
+                  TypeExpr.Lookup(Identifier.LocalScope "result"),
+                  TypeExpr.Lookup(Identifier.LocalScope "result")
+                )
+              )
+            )
+          )
+        Kind = Kind.Arrow(Kind.Star, Kind.Arrow(Kind.Star, Kind.Star))
+        Operation = View_Memo {| deps = None |}
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | View_Memo v -> Some(View_Memo v)
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (op, v) ->
+            reader {
+              match op with
+              | View_Memo s when s.deps.IsNone ->
+                // 1st arg: capture deps (ignored at runtime)
+                return
+                  (View_Memo {| deps = Some v |} |> operationLens.Set, Some memoId)
+                  |> Value.Ext
+              | View_Memo _ ->
+                // 2nd arg: return compute result directly (no memoization at runtime)
+                return v
+              | _ ->
+                return!
+                  Errors.Singleton loc0 (fun () -> "View::memo: unexpected operation state")
+                  |> reader.Throw
+            } }
+
     let viewPropsExtension =
       { TypeName = viewPropsResolvedId, viewPropsSymbolId
         TypeVars = [ (schemaVar, schemaKind); (ctxVar, ctxKind); (stVar, stKind) ]
         Cases = Map.empty
         Operations =
-          [ mapContextOperation; mapStateOperation ] |> Map.ofList
+          [ mapContextOperation; mapStateOperation; memoOperation ] |> Map.ofList
         Serialization = None
         ExtTypeChecker = None }
 

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Common.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Common.fs
@@ -17,6 +17,7 @@ module Common =
   open Ballerina.DSL.Next.Syntax
   open Model
   open Ballerina
+  open Ballerina.Grammar
 
   let parseOperator op =
     parser.Exactly(fun t ->
@@ -93,6 +94,17 @@ module Common =
       | PipeGreaterThan -> "|>"
       | DoubleGreaterThan -> ">>"
 
+  let binaryExprOperatorRule =
+    { Name = "binary-expr-operator"
+      Rule =
+        Alt
+          [ Terminal "*"; Terminal "/"; Terminal "%"
+            Terminal "+"; Terminal "-"
+            Terminal "&&"; Terminal "||"
+            Terminal "=="; Terminal "!="
+            Terminal ">"; Terminal "<"; Terminal ">="; Terminal "<="
+            Terminal "|>"; Terminal ">>" ] }
+
   let binaryExprOperator =
     parser.Any
       [ parseOperator Operator.Times
@@ -125,6 +137,7 @@ module Common =
         |> parser.Map(fun () -> BinaryExprOperator.PipeGreaterThan)
         parseOperator Operator.DoubleGreaterThan
         |> parser.Map(fun () -> BinaryExprOperator.DoubleGreaterThan) ]
+    |> AnnotatedParser.withNamedRule binaryExprOperatorRule
 
   type BinaryTypeOperator =
     | Times
@@ -137,6 +150,10 @@ module Common =
       | Plus -> "+"
       | SingleArrow -> "->"
 
+  let binaryTypeOperatorRule =
+    { Name = "binary-type-operator"
+      Rule = Alt [ Terminal "*"; Terminal "+"; Terminal "->" ] }
+
   let binaryTypeOperator =
     parser.Any
       [ parseOperator Operator.Times
@@ -145,6 +162,7 @@ module Common =
         |> parser.Map(fun () -> BinaryTypeOperator.Plus)
         parseOperator Operator.SingleArrow
         |> parser.Map(fun () -> BinaryTypeOperator.SingleArrow) ]
+    |> AnnotatedParser.withNamedRule binaryTypeOperatorRule
 
   let parseKeyword kw =
     parser.Exactly(fun t ->
@@ -162,6 +180,9 @@ module Common =
   let ifKeyword = parseKeyword Keyword.If
   let thenKeyword = parseKeyword Keyword.Then
   let elseKeyword = parseKeyword Keyword.Else
+
+  let singleTermIdentifierRule =
+    { Name = "term-identifier"; Rule = Terminal "<term-identifier>" }
 
   let singleTermIdentifier =
     parser.Exactly(fun t ->
@@ -189,18 +210,27 @@ module Common =
       | Token.Keyword(Keyword.Descending) ->
         Keyword.Descending.ToString() |> Some
       | _ -> None)
+    |> AnnotatedParser.withNamedRule singleTermIdentifierRule
+
+  let singleIdentifierRule =
+    { Name = "identifier"; Rule = Terminal "<identifier>" }
 
   let singleIdentifier =
     parser.Exactly(fun t ->
       match t.Token with
       | Token.Identifier id -> Some id
       | _ -> None)
+    |> AnnotatedParser.withNamedRule singleIdentifierRule
+
+  let caseLiteralRule =
+    { Name = "case-literal"; Rule = Terminal "<case-literal>" }
 
   let caseLiteral () =
     parser.Exactly(fun t ->
       match t.Token with
       | Token.CaseLiteral(i, n) -> { Case = i; Count = n } |> Some
       | _ -> None)
+    |> AnnotatedParser.withNamedRule caseLiteralRule
 
   let softKeyword k =
     parser.Exactly(fun t ->
@@ -255,9 +285,13 @@ module Common =
   let caseKeyword = softKeyword "case"
   let itemKeyword = softKeyword "item"
 
+  let identifiersMatchRule =
+    { Name = "identifiers-match"
+      Rule = Seq [ NonTerminal "identifier"; Optional (Seq [ Terminal "::"; NonTerminal "identifiers-match" ]) ] }
+
   let rec identifiersMatch () =
     parser {
-      let! id = singleIdentifier
+      let! id = singleIdentifier.Parser
 
       return!
         parser.Any
@@ -267,7 +301,7 @@ module Common =
               return!
                 parser {
                   let! ids =
-                    identifiersMatch () |> parser.Map(NonEmptyList.ToList)
+                    (identifiersMatch ()).Parser |> parser.Map(NonEmptyList.ToList)
 
                   return NonEmptyList.OfList(id, ids)
                 }
@@ -277,11 +311,16 @@ module Common =
             }
             parser { return NonEmptyList.OfList(id, []) } ]
     }
+    |> AnnotatedParser.withNamedRule identifiersMatchRule
+
+  let identifierLocalOrFullyQualifiedRule =
+    { Name = "identifier-local-or-fully-qualified"
+      Rule = Alt [ NonTerminal "identifiers-match"; NonTerminal "identifier" ] }
 
   let identifierLocalOrFullyQualified () =
     parser.Any
       [ parser {
-          let! ids = identifiersMatch ()
+          let! ids = (identifiersMatch ()).Parser
           let ids = ids |> NonEmptyList.rev
 
           match ids.Tail with
@@ -289,25 +328,31 @@ module Common =
           | _ -> return Identifier.FullyQualified(ids.Tail, ids.Head)
         }
         parser {
-          let! id = singleIdentifier
+          let! id = singleIdentifier.Parser
           return Identifier.LocalScope id
         } ]
+    |> AnnotatedParser.withNamedRule identifierLocalOrFullyQualifiedRule
+
+  let identifierWithLookupsRule =
+    { Name = "identifier-with-lookups"
+      Rule = Seq [ NonTerminal "identifier-local-or-fully-qualified"; Repeat (Seq [ Terminal "."; NonTerminal "identifier" ]) ] }
 
   let identifierWithLookups () =
     parser {
-      let! id = identifierLocalOrFullyQualified ()
+      let! id = (identifierLocalOrFullyQualified ()).Parser
 
       let! lookups =
         parser.Many(
           parser {
             do! dotOperator
-            let! prop = singleIdentifier
+            let! prop = singleIdentifier.Parser
             return prop
           }
         )
 
       return id, lookups
     }
+    |> AnnotatedParser.withNamedRule identifierWithLookupsRule
 
   let betweenBrackets p =
     parser {
@@ -347,8 +392,23 @@ module Common =
     }
     |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
 
+  let intLiteralTokenRule =
+    { Name = "int-literal"; Rule = Terminal "<int-literal>" }
+
   let intLiteralToken () =
     parser.Exactly(fun t ->
       match t.Token with
       | Token.IntLiteral s -> s |> Some
       | _ -> None)
+    |> AnnotatedParser.withNamedRule intLiteralTokenRule
+
+  let grammarRules: NamedRule list =
+    [ binaryExprOperatorRule
+      binaryTypeOperatorRule
+      singleTermIdentifierRule
+      singleIdentifierRule
+      caseLiteralRule
+      intLiteralTokenRule
+      identifiersMatchRule
+      identifierLocalOrFullyQualifiedRule
+      identifierWithLookupsRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Expr.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Expr.fs
@@ -23,6 +23,7 @@ module Expr =
   open Type
   open Ballerina.DSL.Next.Syntax
   open Ballerina
+  open Ballerina.Grammar
 
   type ComplexExpressionKind =
     | ScopedIdentifier
@@ -60,24 +61,31 @@ module Expr =
 
   let private parseNoComplexShapes: Set<ComplexExpressionKind> = Set.empty
 
+  let exprRule: NamedRule =
+    { Name = "expr"
+      Rule =
+        Alt
+          [ NonTerminal "string-literal"; NonTerminal "int-literal"; NonTerminal "int64-literal"
+            NonTerminal "decimal-literal"; NonTerminal "float32-literal"; NonTerminal "float64-literal"
+            NonTerminal "bool-literal"; NonTerminal "unit-literal"
+            NonTerminal "match-expr"; NonTerminal "lambda-expr"
+            NonTerminal "let-expr"; NonTerminal "do-expr"
+            NonTerminal "conditional-expr"; NonTerminal "record-cons"
+            NonTerminal "type-let"; NonTerminal "identifier-lookup"
+            NonTerminal "application" ] }
+
   let rec expr
     (depth: int)
     (parseComplexShapes: Set<ComplexExpressionKind>)
-    : Parser<
-        Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
 
     let expr = expr (depth + 1)
     let singleIdentifier = singleTermIdentifier
 
-    let typeDecl v = typeDecl (expr parseAllComplexShapes) v
+    let typeDecl v = typeDecl ((expr parseAllComplexShapes).Parser) v
 
     let parseBoundBody () =
-      expr parseAllComplexShapes
+      (expr parseAllComplexShapes).Parser
       |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
     // let indent = "--"
@@ -181,7 +189,7 @@ module Expr =
 
         return!
           parser {
-            let! matchedExpr = expr parseAllComplexShapes
+            let! matchedExpr = (expr parseAllComplexShapes).Parser
             do! parseKeyword Keyword.With
 
             let! cases =
@@ -191,14 +199,14 @@ module Expr =
 
                   let! id =
                     parser.Any
-                      [ identifierLocalOrFullyQualified () |> parser.Map Left
-                        caseLiteral () |> parser.Map Right ]
+                      [ (identifierLocalOrFullyQualified ()).Parser |> parser.Map Left
+                        (caseLiteral ()).Parser |> parser.Map Right ]
 
                   let pattern =
                     parser {
                       let! paramName =
                         parser.Any
-                          [ singleIdentifier |> parser.Map Some
+                          [ singleIdentifier.Parser |> parser.Map Some
                             unitLiteral () |> parser.Map(fun _ -> None)
                             parser.Lookahead(parseOperator Operator.SingleArrow)
                             |> parser.Map("@anonymous" |> Some |> replaceWith)
@@ -217,7 +225,7 @@ module Expr =
                         |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
                       do! parseOperator Operator.SingleArrow
-                      let! body = expr parseAllComplexShapes
+                      let! body = (expr parseAllComplexShapes).Parser
                       return id, (paramName |> Option.map Var.Create, body)
                     }
 
@@ -235,7 +243,7 @@ module Expr =
                 do! timesOperator
 
                 do! parseOperator Operator.SingleArrow
-                let! body = expr parseAllComplexShapes
+                let! body = (expr parseAllComplexShapes).Parser
                 do! closeRoundBracketOperator
                 return body
               }
@@ -291,14 +299,14 @@ module Expr =
       parser.Any
         [ parser {
             do! openRoundBracketOperator
-            let! paramName = singleIdentifier
+            let! paramName = singleIdentifier.Parser
             do! colonOperator
-            let! typeDecl = typeDecl parseAllComplexTypeShapes
+            let! typeDecl = (typeDecl parseAllComplexTypeShapes).Parser
             do! closeRoundBracketOperator
             return paramName, typeDecl |> Some
           }
           parser {
-            let! paramName = singleIdentifier
+            let! paramName = singleIdentifier.Parser
             return paramName, None
           } ]
 
@@ -313,7 +321,7 @@ module Expr =
             let! pars =
               parser.AtLeastOne(
                 parser.Any
-                  [ typeParam |> parser.Map Left
+                  [ typeParam.Parser |> parser.Map Left
                     termParam |> parser.Map Right ]
               )
 
@@ -324,15 +332,15 @@ module Expr =
             let! bodyType =
               match colon with
               | Left _ ->
-                typeDecl (
+                (typeDecl (
                   parseAllComplexTypeShapes
                   |> Set.remove ComplexTypeKind.BinaryExpressionChain
-                )
+                )).Parser
                 |> parser.Map Some
               | Right _ -> parser { return None }
 
             do! parseOperator Operator.SingleArrow
-            let! body = expr parseAllComplexShapes
+            let! body = (expr parseAllComplexShapes).Parser
 
             return
               (body, true)
@@ -369,12 +377,12 @@ module Expr =
           parser.Any
             [ parser {
                 do! openRoundBracketOperator
-                let! paramName = singleIdentifier
+                let! paramName = singleIdentifier.Parser
                 do! colonOperator
 
                 return!
                   parser {
-                    let! typeDecl = typeDecl parseAllComplexTypeShapes
+                    let! typeDecl = (typeDecl parseAllComplexTypeShapes).Parser
                     do! closeRoundBracketOperator
                     return paramName, typeDecl |> Some
                   }
@@ -383,7 +391,7 @@ module Expr =
                   )
               }
               parser {
-                let! paramName = singleIdentifier
+                let! paramName = singleIdentifier.Parser
 
                 let! paramType =
                   parser.Any
@@ -392,7 +400,7 @@ module Expr =
 
                         return!
                           parser {
-                            let! typeDecl = typeDecl parseAllComplexTypeShapes
+                            let! typeDecl = (typeDecl parseAllComplexTypeShapes).Parser
                             return typeDecl |> Some
                           }
                           |> parser.MapError(
@@ -415,7 +423,7 @@ module Expr =
         let! loc' = parser.Location
 
         let! value =
-          expr parseAllComplexShapes
+          (expr parseAllComplexShapes).Parser
           |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
         do!
@@ -449,7 +457,7 @@ module Expr =
         let! loc = parser.Location
 
         let! value =
-          expr parseAllComplexShapes
+          (expr parseAllComplexShapes).Parser
           |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
         do!
@@ -463,7 +471,7 @@ module Expr =
           |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
         let! body =
-          expr parseAllComplexShapes
+          (expr parseAllComplexShapes).Parser
           |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
 
         return Expr.Do(value, body, loc, TypeCheckScope.Empty)
@@ -477,11 +485,11 @@ module Expr =
 
         return!
           parser {
-            let! cond = expr parseAllComplexShapes
+            let! cond = (expr parseAllComplexShapes).Parser
             do! thenKeyword
-            let! thenBranch = expr parseAllComplexShapes
+            let! thenBranch = (expr parseAllComplexShapes).Parser
             do! elseKeyword
-            let! elseBranch = expr parseAllComplexShapes
+            let! elseBranch = (expr parseAllComplexShapes).Parser
 
             return
               Expr.If(cond, thenBranch, elseBranch, loc, TypeCheckScope.Empty)
@@ -586,7 +594,7 @@ module Expr =
             | Left _ ->
               return mkListLiteral []
             | Right _ ->
-              let! firstExpr = expr parseAllComplexShapes
+              let! firstExpr = (expr parseAllComplexShapes).Parser
 
               let firstLookupId =
                 match firstExpr.Expr with
@@ -599,7 +607,7 @@ module Expr =
                     parser.ManyIndex(fun _ ->
                       parser {
                         do! semicolonOperator
-                        let! value = expr parseAllComplexShapes
+                        let! value = (expr parseAllComplexShapes).Parser
                         return value
                       })
 
@@ -618,9 +626,9 @@ module Expr =
                         if i > 0 then
                           do! semicolonOperator
 
-                        let! id = identifierLocalOrFullyQualified ()
+                        let! id = (identifierLocalOrFullyQualified ()).Parser
                         do! equalsOperator
-                        let! value = expr parseAllComplexShapes
+                        let! value = (expr parseAllComplexShapes).Parser
                         return (id, value)
                       })
 
@@ -634,15 +642,15 @@ module Expr =
                 : Parser<_, _, _, _> =
                 parser {
                   do! equalsOperator
-                  let! firstValue = expr parseAllComplexShapes
+                  let! firstValue = (expr parseAllComplexShapes).Parser
 
                   let! fields =
                     parser.ManyIndex(fun _ ->
                       parser {
                         do! semicolonOperator
-                        let! id = identifierLocalOrFullyQualified ()
+                        let! id = (identifierLocalOrFullyQualified ()).Parser
                         do! equalsOperator
-                        let! value = expr parseAllComplexShapes
+                        let! value = (expr parseAllComplexShapes).Parser
                         return (id, value)
                       })
 
@@ -662,15 +670,15 @@ module Expr =
                 : Parser<_, _, _, _> =
                 parser {
                   do! singleArrowOperator
-                  let! firstValue = expr parseAllComplexShapes
+                  let! firstValue = (expr parseAllComplexShapes).Parser
 
                   let! entries =
                     parser.ManyIndex(fun _ ->
                       parser {
                         do! semicolonOperator
-                        let! key = identifierLocalOrFullyQualified ()
+                        let! key = (identifierLocalOrFullyQualified ()).Parser
                         do! singleArrowOperator
-                        let! value = expr parseAllComplexShapes
+                        let! value = (expr parseAllComplexShapes).Parser
                         return (key, value)
                       })
 
@@ -707,10 +715,10 @@ module Expr =
                   do! commaOperator
 
                   let! value =
-                    expr (
+                    (expr (
                       parseComplexShapes
                       |> Set.remove ComplexExpressionKind.TupleCons
-                    )
+                    )).Parser
 
                   return value
                 }
@@ -732,8 +740,8 @@ module Expr =
 
             let! firstFieldOrRecover =
               parser.Any
-                [ singleIdentifier |> parser.Map(Left >> Some)
-                  intLiteralToken () |> parser.Map(Right >> Some)
+                [ singleIdentifier.Parser |> parser.Map(Left >> Some)
+                  (intLiteralToken ()).Parser |> parser.Map(Right >> Some)
                   parser { return None } ]
 
             match firstFieldOrRecover with
@@ -745,8 +753,8 @@ module Expr =
 
                     return!
                       parser.Any
-                        [ singleIdentifier |> parser.Map Left
-                          intLiteralToken () |> parser.Map Right ]
+                        [ singleIdentifier.Parser |> parser.Map Left
+                          (intLiteralToken ()).Parser |> parser.Map Right ]
                   }
                 )
                 |> parser.Try
@@ -769,7 +777,7 @@ module Expr =
         let! loc = parser.Location
 
         let! id =
-          singleIdentifier
+          singleIdentifier.Parser
           |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
           |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
 
@@ -777,7 +785,7 @@ module Expr =
 
         let! typeDecl =
           parser.Any
-            [ typeDecl parseAllComplexTypeShapes
+            [ (typeDecl parseAllComplexTypeShapes).Parser
               |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.Low))
               (fun () ->
                 $"Malformed type declaration for '{id}' at {loc}")
@@ -855,7 +863,7 @@ module Expr =
       parser {
         let! id =
           parser.Any
-            [ singleIdentifier
+            [ singleIdentifier.Parser
               schemaKeyword |> parser.Map(replaceWith "schema")
               entityKeyword |> parser.Map(replaceWith "entity")
               relationKeyword |> parser.Map(replaceWith "relation") ]
@@ -876,7 +884,7 @@ module Expr =
 
             let! firstIdOrNone =
               parser.Any
-                [ singleIdentifier |> parser.Map Some
+                [ singleIdentifier.Parser |> parser.Map Some
                   parser { return None } ]
 
             match firstIdOrNone with
@@ -887,7 +895,7 @@ module Expr =
                 parser.AtLeastOne(
                   parser {
                     do! doubleColonOperator
-                    return! singleIdentifier
+                    return! singleIdentifier.Parser
                   }
                 )
                 |> parser.Try
@@ -911,13 +919,13 @@ module Expr =
             let! fields =
               parser.AtLeastOne(
                 parser {
-                  let! op = binaryExprOperator
+                  let! op = binaryExprOperator.Parser
 
                   let! value =
-                    expr (
+                    (expr (
                       parseComplexShapes
                       |> Set.remove ComplexExpressionKind.BinaryExpressionChain
-                    )
+                    )).Parser
 
                   return op, value
                 }
@@ -932,9 +940,9 @@ module Expr =
       parser {
         let! res =
           parser.Any
-            [ expr (Set.singleton ComplexExpressionKind.RecordDes)
+            [ (expr (Set.singleton ComplexExpressionKind.RecordDes)).Parser
               |> parser.Map Sum.Left
-              (fun () -> typeDecl parseAllComplexTypeShapes)
+              (fun () -> (typeDecl parseAllComplexTypeShapes).Parser)
               |> betweenSquareBrackets
               |> parser.Map(Sum.Right) ]
           |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
@@ -981,27 +989,27 @@ module Expr =
       | Token.StringLiteral _ -> [ stringLiteral () ]
       | Token.IntLiteral _ -> [ intLiteral () ]
       | Token.Int64Literal _ -> [ int64Literal () ]
-      | Token.CaseLiteral _ -> [ caseLiteral () |> parser.Map Expr.SumCons ]
+      | Token.CaseLiteral _ -> [ (caseLiteral ()).Parser |> parser.Map Expr.SumCons ]
       | Token.DecimalLiteral _ -> [ decimalLiteral () ]
       | Token.Float32Literal _ -> [ float32Literal () ]
       | Token.Float64Literal _ -> [ float64Literal () ]
       | Token.BoolLiteral _ -> [ boolLiteral () ]
       | Token.Operator(Operator.RoundBracket Bracket.Open) ->
         [ unitLiteral ()
-          betweenBrackets (fun () -> expr parseAllComplexShapes) ]
+          betweenBrackets (fun () -> (expr parseAllComplexShapes).Parser) ]
       | Token.Keyword Keyword.Fun -> [ exprLambda () ]
       | Token.Keyword Keyword.If -> [ exprConditional () ]
       | Token.Operator(Operator.CurlyBracket Bracket.Open) -> [ recordCons () ]
       | Token.Keyword Keyword.Type -> [ typeLet () ]
       | Token.Keyword Keyword.Match -> [ matchWith () ]
       | Token.Keyword Keyword.Query ->
-        [ query (fun () -> expr parseAllComplexShapes) () ]
+        [ (query (fun () -> (expr parseAllComplexShapes).Parser) ()).Parser ]
       | Token.Keyword Keyword.View ->
         [ // Try View::name first, then fall back to view expression
           parser {
             do! parseKeyword Keyword.View
             do! doubleColonOperator
-            let! name = singleIdentifier
+            let! name = singleIdentifier.Parser
             let! loc = parser.Location
             match ViewOperationKind.TryParse name with
             | Some op ->
@@ -1015,13 +1023,13 @@ module Expr =
                 |> Errors.Singleton loc
                 |> parser.Throw
           }
-          viewExpr (fun () -> expr parseAllComplexShapes) () ]
+          (viewExpr (fun () -> (expr parseAllComplexShapes).Parser) ()).Parser ]
       | Token.Keyword Keyword.Co ->
         [ // Try Co::name first, then fall back to co expression
           parser {
             do! parseKeyword Keyword.Co
             do! doubleColonOperator
-            let! name = singleIdentifier
+            let! name = singleIdentifier.Parser
             let! loc = parser.Location
             match CoOperationKind.TryParse name with
             | Some op ->
@@ -1035,9 +1043,9 @@ module Expr =
                 |> Errors.Singleton loc
                 |> parser.Throw
           }
-          coExpr (fun () -> expr parseAllComplexShapes) () ]
+          (coExpr (fun () -> (expr parseAllComplexShapes).Parser) ()).Parser ]
       | Token.Operator Operator.LessThan ->
-        [ viewNodeExpr (fun () -> expr parseAllComplexShapes) () ]
+        [ (viewNodeExpr (fun () -> (expr parseAllComplexShapes).Parser) ()).Parser ]
       | Token.Identifier _
       | Token.Keyword Keyword.Schema
       | Token.Keyword Keyword.Entity
@@ -1089,7 +1097,7 @@ module Expr =
         //   )
 
         // do Console.ReadLine() |> ignore
-        let! e = expr parseNoComplexShapes
+        let! e = (expr parseNoComplexShapes).Parser
         // do Console.Write $"{e.ToFSharpString}"
         // do Console.WriteLine $"included = {parseComplexShapes.ToFSharpString}"
         // do Console.ReadLine() |> ignore
@@ -1392,12 +1400,18 @@ module Expr =
         | Sum.Right e -> return! e |> parser.Throw
         | Sum.Left res -> return res
     }
+    |> AnnotatedParser.withNamedRule exprRule
+
+  let programRule: NamedRule =
+    { Name = "program"
+      Rule = Seq [ NonTerminal "expr"; Terminal "<eof>" ] }
 
   let program<'valueExt>
     ()
-    : Parser<Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>, _, _, _> =
+    : AnnotatedParser<Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>>
+    =
     parser {
-      let! e = expr 0 parseAllComplexShapes
+      let! e = (expr 0 parseAllComplexShapes).Parser
 
       let! loc = parser.Location
 
@@ -1412,3 +1426,6 @@ module Expr =
       do! parser.EndOfStream()
       return e
     }
+    |> AnnotatedParser.withNamedRule programRule
+
+  let grammarRules: NamedRule list = [ exprRule; programRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Grammar.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Grammar.fs
@@ -1,0 +1,15 @@
+namespace Ballerina.DSL.Next.Syntax.Parser
+
+open Ballerina.Grammar
+
+module Grammar =
+
+  let allRules: NamedRule list =
+    Common.grammarRules
+    @ Kind.grammarRules
+    @ TypeHooksAndProperties.grammarRules
+    @ TypeSchema.grammarRules
+    @ Type.grammarRules
+    @ Query.grammarRules
+    @ View.grammarRules
+    @ Expr.grammarRules

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Kind.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Kind.fs
@@ -14,6 +14,13 @@ module Kind =
   open Ballerina.LocalizedErrors
   open Ballerina.Errors
   open Ballerina.DSL.Next.Terms
+  open Ballerina.Grammar
+
+  let kindDeclRule =
+    { Name = "kind"
+      Rule =
+        Seq [ Alt [ Terminal "*"; Seq [ Terminal "("; NonTerminal "kind"; Terminal ")" ] ]
+              Optional (Seq [ Terminal "->"; NonTerminal "kind" ]) ] }
 
   let rec kindDecl () =
     parser {
@@ -22,7 +29,7 @@ module Kind =
           [ (starOperator |> parser.Map(fun _ -> Kind.Star))
             (parser {
               do! openRoundBracketOperator
-              let! res = kindDecl ()
+              let! res = (kindDecl ()).Parser
               do! closeRoundBracketOperator
               return res
             }) ]
@@ -32,6 +39,9 @@ module Kind =
       match singleArrow with
       | Right _ -> return Kind.Star
       | _ ->
-        let! rest = kindDecl ()
+        let! rest = (kindDecl ()).Parser
         return Kind.Arrow(first, rest)
     }
+    |> AnnotatedParser.withNamedRule kindDeclRule
+
+  let grammarRules: NamedRule list = [ kindDeclRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Query.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Query.fs
@@ -23,6 +23,7 @@ module Query =
   open Type
   open Ballerina.DSL.Next.Syntax
   open Ballerina
+  open Ballerina.Grammar
 
   type ComplexExpressionKind =
     | ScopedIdentifier
@@ -54,16 +55,19 @@ module Query =
 
   let private parseNoComplexShapes: Set<ComplexExpressionKind> = Set.empty
 
+  let queryExprRule: NamedRule =
+    { Name = "query-expr"
+      Rule =
+        Alt
+          [ NonTerminal "string-literal"; NonTerminal "int-literal"
+            NonTerminal "decimal-literal"; NonTerminal "bool-literal"
+            NonTerminal "conditional-expr"; NonTerminal "identifier-lookup"
+            NonTerminal "application" ] }
+
   let rec queryexpr<'valueExt>
     (query: unit -> _)
     (depth: int)
     (parseComplexShapes: Set<ComplexExpressionKind>)
-    : Parser<
-        ExprQueryExpr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
 
     let expr = queryexpr query (depth + 1)
@@ -159,11 +163,11 @@ module Query =
 
         return!
           parser {
-            let! cond = expr parseAllComplexShapes
+            let! cond = (expr parseAllComplexShapes).Parser
             do! thenKeyword
-            let! thenBranch = expr parseAllComplexShapes
+            let! thenBranch = (expr parseAllComplexShapes).Parser
             do! elseKeyword
-            let! elseBranch = expr parseAllComplexShapes
+            let! elseBranch = (expr parseAllComplexShapes).Parser
 
             return
               ExprQueryExprRec.QueryConditional(cond, thenBranch, elseBranch)
@@ -179,7 +183,7 @@ module Query =
 
         return!
           parser {
-            let! q = query ()
+            let! q = (query ()).Parser
 
             return ExprQueryExprRec.QueryCount(q) |> ExprQueryExpr.Create loc
           }
@@ -193,7 +197,7 @@ module Query =
 
         return!
           parser {
-            let! q = query ()
+            let! q = (query ()).Parser
 
             return ExprQueryExprRec.QueryExists(q) |> ExprQueryExpr.Create loc
           }
@@ -207,7 +211,7 @@ module Query =
 
         return!
           parser {
-            let! q = query ()
+            let! q = (query ()).Parser
 
             return ExprQueryExprRec.QueryArray(q) |> ExprQueryExpr.Create loc
           }
@@ -226,10 +230,10 @@ module Query =
                   do! commaOperator
 
                   let! value =
-                    expr (
+                    (expr (
                       parseComplexShapes
                       |> Set.remove ComplexExpressionKind.TupleCons
-                    )
+                    )).Parser
 
                   return value
                 }
@@ -254,7 +258,7 @@ module Query =
                   return!
                     parser.Any
                       [ singleIdentifier |> parser.Map Left
-                        intLiteralToken () |> parser.Map Right ]
+                        (intLiteralToken ()).Parser |> parser.Map Right ]
                 }
               )
 
@@ -320,13 +324,13 @@ module Query =
             let! fields =
               parser.AtLeastOne(
                 parser {
-                  let! op = binaryExprOperator
+                  let! op = binaryExprOperator.Parser
 
                   let! value =
-                    expr (
+                    (expr (
                       parseComplexShapes
                       |> Set.remove ComplexExpressionKind.BinaryExpressionChain
-                    )
+                    )).Parser
 
                   return op, value
                 }
@@ -338,7 +342,7 @@ module Query =
       }
 
     let argExpr () =
-      expr parseNoComplexShapes
+      (expr parseNoComplexShapes).Parser
       |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
 
     let application () =
@@ -356,7 +360,7 @@ module Query =
         decimalLiteral ()
         boolLiteral ()
         unitLiteral ()
-        betweenBrackets (fun () -> expr parseAllComplexShapes)
+        betweenBrackets (fun () -> (expr parseAllComplexShapes).Parser)
         exprConditional ()
         exprCount ()
         exprExists ()
@@ -388,7 +392,7 @@ module Query =
         //   )
 
         // do Console.ReadLine() |> ignore
-        let! e = expr parseNoComplexShapes
+        let! e = (expr parseNoComplexShapes).Parser
         // do Console.Write $"{e.ToFSharpString}"
         // do Console.WriteLine $"included = {parseComplexShapes.ToFSharpString}"
         // do Console.ReadLine() |> ignore
@@ -619,7 +623,13 @@ module Query =
         | Sum.Right e -> return! e |> parser.Throw
         | Sum.Left res -> return res
     }
+    |> AnnotatedParser.withNamedRule queryExprRule
 
+
+  let queryIteratorsRule: NamedRule =
+    { Name = "query-iterators"
+      Rule =
+        Repeat1 (Seq [ Terminal "from"; NonTerminal "identifier"; Terminal "in"; NonTerminal "expr" ]) }
 
   let rec private query_iterators_and_datasources<'valueExt>
     (expr:
@@ -639,7 +649,7 @@ module Query =
         parser {
 
           let! loc = parser.Location
-          let! _iterators = queryexpr<'valueExt> query 0 parseAllComplexShapes
+          let! _iterators = (queryexpr<'valueExt> query 0 parseAllComplexShapes).Parser
 
           let! _iterators =
             [ parser {
@@ -744,6 +754,12 @@ module Query =
         }
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule queryIteratorsRule
+
+  let queryJoinsRule: NamedRule =
+    { Name = "query-joins"
+      Rule =
+        Repeat (Seq [ Terminal "join"; NonTerminal "identifier"; Terminal "in"; NonTerminal "expr"; Terminal "on"; NonTerminal "expr"; Terminal "="; NonTerminal "expr" ]) }
 
   let private query_joins<'valueExt> query =
     parser {
@@ -764,7 +780,7 @@ module Query =
                     do! andKeyword
 
                   let! join_terms =
-                    queryexpr<'valueExt> query 0 parseAllComplexShapes
+                    (queryexpr<'valueExt> query 0 parseAllComplexShapes).Parser
 
                   let! join_terms =
                     join_terms
@@ -800,6 +816,12 @@ module Query =
           }
           |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule queryJoinsRule
+
+  let queryWhereRule: NamedRule =
+    { Name = "query-where"
+      Rule =
+        Optional (Seq [ Terminal "where"; NonTerminal "expr" ]) }
 
   let private query_where<'valueExt> query =
     parser {
@@ -810,20 +832,32 @@ module Query =
       | Left _ ->
         return!
           parser {
-            let! predicate = queryexpr<'valueExt> query 0 parseAllComplexShapes
+            let! predicate = (queryexpr<'valueExt> query 0 parseAllComplexShapes).Parser
             return Some predicate
           }
           |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule queryWhereRule
+
+  let querySelectRule: NamedRule =
+    { Name = "query-select"
+      Rule =
+        Seq [ Terminal "select"; NonTerminal "expr" ] }
 
   let private query_select<'valueExt> query =
     parser {
       do! selectKeyword
 
       return!
-        queryexpr<'valueExt> query 0 parseAllComplexShapes
+        (queryexpr<'valueExt> query 0 parseAllComplexShapes).Parser
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule querySelectRule
+
+  let queryOrderbyRule: NamedRule =
+    { Name = "query-orderby"
+      Rule =
+        Optional (Seq [ Terminal "orderBy"; NonTerminal "expr"; Alt [ Terminal "ascending"; Terminal "descending" ] ]) }
 
   let private query_orderby<'valueExt> query =
     parser {
@@ -834,7 +868,7 @@ module Query =
           match starts_with_orderby with
           | Right _ -> return None
           | Left _ ->
-            let! predicate = queryexpr<'valueExt> query 0 parseAllComplexShapes
+            let! predicate = (queryexpr<'valueExt> query 0 parseAllComplexShapes).Parser
             let! is_ascending = ascendingKeyword |> parser.Try
 
             if is_ascending.IsLeft then
@@ -855,6 +889,12 @@ module Query =
         }
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule queryOrderbyRule
+
+  let queryDistinctRule: NamedRule =
+    { Name = "query-distinct"
+      Rule =
+        Optional (Terminal "distinct") }
 
   let private query_distinct<'valueExt> (query) =
     parser {
@@ -868,7 +908,7 @@ module Query =
             return!
               parser {
                 let! distinction =
-                  queryexpr<'valueExt> query 0 parseAllComplexShapes
+                  (queryexpr<'valueExt> query 0 parseAllComplexShapes).Parser
 
                 return Some distinction
               }
@@ -878,6 +918,12 @@ module Query =
         }
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule queryDistinctRule
+
+  let queryBodyRule: NamedRule =
+    { Name = "query-body"
+      Rule =
+        Seq [ NonTerminal "query-iterators"; NonTerminal "query-joins"; NonTerminal "query-where"; NonTerminal "query-select"; NonTerminal "query-orderby"; NonTerminal "query-distinct" ] }
 
   let rec private query'<'valueExt>
     (expr:
@@ -889,12 +935,6 @@ module Query =
           Errors<Location>
          >)
     ()
-    : Parser<
-        ExprQuery<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     parser {
       let! hasBracket =
@@ -910,13 +950,13 @@ module Query =
           do! openCurlyBracketOperator
 
           let! iterators_with_datasources =
-            query_iterators_and_datasources expr (query expr)
+            (query_iterators_and_datasources expr (query expr)).Parser
 
-          let! joins = query_joins (query expr)
-          let! where_ = query_where (query expr)
-          let! select_expr = query_select<'valueExt> (query expr)
-          let! orderby_ = query_orderby (query expr)
-          let! distinct_ = query_distinct (query expr)
+          let! joins = (query_joins (query expr)).Parser
+          let! where_ = (query_where (query expr)).Parser
+          let! select_expr = (query_select<'valueExt> (query expr)).Parser
+          let! orderby_ = (query_orderby (query expr)).Parser
+          let! distinct_ = (query_distinct (query expr)).Parser
 
           do! closeCurlyBracketOperator
 
@@ -940,6 +980,12 @@ module Query =
         }
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule queryBodyRule
+
+  let queryRule: NamedRule =
+    { Name = "query"
+      Rule =
+        Seq [ Terminal "query"; Terminal "{"; NonTerminal "query-body"; Terminal "}" ] }
 
   let query<'valueExt>
     (expr:
@@ -951,17 +997,16 @@ module Query =
           Errors<Location>
          >)
     ()
-    : Parser<
-        Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     parser {
       let! loc = parser.Location
 
-      let! q = query' expr ()
+      let! q = (query' expr ()).Parser
       let res = Expr.Query(q, loc, TypeCheckScope.Empty)
       return res
     }
+    |> AnnotatedParser.withNamedRule queryRule
+
+  let grammarRules: NamedRule list =
+    [ queryExprRule; queryIteratorsRule; queryJoinsRule; queryWhereRule
+      querySelectRule; queryOrderbyRule; queryDistinctRule; queryBodyRule; queryRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type.fs
@@ -18,6 +18,7 @@ module Type =
   open Ballerina.DSL.Next.Terms
   open Ballerina
   open Ballerina.DSL.Next.Syntax.Parser.TypeSchema
+  open Ballerina.Grammar
 
   type ComplexTypeKind =
     | ScopedIdentifier
@@ -41,15 +42,34 @@ module Type =
 
   let parseNoComplexTypeShapes: Set<ComplexTypeKind> = Set.empty
 
+  let typeParamRule =
+    { Name = "type-param"
+      Rule =
+        Seq [ Terminal "["; NonTerminal "identifier"; Terminal ":"; NonTerminal "kind"; Terminal "]" ] }
+
   let typeParam =
     parser {
       do! openSquareBracketOperator
-      let! paramName = singleIdentifier
+      let! paramName = singleIdentifier.Parser
       do! colonOperator
-      let! kind = kindDecl ()
+      let! kind = (kindDecl ()).Parser
       do! closeSquareBracketOperator
       return paramName, kind
     }
+    |> AnnotatedParser.withNamedRule typeParamRule
+
+  let typeDeclRule =
+    { Name = "type-decl"
+      Rule =
+        Alt
+          [ NonTerminal "type-param"
+            Terminal "bool"; Terminal "int"; Terminal "int64"
+            Terminal "float32"; Terminal "float64"; Terminal "decimal"
+            Terminal "string"; Terminal "guid"; Terminal "dateTime"
+            Terminal "dateOnly"; Terminal "timeSpan"; Terminal "vector"
+            Terminal "FromQueryRow"; Seq [ Terminal "("; Terminal ")" ]
+            NonTerminal "schema-decl"; NonTerminal "record-type"
+            NonTerminal "union-type"; NonTerminal "identifier" ] }
 
   let rec typeDecl
     (parseExpr:
@@ -60,16 +80,16 @@ module Type =
         Errors<Location>
        >)
     (parseComplexShapes: Set<ComplexTypeKind>)
-    : Parser<TypeExpr<'valueExt>, _, _, Errors<Location>> =
+    =
     let lookupTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
         return TypeExpr.Lookup(Identifier.LocalScope id)
       }
 
     let boolTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "boolean" -> return TypeExpr.Primitive PrimitiveType.Bool
@@ -85,7 +105,7 @@ module Type =
 
     let int32TypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "int" -> return TypeExpr.Primitive PrimitiveType.Int32
@@ -102,7 +122,7 @@ module Type =
 
     let int64TypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "int64" -> return TypeExpr.Primitive PrimitiveType.Int64
@@ -117,7 +137,7 @@ module Type =
 
     let float32TypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "float32" -> return TypeExpr.Primitive PrimitiveType.Float32
@@ -132,7 +152,7 @@ module Type =
 
     let float64TypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "float64" -> return TypeExpr.Primitive PrimitiveType.Float64
@@ -147,7 +167,7 @@ module Type =
 
     let decimalTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "decimal" -> return TypeExpr.Primitive PrimitiveType.Decimal
@@ -162,7 +182,7 @@ module Type =
 
     let stringTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "string" -> return TypeExpr.Primitive PrimitiveType.String
@@ -177,7 +197,7 @@ module Type =
 
     let guidTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "guid" -> return TypeExpr.Primitive PrimitiveType.Guid
@@ -192,7 +212,7 @@ module Type =
 
     let dateTimeTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "dateTime" -> return TypeExpr.Primitive PrimitiveType.DateTime
@@ -207,7 +227,7 @@ module Type =
 
     let dateOnlyTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "date" -> return TypeExpr.Primitive PrimitiveType.DateOnly
@@ -223,7 +243,7 @@ module Type =
 
     let timeSpanTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "timeSpan" -> return TypeExpr.Primitive PrimitiveType.TimeSpan
@@ -238,7 +258,7 @@ module Type =
 
     let vectorTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "vector" -> return TypeExpr.Primitive PrimitiveType.Vector
@@ -253,7 +273,7 @@ module Type =
 
     let fromQueryRowTypeDecl () =
       parser {
-        let! id = singleIdentifier
+        let! id = singleIdentifier.Parser
 
         match id with
         | "FromQueryRow" -> return TypeExpr.FromQueryRow
@@ -274,10 +294,10 @@ module Type =
       }
 
     let schema () =
-      TypeSchema.schema
+      (TypeSchema.schema
         parseExpr
-        (fun () -> typeDecl parseExpr parseAllComplexTypeShapes)
-        ()
+        (fun () -> (typeDecl parseExpr parseAllComplexTypeShapes).Parser)
+        ()).Parser
 
     let record () =
       parser {
@@ -291,7 +311,7 @@ module Type =
                   if i > 0 then
                     do! semicolonOperator
 
-                  let! id = singleIdentifier
+                  let! id = singleIdentifier.Parser
                   let! fieldLoc = parser.Location
 
                   do!
@@ -307,7 +327,7 @@ module Type =
                   return!
                     parser {
                       let! typeDecl =
-                        typeDecl parseExpr parseAllComplexTypeShapes
+                        (typeDecl parseExpr parseAllComplexTypeShapes).Parser
 
                       return (id, typeDecl)
                     }
@@ -345,11 +365,11 @@ module Type =
 
                   return!
                     parser {
-                      let! id = singleIdentifier
+                      let! id = singleIdentifier.Parser
                       do! ofKeyword
 
                       let! typeDecl =
-                        typeDecl parseExpr parseAllComplexTypeShapes
+                        (typeDecl parseExpr parseAllComplexTypeShapes).Parser
 
                       return (id, typeDecl)
                     }
@@ -381,7 +401,7 @@ module Type =
               parser.AtLeastOne(
                 parser {
                   do! doubleColonOperator
-                  return! singleIdentifier
+                  return! singleIdentifier.Parser
                 }
               )
 
@@ -400,13 +420,13 @@ module Type =
             let! fields =
               parser.AtLeastOne(
                 parser {
-                  let! op = binaryTypeOperator
+                  let! op = binaryTypeOperator.Parser
 
                   let! value =
-                    typeDecl
+                    (typeDecl
                       parseExpr
                       (parseComplexShapes
-                       |> Set.remove ComplexTypeKind.BinaryExpressionChain)
+                       |> Set.remove ComplexTypeKind.BinaryExpressionChain)).Parser
 
                   return op, value
                 }
@@ -431,8 +451,8 @@ module Type =
 
                   return!
                     parser.Any
-                      [ singleIdentifier |> parser.Map Left
-                        intLiteralToken () |> parser.Map Right ]
+                      [ singleIdentifier.Parser |> parser.Map Left
+                        (intLiteralToken ()).Parser |> parser.Map Right ]
                 }
               )
 
@@ -447,7 +467,7 @@ module Type =
       parser {
         let! args =
           parser.AtLeastOne(
-            (fun () -> typeDecl parseExpr parseAllComplexTypeShapes)
+            (fun () -> (typeDecl parseExpr parseAllComplexTypeShapes).Parser)
             |> betweenSquareBrackets
           )
 
@@ -456,10 +476,10 @@ module Type =
 
     let typeLambda () =
       parser {
-        let! pars = parser.AtLeastOne typeParam
+        let! pars = parser.AtLeastOne typeParam.Parser
         do! parseOperator Operator.SingleArrow
         let pars = pars |> NonEmptyList.ToSeq
-        let! body = typeDecl parseExpr parseAllComplexTypeShapes
+        let! body = (typeDecl parseExpr parseAllComplexTypeShapes).Parser
 
         return
           Seq.foldBack
@@ -470,7 +490,7 @@ module Type =
       }
 
     let simpleShapes =
-      [ (fun () -> typeDecl parseExpr parseAllComplexTypeShapes)
+      [ (fun () -> (typeDecl parseExpr parseAllComplexTypeShapes).Parser)
         |> betweenBrackets
         typeLambda ()
         schema ()
@@ -516,7 +536,7 @@ module Type =
         //   )
 
         // do Console.ReadLine() |> ignore
-        let! e = typeDecl parseExpr parseNoComplexTypeShapes
+        let! e = (typeDecl parseExpr parseNoComplexTypeShapes).Parser
         // do Console.Write $"{e.ToFSharpString}"
         // do Console.WriteLine $"included = {parseComplexShapes.ToFSharpString}"
         // do Console.ReadLine() |> ignore
@@ -711,3 +731,6 @@ module Type =
         | Sum.Right e -> return! e |> parser.Throw
         | Sum.Left(res, _) -> return res
     }
+    |> AnnotatedParser.withNamedRule typeDeclRule
+
+  let grammarRules: NamedRule list = [ typeParamRule; typeDeclRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type/HooksAndProperties.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type/HooksAndProperties.fs
@@ -12,6 +12,7 @@ module TypeHooksAndProperties =
   open Ballerina.LocalizedErrors
   open Ballerina.Errors
   open Ballerina
+  open Ballerina.Grammar
 
   type TypeExprParser<'valueExt> =
     Parser<
@@ -23,6 +24,10 @@ module TypeHooksAndProperties =
 
   type TypeDeclParser<'valueExt> =
     Parser<TypeExpr<'valueExt>, LocalizedToken, Location, Errors<Location>>
+
+  let relationHooksRule =
+    { Name = "relation-hooks"
+      Rule = Repeat (Seq [ Terminal "let"; Terminal "on"; Alt [ Terminal "linking"; Terminal "linked"; Terminal "unlinking"; Terminal "unlinked" ]; Terminal "="; NonTerminal "expr" ]) }
 
   let relation_hooks (parseExpr: TypeExprParser<'valueExt>) () =
     let onHook (hookKeyword, hookKeywordParser) =
@@ -57,6 +62,11 @@ module TypeHooksAndProperties =
     |> parser.Any
     |> parser.Many
     |> parser.Map(Map.ofList)
+    |> AnnotatedParser.withNamedRule relationHooksRule
+
+  let entityHooksRule =
+    { Name = "entity-hooks"
+      Rule = Repeat (Seq [ Terminal "let"; Alt [ Terminal "on"; Terminal "can" ]; Alt [ Terminal "creating"; Terminal "created"; Terminal "updating"; Terminal "updated"; Terminal "deleting"; Terminal "deleted"; Terminal "background"; Terminal "create"; Terminal "read"; Terminal "update"; Terminal "delete" ]; Terminal "="; NonTerminal "expr" ]) }
 
   let entity_hooks (parseExpr: TypeExprParser<'valueExt>) () =
     let onHook (preHookKeyword) (hookKeyword, hookKeywordParser) =
@@ -98,25 +108,24 @@ module TypeHooksAndProperties =
     |> parser.Any
     |> parser.Many
     |> parser.Map(Map.ofList)
+    |> AnnotatedParser.withNamedRule entityHooksRule
+
+  let entityPropertiesRule =
+    { Name = "entity-properties"
+      Rule = Repeat (Seq [ Terminal "let"; Terminal "property"; Optional (NonTerminal "schema-path"); NonTerminal "identifier"; Terminal ":"; NonTerminal "type-decl"; Terminal "="; NonTerminal "expr" ]) }
 
   let entity_properties
     (parseExpr: TypeExprParser<'valueExt>)
     parseSchemaPath
     (parseTypeDecl: unit -> TypeDeclParser<'valueExt>)
     ()
-    : Parser<
-        SchemaEntityPropertyExpr<'valueExt> list,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     parser.Many(
       parser {
         do! letKeyword
         do! propertyKeyword
         let! path = parseSchemaPath ()
-        let! propertyName = singleIdentifier
+        let! propertyName = singleIdentifier.Parser
         do! colonOperator
         let! propertyType = parseTypeDecl ()
         do! equalsOperator
@@ -130,16 +139,15 @@ module TypeHooksAndProperties =
       }
     )
     |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
+    |> AnnotatedParser.withNamedRule entityPropertiesRule
+
+  let entityVectorsRule =
+    { Name = "entity-vectors"
+      Rule = Repeat (Seq [ Terminal "let"; Terminal "vector"; NonTerminal "identifier"; Terminal "="; NonTerminal "expr" ]) }
 
   let entity_vectors
     (parseExpr: TypeExprParser<'valueExt>)
     ()
-    : Parser<
-        SchemaEntityVectorExpr<'valueExt> list,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     parser.Many(
       parser {
@@ -158,7 +166,7 @@ module TypeHooksAndProperties =
           |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
           |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
 
-        let! vectorName = singleIdentifier
+        let! vectorName = singleIdentifier.Parser
         do! equalsOperator
         let! vectorBody = parseExpr
 
@@ -168,3 +176,6 @@ module TypeHooksAndProperties =
       }
     )
     |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
+    |> AnnotatedParser.withNamedRule entityVectorsRule
+
+  let grammarRules: NamedRule list = [ relationHooksRule; entityHooksRule; entityPropertiesRule; entityVectorsRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type/Schema.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type/Schema.fs
@@ -12,6 +12,7 @@ module TypeSchema =
   open Ballerina.LocalizedErrors
   open Ballerina.Errors
   open Ballerina
+  open Ballerina.Grammar
 
   type TypeExprParser<'valueExt> =
     Parser<
@@ -24,10 +25,14 @@ module TypeSchema =
   type TypeDeclParser<'valueExt> =
     Parser<TypeExpr<'valueExt>, LocalizedToken, Location, Errors<Location>>
 
+  let cardinalityRule =
+    { Name = "cardinality"
+      Rule = Alt [ Terminal "0"; Terminal "1"; Terminal "*" ] }
+
   let cardinality () =
     parser.Any
       [ parser {
-          let! v = intLiteralToken ()
+          let! v = (intLiteralToken ()).Parser
 
           if v = 0 then
             return Cardinality.Zero
@@ -56,6 +61,11 @@ module TypeSchema =
         }
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High)) ]
     |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
+    |> AnnotatedParser.withNamedRule cardinalityRule
+
+  let schemaPathRule =
+    { Name = "schema-path"
+      Rule = Optional (Seq [ Terminal "["; NonTerminal "schema-path-segments"; Terminal "]" ]) }
 
   let rec schemaPath () =
     parser {
@@ -64,12 +74,17 @@ module TypeSchema =
       | Left _ ->
         return!
           parser {
-            let! segments = schemaPathSegments ()
+            let! segments = (schemaPathSegments ()).Parser
             do! closeSquareBracketOperator
             return Some segments
           }
           |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
+    |> AnnotatedParser.withNamedRule schemaPathRule
+
+  and schemaPathSegmentsRule =
+    { Name = "schema-path-segments"
+      Rule = Repeat (Seq [ Optional (Seq [ Terminal "let"; NonTerminal "identifier"; Terminal ":" ]); Alt [ Seq [ Terminal "field"; NonTerminal "identifier" ]; Seq [ Terminal "case"; NonTerminal "identifier" ]; Seq [ Terminal "item"; NonTerminal "int-literal" ]; Seq [ Terminal "iterator"; Terminal "("; NonTerminal "identifier"; Terminal ","; NonTerminal "identifier"; Terminal ","; NonTerminal "identifier"; Terminal ")" ] ] ]) }
 
   and schemaPathSegments () =
     parser.ManyIndex(fun i ->
@@ -84,7 +99,7 @@ module TypeSchema =
             match no_binding with
             | Right _ -> return None
             | Left _ ->
-              let! id = singleIdentifier
+              let! id = singleIdentifier.Parser
               do! colonOperator
               let id = id |> LocalIdentifier.Create
               return id |> Some
@@ -95,35 +110,35 @@ module TypeSchema =
             [ afterKeyword
                 fieldKeyword
                 (parser {
-                  let! id = identifierLocalOrFullyQualified ()
+                  let! id = (identifierLocalOrFullyQualified ()).Parser
                   return SchemaPathTypeDecompositionExpr.Field id
                 })
               afterKeyword
                 caseKeyword
                 (parser.Any
                   [ parser {
-                      let! id = identifierLocalOrFullyQualified ()
+                      let! id = (identifierLocalOrFullyQualified ()).Parser
                       return SchemaPathTypeDecompositionExpr.UnionCase id
                     }
                     parser {
-                      let! case = caseLiteral ()
+                      let! case = (caseLiteral ()).Parser
                       return SchemaPathTypeDecompositionExpr.SumCase case
                     } ])
               afterKeyword
                 itemKeyword
                 (parser {
-                  let! item = intLiteralToken ()
+                  let! item = (intLiteralToken ()).Parser
                   return SchemaPathTypeDecompositionExpr.Item { Index = item }
                 })
               afterKeyword
                 iteratorKeyword
                 (parser {
                   do! openRoundBracketOperator
-                  let! mapper = identifierLocalOrFullyQualified ()
+                  let! mapper = (identifierLocalOrFullyQualified ()).Parser
                   do! commaOperator
-                  let! containerType = identifierLocalOrFullyQualified ()
+                  let! containerType = (identifierLocalOrFullyQualified ()).Parser
                   do! commaOperator
-                  let! typeDef = identifierLocalOrFullyQualified ()
+                  let! typeDef = (identifierLocalOrFullyQualified ()).Parser
                   do! closeRoundBracketOperator
 
                   return
@@ -137,24 +152,23 @@ module TypeSchema =
         return var, res
       })
     |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
+    |> AnnotatedParser.withNamedRule schemaPathSegmentsRule
+
+  let relationExtensionRule =
+    { Name = "relation-extension"
+      Rule = Seq [ Terminal "relation"; NonTerminal "identifier"; Terminal "{"; NonTerminal "relation-hooks"; Terminal "}" ] }
 
   let relation_extension
     (parseExpr: TypeExprParser<'valueExt>)
     ()
-    : Parser<
-        (SchemaRelationName * SchemaRelationHooksExpr<'valueExt>),
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     afterKeyword
       relationKeyword
       (parser {
-        let! relationName = singleIdentifier
+        let! relationName = singleIdentifier.Parser
         do! openCurlyBracketOperator
 
-        let! hooks = TypeHooksAndProperties.relation_hooks parseExpr ()
+        let! hooks = (TypeHooksAndProperties.relation_hooks parseExpr ()).Parser
 
         let onLinking = hooks |> Map.tryFind SchemaRelationHook.Linking
         let onLinked = hooks |> Map.tryFind SchemaRelationHook.Linked
@@ -171,16 +185,15 @@ module TypeSchema =
 
         return { SchemaRelationName.Name = relationName }, relationHooksExpr
       })
+    |> AnnotatedParser.withNamedRule relationExtensionRule
+
+  let relationRule =
+    { Name = "relation"
+      Rule = Seq [ Terminal "relation"; NonTerminal "identifier"; Terminal "{"; Terminal "from"; NonTerminal "identifier"; Optional (NonTerminal "schema-path"); Terminal "to"; NonTerminal "identifier"; Optional (NonTerminal "schema-path"); Optional (Seq [ Terminal "cardinality"; NonTerminal "cardinality"; Terminal ".."; NonTerminal "cardinality" ]); NonTerminal "relation-hooks"; Terminal "}" ] }
 
   let relation
     (parseExpr: TypeExprParser<'valueExt>)
     ()
-    : Parser<
-        SchemaRelationExpr<'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     parser {
       let! loc_fallback = parser.Location
@@ -196,15 +209,15 @@ module TypeSchema =
 
       return!
         (parser {
-          let! relationName = singleIdentifier
+          let! relationName = singleIdentifier.Parser
           do! openCurlyBracketOperator
           do! fromKeyword
-          let! fromEntity = identifierLocalOrFullyQualified ()
-          let! fromPath = schemaPath ()
+          let! fromEntity = (identifierLocalOrFullyQualified ()).Parser
+          let! fromPath = (schemaPath ()).Parser
 
           do! toKeyword
-          let! toEntity = identifierLocalOrFullyQualified ()
-          let! toPath = schemaPath ()
+          let! toEntity = (identifierLocalOrFullyQualified ()).Parser
+          let! toPath = (schemaPath ()).Parser
 
           let! hasCardinality = cardinalityKeyword |> parser.Try
 
@@ -213,9 +226,9 @@ module TypeSchema =
             | Right _ -> parser { return None }
             | Left() ->
               parser {
-                let! from = cardinality ()
+                let! from = (cardinality ()).Parser
                 do! doubleDotOperator
-                let! to_ = cardinality ()
+                let! to_ = (cardinality ()).Parser
 
                 return
                   Some(
@@ -225,7 +238,7 @@ module TypeSchema =
               }
 
 
-          let! hooks = TypeHooksAndProperties.relation_hooks parseExpr ()
+          let! hooks = (TypeHooksAndProperties.relation_hooks parseExpr ()).Parser
 
           let onLinking = hooks |> Map.tryFind SchemaRelationHook.Linking
           let onLinked = hooks |> Map.tryFind SchemaRelationHook.Linked
@@ -250,17 +263,16 @@ module TypeSchema =
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
     |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
+    |> AnnotatedParser.withNamedRule relationRule
+
+  let entityRule =
+    { Name = "entity"
+      Rule = Seq [ Terminal "entity"; NonTerminal "identifier"; Terminal "{"; Terminal "type"; NonTerminal "type-decl"; NonTerminal "type-decl"; NonTerminal "entity-properties"; NonTerminal "entity-vectors"; NonTerminal "entity-hooks"; Terminal "}" ] }
 
   let entity
     (parseExpr: TypeExprParser<'valueExt>)
     (parseTypeDecl: unit -> TypeDeclParser<'valueExt>)
     ()
-    : Parser<
-        SchemaEntityExpr<'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     parser {
       let! loc_fallback = parser.Location
@@ -276,7 +288,7 @@ module TypeSchema =
 
       return!
         (parser {
-          let! entityName = singleIdentifier
+          let! entityName = singleIdentifier.Parser
           do! openCurlyBracketOperator
 
           do!
@@ -290,15 +302,15 @@ module TypeSchema =
           let! idType = parseTypeDecl ()
 
           let! properties =
-            TypeHooksAndProperties.entity_properties
+            (TypeHooksAndProperties.entity_properties
               parseExpr
-              schemaPath
+              (fun () -> (schemaPath ()).Parser)
               parseTypeDecl
-              ()
+              ()).Parser
 
-          let! vectors = TypeHooksAndProperties.entity_vectors parseExpr ()
+          let! vectors = (TypeHooksAndProperties.entity_vectors parseExpr ()).Parser
 
-          let! hooks = TypeHooksAndProperties.entity_hooks parseExpr ()
+          let! hooks = (TypeHooksAndProperties.entity_hooks parseExpr ()).Parser
           let onCreating = hooks |> Map.tryFind SchemaEntityHook.Creating
           let onCreated = hooks |> Map.tryFind SchemaEntityHook.Created
           let onUpdating = hooks |> Map.tryFind SchemaEntityHook.Updating
@@ -358,24 +370,23 @@ module TypeSchema =
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }
     |> parser.MapError(Errors<Location>.FilterHighestPriorityOnly)
+    |> AnnotatedParser.withNamedRule entityRule
+
+  let entityExtensionRule =
+    { Name = "entity-extension"
+      Rule = Seq [ Terminal "entity"; NonTerminal "identifier"; Terminal "{"; NonTerminal "entity-hooks"; Terminal "}" ] }
 
   let entity_extension
     (parseExpr: TypeExprParser<'valueExt>)
     ()
-    : Parser<
-        (SchemaEntityName * SchemaEntityHooksExpr<'valueExt>),
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
     afterKeyword
       entityKeyword
       (parser {
-        let! entityName = singleIdentifier
+        let! entityName = singleIdentifier.Parser
         do! openCurlyBracketOperator
 
-        let! hooks = TypeHooksAndProperties.entity_hooks parseExpr ()
+        let! hooks = (TypeHooksAndProperties.entity_hooks parseExpr ()).Parser
         let onCreating = hooks |> Map.tryFind SchemaEntityHook.Creating
         let onCreated = hooks |> Map.tryFind SchemaEntityHook.Created
         let onUpdating = hooks |> Map.tryFind SchemaEntityHook.Updating
@@ -405,12 +416,17 @@ module TypeSchema =
 
         return { SchemaEntityName.Name = entityName }, entityHooksExpr
       })
+    |> AnnotatedParser.withNamedRule entityExtensionRule
+
+  let schemaRule =
+    { Name = "schema-decl"
+      Rule = Seq [ Terminal "schema"; Terminal "{"; Optional (Seq [ Terminal "include"; NonTerminal "identifier"; Optional (Seq [ Terminal "with"; Terminal "{"; Repeat (Alt [ NonTerminal "entity-extension"; NonTerminal "relation-extension" ]); Terminal "}" ]) ]); Repeat (Alt [ NonTerminal "entity"; NonTerminal "relation" ]); Terminal "}" ] }
 
   let schema
     (parseExpr: TypeExprParser<'valueExt>)
     (parseTypeDecl: unit -> TypeDeclParser<'valueExt>)
     ()
-    : Parser<TypeExpr<'valueExt>, LocalizedToken, Location, Errors<Location>> =
+    =
     afterKeyword
       schemaKeyword
       (parser {
@@ -430,7 +446,7 @@ module TypeSchema =
                   match isEntity with
                   | Left _ ->
                     return!
-                      entity_extension parseExpr ()
+                      (entity_extension parseExpr ()).Parser
                       |> parser.Map Sum.Left
                       |> parser.MapError(
                         Errors<Location>.FilterHighestPriorityOnly
@@ -442,7 +458,7 @@ module TypeSchema =
                     match isRelation with
                     | Left _ ->
                       return!
-                        relation_extension parseExpr ()
+                        (relation_extension parseExpr ()).Parser
                         |> parser.Map Sum.Right
                         |> parser.MapError(
                           Errors<Location>.FilterHighestPriorityOnly
@@ -485,7 +501,7 @@ module TypeSchema =
                   match isEntity with
                   | Left _ ->
                     return!
-                      entity parseExpr parseTypeDecl ()
+                      (entity parseExpr parseTypeDecl ()).Parser
                       |> parser.Map Sum.Left
                       |> parser.MapError(
                         Errors<Location>.FilterHighestPriorityOnly
@@ -497,7 +513,7 @@ module TypeSchema =
                     match isRelation with
                     | Left _ ->
                       return!
-                        relation parseExpr ()
+                        (relation parseExpr ()).Parser
                         |> parser.Map Sum.Right
                         |> parser.MapError(
                           Errors<Location>.FilterHighestPriorityOnly
@@ -534,7 +550,7 @@ module TypeSchema =
             match hasInclude with
             | Right _ -> return None
             | Left() ->
-              let! schemaName = singleIdentifier
+              let! schemaName = singleIdentifier.Parser
               let! hasWith = withKeyword |> parser.Try
 
               let! entities, relations =
@@ -592,3 +608,6 @@ module TypeSchema =
               Entities = entities
               Relations = relations }
       })
+    |> AnnotatedParser.withNamedRule schemaRule
+
+  let grammarRules: NamedRule list = [ cardinalityRule; schemaPathRule; schemaPathSegmentsRule; relationExtensionRule; relationRule; entityRule; entityExtensionRule; schemaRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/View.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/View.fs
@@ -18,21 +18,32 @@ module View =
   open Type
   open Ballerina.DSL.Next.Syntax
   open Ballerina
+  open Ballerina.Grammar
 
   // ═══════════════════════════════════════════════════════════════════════════
   // JSX View Parser
   // ═══════════════════════════════════════════════════════════════════════════
 
-  let private lessThanOperator = parseOperator Operator.LessThan
-  let private greaterThanOperator = parseOperator Operator.GreaterThan
-  let private tagSelfCloseOperator = parseOperator Operator.TagSelfClose
-  let private tagCloseOperator = parseOperator Operator.TagClose
+  let lessThanOpRule = { Name = "less-than-op"; Rule = Terminal "<" }
+  let greaterThanOpRule = { Name = "greater-than-op"; Rule = Terminal ">" }
+  let tagSelfCloseOpRule = { Name = "tag-self-close-op"; Rule = Terminal "/>" }
+  let tagCloseOpRule = { Name = "tag-close-op"; Rule = Terminal "</" }
+
+  let private lessThanOperator = parseOperator Operator.LessThan |> AnnotatedParser.withNamedRule lessThanOpRule
+  let private greaterThanOperator = parseOperator Operator.GreaterThan |> AnnotatedParser.withNamedRule greaterThanOpRule
+  let private tagSelfCloseOperator = parseOperator Operator.TagSelfClose |> AnnotatedParser.withNamedRule tagSelfCloseOpRule
+  let private tagCloseOperator = parseOperator Operator.TagClose |> AnnotatedParser.withNamedRule tagCloseOpRule
+
+  let tagIdentifierRule = { Name = "tag-identifier"; Rule = Terminal "<tag-identifier>" }
 
   let private tagIdentifier =
     parser.Exactly(fun t ->
       match t.Token with
       | Token.Identifier id -> Some id
       | _ -> None)
+    |> AnnotatedParser.withNamedRule tagIdentifierRule
+
+  let attrIdentifierRule = { Name = "attr-identifier"; Rule = Terminal "<attr-identifier>" }
 
   /// Attribute name parser: accepts identifiers and keywords (e.g. type, for)
   let private attrIdentifier =
@@ -41,6 +52,9 @@ module View =
       | Token.Identifier id -> Some id
       | Token.Keyword k -> Some (k.ToString().ToLowerInvariant())
       | _ -> None)
+    |> AnnotatedParser.withNamedRule attrIdentifierRule
+
+  let stringAttrValueRule = { Name = "string-attr-value"; Rule = Terminal "<string-literal>" }
 
   /// Parse a string attribute value: attr="value"
   let private stringAttrValue =
@@ -48,6 +62,11 @@ module View =
       match t.Token with
       | Token.StringLiteral s -> Some s
       | _ -> None)
+    |> AnnotatedParser.withNamedRule stringAttrValueRule
+
+  let viewExprRule =
+    { Name = "view-expr"
+      Rule = Alt [ NonTerminal "view-element"; NonTerminal "view-fragment"; NonTerminal "view-expr-container"; NonTerminal "view-text-node" ] }
 
   let viewExpr<'valueExt>
     (expr:
@@ -59,12 +78,6 @@ module View =
           Errors<Location>
          >)
     ()
-    : Parser<
-        Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
 
     let rec viewNode () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
@@ -78,15 +91,15 @@ module View =
     and viewElement () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {
         let! loc = parser.Location
-        do! lessThanOperator
-        let! tag = tagIdentifier
+        do! lessThanOperator.Parser
+        let! tag = tagIdentifier.Parser
         let! attrs = viewAttributes () |> parser.Many
 
         return!
           parser.Any
             [ // Self-closing: <tag attrs />
               parser {
-                do! tagSelfCloseOperator
+                do! tagSelfCloseOperator.Parser
                 return
                   { Location = loc
                     Node =
@@ -98,11 +111,11 @@ module View =
               }
               // Opening tag: <tag attrs>children</tag>
               parser {
-                do! greaterThanOperator
+                do! greaterThanOperator.Parser
                 let! children = viewChildren ()
-                do! tagCloseOperator
-                let! _closeTag = tagIdentifier
-                do! greaterThanOperator
+                do! tagCloseOperator.Parser
+                let! _closeTag = tagIdentifier.Parser
+                do! greaterThanOperator.Parser
                 return
                   { Location = loc
                     Node =
@@ -119,13 +132,13 @@ module View =
       parser {
         let! loc = parser.Location
         // <>
-        do! lessThanOperator
-        do! greaterThanOperator
+        do! lessThanOperator.Parser
+        do! greaterThanOperator.Parser
         // children
         let! children = viewChildren ()
         // </>
-        do! tagCloseOperator
-        do! greaterThanOperator
+        do! tagCloseOperator.Parser
+        do! greaterThanOperator.Parser
         return
           { Location = loc
             Node = ExprViewNodeRec.ViewFragment children }
@@ -173,13 +186,13 @@ module View =
 
     and viewAttributes () : Parser<ExprViewAttribute<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {
-        let! name = attrIdentifier
+        let! name = attrIdentifier.Parser
         do! equalsOperator
         return!
           parser.Any
             [ // String value: attr="value"
               parser {
-                let! value = stringAttrValue
+                let! value = stringAttrValue.Parser
                 return ExprViewAttribute.ViewAttrStringValue(name, value)
               }
               // Expression value: attr={expr}
@@ -202,14 +215,14 @@ module View =
         parser.Any
           [ parser {
               do! openRoundBracketOperator
-              let! paramName = singleIdentifier
+              let! paramName = singleIdentifier.Parser
               do! colonOperator
-              let! typeDecl = typeDecl (expr ()) parseAllComplexTypeShapes
+              let! typeDecl = (typeDecl (expr ()) parseAllComplexTypeShapes).Parser
               do! closeRoundBracketOperator
               return paramName, Some typeDecl
             }
             parser {
-              let! paramName = singleIdentifier
+              let! paramName = singleIdentifier.Parser
               return paramName, None
             } ]
         |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
@@ -227,6 +240,11 @@ module View =
           Location = loc
           Scope = TypeCheckScope.Empty }
     }
+    |> AnnotatedParser.withNamedRule viewExprRule
+
+  let viewNodeExprRule =
+    { Name = "view-node-expr"
+      Rule = Alt [ NonTerminal "view-element"; NonTerminal "view-fragment"; NonTerminal "view-expr-container"; NonTerminal "view-text-node" ] }
 
   /// Standalone JSX element expression: <tag .../> or <tag ...>children</tag>
   /// Used when JSX elements appear inside expression contexts (e.g. lambda bodies).
@@ -241,12 +259,6 @@ module View =
           Errors<Location>
          >)
     ()
-    : Parser<
-        Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
 
     let rec viewNode () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
@@ -260,14 +272,14 @@ module View =
     and viewElement () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {
         let! loc = parser.Location
-        do! lessThanOperator
-        let! tag = tagIdentifier
+        do! lessThanOperator.Parser
+        let! tag = tagIdentifier.Parser
         let! attrs = viewAttributes () |> parser.Many
 
         return!
           parser.Any
             [ parser {
-                do! tagSelfCloseOperator
+                do! tagSelfCloseOperator.Parser
                 return
                   { Location = loc
                     Node =
@@ -278,11 +290,11 @@ module View =
                           SelfClosing = true } }
               }
               parser {
-                do! greaterThanOperator
+                do! greaterThanOperator.Parser
                 let! children = viewChildren ()
-                do! tagCloseOperator
-                let! _closeTag = tagIdentifier
-                do! greaterThanOperator
+                do! tagCloseOperator.Parser
+                let! _closeTag = tagIdentifier.Parser
+                do! greaterThanOperator.Parser
                 return
                   { Location = loc
                     Node =
@@ -298,11 +310,11 @@ module View =
     and viewFragment () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {
         let! loc = parser.Location
-        do! lessThanOperator
-        do! greaterThanOperator
+        do! lessThanOperator.Parser
+        do! greaterThanOperator.Parser
         let! children = viewChildren ()
-        do! tagCloseOperator
-        do! greaterThanOperator
+        do! tagCloseOperator.Parser
+        do! greaterThanOperator.Parser
         return
           { Location = loc
             Node = ExprViewNodeRec.ViewFragment children }
@@ -350,12 +362,12 @@ module View =
 
     and viewAttributes () : Parser<ExprViewAttribute<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {
-        let! name = attrIdentifier
+        let! name = attrIdentifier.Parser
         do! equalsOperator
         return!
           parser.Any
             [ parser {
-                let! value = stringAttrValue
+                let! value = stringAttrValue.Parser
                 return ExprViewAttribute.ViewAttrStringValue(name, value)
               }
               parser {
@@ -380,6 +392,11 @@ module View =
           Location = loc
           Scope = TypeCheckScope.Empty }
     }
+    |> AnnotatedParser.withNamedRule viewNodeExprRule
+
+  let coExprRule =
+    { Name = "co-expr"
+      Rule = Seq [ Terminal "co"; Terminal "{"; Repeat (Alt [ NonTerminal "co-let-bang"; NonTerminal "co-do-bang"; NonTerminal "co-return"; NonTerminal "co-return-bang"; NonTerminal "co-let" ]); Terminal "}" ] }
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Coroutine Parser (co { ... })
@@ -395,12 +412,6 @@ module View =
           Errors<Location>
          >)
     ()
-    : Parser<
-        Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-        LocalizedToken,
-        Location,
-        Errors<Location>
-       >
     =
 
     let rec coStep () : Parser<ExprCoStep<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
@@ -417,7 +428,7 @@ module View =
         let! loc = parser.Location
         do! parseKeyword Keyword.Let
         do! parseOperator Operator.Bang
-        let! varName = singleIdentifier
+        let! varName = singleIdentifier.Parser
         do! equalsOperator
         let! value = expr ()
         do! semicolonOperator
@@ -431,7 +442,7 @@ module View =
       parser {
         let! loc = parser.Location
         do! parseKeyword Keyword.Let
-        let! varName = singleIdentifier
+        let! varName = singleIdentifier.Parser
         do! equalsOperator
         let! value = expr ()
         do! semicolonOperator
@@ -499,3 +510,9 @@ module View =
           Location = loc
           Scope = TypeCheckScope.Empty }
     }
+    |> AnnotatedParser.withNamedRule coExprRule
+
+  let grammarRules: NamedRule list =
+    [ lessThanOpRule; greaterThanOpRule; tagSelfCloseOpRule; tagCloseOpRule
+      tagIdentifierRule; attrIdentifierRule; stringAttrValueRule
+      viewExprRule; viewNodeExprRule; coExprRule ]

--- a/backend/libraries/ballerina-lang/Next/Syntax/ballerina-lang-parser.fsproj
+++ b/backend/libraries/ballerina-lang/Next/Syntax/ballerina-lang-parser.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="Parser/Query.fs" />
     <Compile Include="Parser/View.fs" />
     <Compile Include="Parser/Expr.fs" />
+    <Compile Include="Parser/Grammar.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Data" Version="6.6.0" />

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/View.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/View.fs
@@ -106,32 +106,36 @@ module View =
                   | Some tagSchema ->
                     match tagSchema |> Map.tryFind name with
                     | Some acceptableTypes ->
-                      let exprType = checkedExpr.Type
+                      // The 'style' attribute accepts any record of strings (CSS properties)
+                      // in addition to plain string values. Skip strict unification for style
+                      // to allow inline style objects like { marginTop = "0.75rem" }.
+                      if name <> "style" then
+                        let exprType = checkedExpr.Type
 
-                      let unifyAttempts =
-                        acceptableTypes
-                        |> List.map (fun expectedType ->
-                          state {
-                            do!
-                              TypeValue.Unify(loc0, exprType, expectedType)
-                              |> Expr<'T, 'Id, 'valueExt>.liftUnification
+                        let unifyAttempts =
+                          acceptableTypes
+                          |> List.map (fun expectedType ->
+                            state {
+                              do!
+                                TypeValue.Unify(loc0, exprType, expectedType)
+                                |> Expr<'T, 'Id, 'valueExt>.liftUnification
 
-                            return ()
-                          })
+                              return ()
+                            })
 
-                      match unifyAttempts with
-                      | first :: rest ->
-                        do!
-                          state.Any(first, rest)
-                          |> state.MapError(fun _ ->
-                            let typeNames =
-                              acceptableTypes
-                              |> List.map (fun t -> $"{t}")
-                              |> String.concat " | "
+                        match unifyAttempts with
+                        | first :: rest ->
+                          do!
+                            state.Any(first, rest)
+                            |> state.MapError(fun _ ->
+                              let typeNames =
+                                acceptableTypes
+                                |> List.map (fun t -> $"{t}")
+                                |> String.concat " | "
 
-                            Errors.Singleton loc0 (fun () ->
-                              $"Attribute '{name}' on <{el.Tag}> expects type {typeNames}, but got {exprType}"))
-                      | [] -> ()
+                              Errors.Singleton loc0 (fun () ->
+                                $"Attribute '{name}' on <{el.Tag}> expects type {typeNames}, but got {exprType}"))
+                        | [] -> ()
 
                       return TypeCheckedViewAttribute.ViewAttrExprValue(name, checkedExpr)
                     | None ->

--- a/frontend/apps/test/package.json
+++ b/frontend/apps/test/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^18.2.0",
     "react-grid-layout": "^1.4.4",
     "tsx": "^4.19.2",
-    "uuid": "^9.0.1"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@rspack/cli": "1.7.9",

--- a/frontend/apps/web/package.json
+++ b/frontend/apps/web/package.json
@@ -15,7 +15,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-grid-layout": "^1.4.4",
-    "uuid": "^9.0.1"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@rspack/cli": "1.7.9",

--- a/frontend/libraries/ballerina-core/package.json
+++ b/frontend/libraries/ballerina-core/package.json
@@ -31,7 +31,7 @@
     "immutable": "^5.1.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "uuid": "^9.0.1"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@types/node": "^24.10.2",
@@ -43,6 +43,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.9.3",
-    "uuid": "^9.0.1"
+    "uuid": "^14.0.0"
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2330,7 +2330,7 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@polka/url@^1.0.0-next.20", "@polka/url@^1.0.0-next.24":
+"@polka/url@^1.0.0-next.24":
   version "1.0.0-next.29"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
   integrity sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==
@@ -2805,28 +2805,13 @@
     "@rspack/binding-win32-ia32-msvc" "1.0.0"
     "@rspack/binding-win32-x64-msvc" "1.0.0"
 
-"@rspack/cli@0.5.5":
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/@rspack/cli/-/cli-0.5.5.tgz#83621ee6cd9ee85deeec2156424d71787959703c"
-  integrity sha512-3+OxCfxSSMgaJsUt4rZ7cXe14U7/Hhg/5hE/OOKO1WVybcS+psw8MsxoXRuYesEl4wOHL0armzIK2osbbUsjkA==
+"@rspack/cli@1.7.9":
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/@rspack/cli/-/cli-1.7.9.tgz#474e8d9c8e76e77149f99221b0457ab4e28819d9"
+  integrity sha512-VwJIO8ZUGnU5v38O2Fp3KczoYVaDy/kA0rBWhoUNhfdlwyVx3ZiA1VnIYF3XtXNlur6YqT2g7Y+KA1cX8qK5zw==
   dependencies:
     "@discoveryjs/json-ext" "^0.5.7"
-    "@rspack/dev-server" "0.5.5"
-    colorette "2.0.19"
-    exit-hook "^3.2.0"
-    interpret "^3.1.1"
-    rechoir "^0.8.0"
-    semver "6.3.1"
-    webpack-bundle-analyzer "4.6.1"
-    yargs "17.6.2"
-
-"@rspack/cli@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@rspack/cli/-/cli-1.7.0.tgz#c1b7dc074f1620b2af70c0e179eae71653ea5bb2"
-  integrity sha512-4fGf1lvP9+JzpkVIljtZ+NrGn8JEsyVwNACDZPL4Heg1U2tStIde2RvzHLVs+0+NBVENu47v6tho5xMLcJPB7w==
-  dependencies:
-    "@discoveryjs/json-ext" "^0.5.7"
-    "@rspack/dev-server" "~1.1.4"
+    "@rspack/dev-server" "~1.1.5"
     exit-hook "^4.0.0"
     webpack-bundle-analyzer "4.10.2"
 
@@ -2860,21 +2845,7 @@
     "@rspack/lite-tapable" "1.0.0"
     caniuse-lite "^1.0.30001616"
 
-"@rspack/dev-server@0.5.5":
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/@rspack/dev-server/-/dev-server-0.5.5.tgz#c033422923e578c565e5980ed89b939689b7793b"
-  integrity sha512-dPi3icKaJ8kmdB3p1gYD2rVm9QCb9h9ZPHD/Jsqy+alGuNnBnZf5U4DhNBI6pKfmar8WXrHVPrMTd2QR6ntpng==
-  dependencies:
-    chokidar "3.5.3"
-    connect-history-api-fallback "2.0.0"
-    express "4.18.1"
-    http-proxy-middleware "2.0.6"
-    mime-types "2.1.35"
-    webpack-dev-middleware "6.0.2"
-    webpack-dev-server "4.13.1"
-    ws "8.8.1"
-
-"@rspack/dev-server@~1.1.4":
+"@rspack/dev-server@~1.1.5":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@rspack/dev-server/-/dev-server-1.1.5.tgz#3d0f8d5256fe0b77ba6617b0e3c8fb5bcab3f081"
   integrity sha512-cwz0qc6iqqoJhyWqxP7ZqE2wyYNHkBMQUXxoQ0tNoZ4YNRkDyQ4HVJ/3oPSmMKbvJk/iJ16u7xZmwG6sK47q/A==
@@ -3013,7 +2984,7 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/bonjour@^3.5.13", "@types/bonjour@^3.5.9":
+"@types/bonjour@^3.5.13":
   version "3.5.13"
   resolved "https://registry.yarnpkg.com/@types/bonjour/-/bonjour-3.5.13.tgz#adf90ce1a105e81dd1f9c61fdc5afda1bfb92956"
   integrity sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==
@@ -3049,7 +3020,7 @@
   resolved "https://registry.yarnpkg.com/@types/command-line-usage/-/command-line-usage-5.0.4.tgz#374e4c62d78fbc5a670a0f36da10235af879a0d5"
   integrity sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==
 
-"@types/connect-history-api-fallback@^1.3.5", "@types/connect-history-api-fallback@^1.5.4":
+"@types/connect-history-api-fallback@^1.5.4":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz#7de71645a103056b48ac3ce07b3520b819c1d5b3"
   integrity sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==
@@ -3098,7 +3069,7 @@
     "@types/express-serve-static-core" "^5.0.0"
     "@types/serve-static" "^2"
 
-"@types/express@^4.17.13", "@types/express@^4.17.21":
+"@types/express@^4.17.21":
   version "4.17.25"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.25.tgz#070c8c73a6fee6936d65c195dbbfb7da5026649b"
   integrity sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==
@@ -3279,11 +3250,6 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/retry@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
-  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
-
 "@types/retry@0.12.2":
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.2.tgz#ed279a64fa438bb69f2480eda44937912bb7480a"
@@ -3304,14 +3270,14 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@types/serve-index@^1.9.1", "@types/serve-index@^1.9.4":
+"@types/serve-index@^1.9.4":
   version "1.9.4"
   resolved "https://registry.yarnpkg.com/@types/serve-index/-/serve-index-1.9.4.tgz#e6ae13d5053cb06ed36392110b4f9a49ac4ec898"
   integrity sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==
   dependencies:
     "@types/express" "*"
 
-"@types/serve-static@^1", "@types/serve-static@^1.13.10", "@types/serve-static@^1.15.5":
+"@types/serve-static@^1", "@types/serve-static@^1.15.5":
   version "1.15.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.10.tgz#768169145a778f8f5dfcb6360aead414a3994fee"
   integrity sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==
@@ -3328,7 +3294,7 @@
     "@types/http-errors" "*"
     "@types/node" "*"
 
-"@types/sockjs@^0.3.33", "@types/sockjs@^0.3.36":
+"@types/sockjs@^0.3.36":
   version "0.3.36"
   resolved "https://registry.yarnpkg.com/@types/sockjs/-/sockjs-0.3.36.tgz#ce322cf07bcc119d4cbf7f88954f3a3bd0f67535"
   integrity sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==
@@ -3350,7 +3316,7 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
   integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
 
-"@types/ws@^8.5.1", "@types/ws@^8.5.10":
+"@types/ws@^8.5.10":
   version "8.18.1"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
   integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
@@ -3928,24 +3894,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
-body-parser@1.20.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.0.tgz#3de69bd89011c11573d7bfee6a64f11b6bd27cc5"
-  integrity sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==
-  dependencies:
-    bytes "3.1.2"
-    content-type "~1.0.4"
-    debug "2.6.9"
-    depd "2.0.0"
-    destroy "1.2.0"
-    http-errors "2.0.0"
-    iconv-lite "0.4.24"
-    on-finished "2.4.1"
-    qs "6.10.3"
-    raw-body "2.5.1"
-    type-is "~1.6.18"
-    unpipe "1.0.0"
-
 body-parser@~1.20.3:
   version "1.20.4"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.4.tgz#f8e20f4d06ca8a50a71ed329c15dccad1cdc547f"
@@ -3964,7 +3912,7 @@ body-parser@~1.20.3:
     type-is "~1.6.18"
     unpipe "~1.0.0"
 
-bonjour-service@^1.0.11, bonjour-service@^1.2.1:
+bonjour-service@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/bonjour-service/-/bonjour-service-1.3.0.tgz#80d867430b5a0da64e82a8047fc1e355bdb71722"
   integrity sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==
@@ -4241,22 +4189,7 @@ charenc@0.0.2, charenc@~0.0.1:
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
 
-chokidar@3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
-  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
-  dependencies:
-    anymatch "~3.1.2"
-    braces "~3.0.2"
-    glob-parent "~5.1.2"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.6.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
-
-chokidar@^3.5.3, chokidar@^3.6.0:
+chokidar@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
@@ -4442,11 +4375,6 @@ color@^4.2.3:
     color-convert "^2.0.1"
     color-string "^1.9.0"
 
-colorette@2.0.19:
-  version "2.0.19"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
-  integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
-
 colorette@^2.0.10:
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
@@ -4534,7 +4462,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-connect-history-api-fallback@2.0.0, connect-history-api-fallback@^2.0.0:
+connect-history-api-fallback@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz#647264845251a0daf25b97ce87834cace0f5f1c8"
   integrity sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==
@@ -4549,7 +4477,7 @@ connect@^3.6.5, connect@^3.7.0:
     parseurl "~1.3.3"
     utils-merge "1.0.1"
 
-content-disposition@0.5.4, content-disposition@~0.5.4:
+content-disposition@~0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
   integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
@@ -4566,11 +4494,6 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-cookie-signature@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
-  integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
-
 cookie-signature@^1.1.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.2.2.tgz#57c7fc3cc293acab9fec54d73e15690ebe4a1793"
@@ -4580,11 +4503,6 @@ cookie-signature@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.7.tgz#ab5dd7ab757c54e60f37ef6550f481c426d10454"
   integrity sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==
-
-cookie@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
-  integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
 cookie@^0.7.2, cookie@~0.7.1:
   version "0.7.2"
@@ -4824,13 +4742,6 @@ default-gateway@^4.2.0:
   dependencies:
     execa "^1.0.0"
     ip-regex "^2.1.0"
-
-default-gateway@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-6.0.3.tgz#819494c888053bdb743edbf343d6cdf7f2943a71"
-  integrity sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==
-  dependencies:
-    execa "^5.0.0"
 
 defaults@^1.0.3:
   version "1.0.4"
@@ -5444,11 +5355,6 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
-exit-hook@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-3.2.0.tgz#7d86bc361a4d79278001b72a0509318a6f468f20"
-  integrity sha512-aIQN7Q04HGAV/I5BszisuHTZHXNoC23WtLkxdCLuYZMdWviRD0TMIt2bnUBi9MrHaF/hH8b3gwG9iaAUHKnJGA==
-
 exit-hook@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-4.0.0.tgz#c1e16ebd03d3166f837b1502dac755bb5c460d58"
@@ -5657,44 +5563,7 @@ exponential-backoff@^3.1.1:
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.3.tgz#51cf92c1c0493c766053f9d3abee4434c244d2f6"
   integrity sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==
 
-express@4.18.1:
-  version "4.18.1"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.18.1.tgz#7797de8b9c72c857b9cd0e14a5eea80666267caf"
-  integrity sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==
-  dependencies:
-    accepts "~1.3.8"
-    array-flatten "1.1.1"
-    body-parser "1.20.0"
-    content-disposition "0.5.4"
-    content-type "~1.0.4"
-    cookie "0.5.0"
-    cookie-signature "1.0.6"
-    debug "2.6.9"
-    depd "2.0.0"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    finalhandler "1.2.0"
-    fresh "0.5.2"
-    http-errors "2.0.0"
-    merge-descriptors "1.0.1"
-    methods "~1.1.2"
-    on-finished "2.4.1"
-    parseurl "~1.3.3"
-    path-to-regexp "0.1.7"
-    proxy-addr "~2.0.7"
-    qs "6.10.3"
-    range-parser "~1.2.1"
-    safe-buffer "5.2.1"
-    send "0.18.0"
-    serve-static "1.15.0"
-    setprototypeof "1.2.0"
-    statuses "2.0.1"
-    type-is "~1.6.18"
-    utils-merge "1.0.1"
-    vary "~1.1.2"
-
-express@^4.17.3, express@^4.21.2:
+express@^4.21.2:
   version "4.22.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.22.1.tgz#1de23a09745a4fffdb39247b344bb5eaff382069"
   integrity sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==
@@ -5881,19 +5750,6 @@ finalhandler@1.1.2:
     on-finished "~2.3.0"
     parseurl "~1.3.3"
     statuses "~1.5.0"
-    unpipe "~1.0.0"
-
-finalhandler@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.2.0.tgz#7d23fe5731b207b4640e4fcd00aec1f9207a7b32"
-  integrity sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==
-  dependencies:
-    debug "2.6.9"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    on-finished "2.4.1"
-    parseurl "~1.3.3"
-    statuses "2.0.1"
     unpipe "~1.0.0"
 
 finalhandler@~1.3.1:
@@ -6094,11 +5950,6 @@ fs-minipass@^3.0.0:
   integrity sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==
   dependencies:
     minipass "^7.0.3"
-
-fs-monkey@^1.0.4:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.1.0.tgz#632aa15a20e71828ed56b24303363fb1414e5997"
-  integrity sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -6502,7 +6353,7 @@ html-encoding-sniffer@^3.0.0:
   dependencies:
     whatwg-encoding "^2.0.0"
 
-html-entities@^2.3.2, html-entities@^2.5.2:
+html-entities@^2.5.2:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.6.0.tgz#7c64f1ea3b36818ccae3d3fb48b6974208e984f8"
   integrity sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==
@@ -6576,18 +6427,7 @@ http-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-http-proxy-middleware@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz#e1a4dd6979572c7ab5a4e4b55095d1f32a74963f"
-  integrity sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==
-  dependencies:
-    "@types/http-proxy" "^1.17.8"
-    http-proxy "^1.18.1"
-    is-glob "^4.0.1"
-    is-plain-obj "^3.0.0"
-    micromatch "^4.0.2"
-
-http-proxy-middleware@^2.0.3, http-proxy-middleware@^2.0.9:
+http-proxy-middleware@^2.0.9:
   version "2.0.9"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz#e9e63d68afaa4eee3d147f39149ab84c0c2815ef"
   integrity sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==
@@ -6650,19 +6490,19 @@ i18next@^25.7.3:
   dependencies:
     "@babel/runtime" "^7.29.2"
 
-iconv-lite@0.4.24, iconv-lite@~0.4.24:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
-
 iconv-lite@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
+
+iconv-lite@~0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 ieee754@^1.1.13:
   version "1.2.1"
@@ -6751,11 +6591,6 @@ internal-slot@^1.1.0:
     hasown "^2.0.2"
     side-channel "^1.1.0"
 
-interpret@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-3.1.1.tgz#5be0ceed67ca79c6c4bc5cf0d7ee843dcea110c4"
-  integrity sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==
-
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
@@ -6773,7 +6608,7 @@ ipaddr.js@1.9.1, ipaddr.js@^1.9.0:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
-ipaddr.js@^2.0.1, ipaddr.js@^2.1.0:
+ipaddr.js@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.3.0.tgz#71dce70e1398122208996d1c22f2ba46a24b1abc"
   integrity sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==
@@ -7853,7 +7688,7 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-launch-editor@^2.6.0, launch-editor@^2.6.1:
+launch-editor@^2.6.1:
   version "2.13.2"
   resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.13.2.tgz#41d51baaf8afb393224b89bd2bcb4e02f2306405"
   integrity sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==
@@ -7997,7 +7832,7 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
-lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
+lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.23"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
   integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
@@ -8120,13 +7955,6 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
-memfs@^3.4.12, memfs@^3.4.3:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.6.0.tgz#d7a2110f86f79dd950a8b6df6d57bc984aa185f6"
-  integrity sha512-EGowvkkgbMcIChjMTMkESFDbZeSh8xZ7kNSF0hAiAN4Jh6jgHCRS0Ga/+C8y6Au+oqpezRHCfPsmJ2+DwAgiwQ==
-  dependencies:
-    fs-monkey "^1.0.4"
-
 memfs@^4.43.1:
   version "4.57.1"
   resolved "https://registry.yarnpkg.com/memfs/-/memfs-4.57.1.tgz#5ccee42e2aab1cf086c45baf9c4ef1ff4fffb123"
@@ -8161,11 +7989,6 @@ memory-cache@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/memory-cache/-/memory-cache-0.2.0.tgz#7890b01d52c00c8ebc9d533e1f8eb17e3034871a"
   integrity sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA==
-
-merge-descriptors@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
-  integrity sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
 
 merge-descriptors@1.0.3:
   version "1.0.3"
@@ -8397,7 +8220,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
-mime-types@2.1.35, mime-types@^2.1.12, mime-types@^2.1.31, mime-types@^2.1.35, mime-types@~2.1.24, mime-types@~2.1.34, mime-types@~2.1.35:
+mime-types@^2.1.12, mime-types@^2.1.35, mime-types@~2.1.24, mime-types@~2.1.34, mime-types@~2.1.35:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -8867,7 +8690,7 @@ open@^7.0.3:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-open@^8.0.4, open@^8.0.9, open@^8.3.0:
+open@^8.0.4, open@^8.3.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
   integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==
@@ -8980,14 +8803,6 @@ p-map@^4.0.0:
   integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
-
-p-retry@^4.5.0:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
-  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
-  dependencies:
-    "@types/retry" "0.12.0"
-    retry "^0.13.1"
 
 p-retry@^6.2.0:
   version "6.2.1"
@@ -9103,11 +8918,6 @@ path-scurry@^2.0.2:
   dependencies:
     lru-cache "^11.0.0"
     minipass "^7.1.2"
-
-path-to-regexp@0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
-  integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
 
 path-to-regexp@~0.1.12:
   version "0.1.12"
@@ -9332,13 +9142,6 @@ qrcode-terminal@0.12.0:
   resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz#bb5b699ef7f9f0505092a3748be4464fe71b5819"
   integrity sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==
 
-qs@6.10.3:
-  version "6.10.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
-  integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
-  dependencies:
-    side-channel "^1.0.4"
-
 qs@~6.14.0:
   version "6.14.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.2.tgz#b5634cf9d9ad9898e31fba3504e866e8efb6798c"
@@ -9377,16 +9180,6 @@ range-parser@^1.2.1, range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
-
-raw-body@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
-  integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
-  dependencies:
-    bytes "3.1.2"
-    http-errors "2.0.0"
-    iconv-lite "0.4.24"
-    unpipe "1.0.0"
 
 raw-body@~2.5.3:
   version "2.5.3"
@@ -9682,13 +9475,6 @@ recast@^0.21.0:
     esprima "~4.0.0"
     source-map "~0.6.1"
     tslib "^2.0.1"
-
-rechoir@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.8.0.tgz#49f866e0d32146142da3ad8f0eff352b3215ff22"
-  integrity sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==
-  dependencies:
-    resolve "^1.20.0"
 
 redeyed@~2.1.0:
   version "2.1.1"
@@ -9999,18 +9785,13 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==
 
-selfsigned@^2.1.1, selfsigned@^2.4.1:
+selfsigned@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.4.1.tgz#560d90565442a3ed35b674034cec4e95dceb4ae0"
   integrity sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==
   dependencies:
     "@types/node-forge" "^1.3.0"
     node-forge "^1"
-
-semver@6.3.1, semver@^6.3.0, semver@^6.3.1:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@7.5.2:
   version "7.5.2"
@@ -10031,12 +9812,17 @@ semver@^5.5.0, semver@^5.6.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
+semver@^6.3.0, semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
 semver@^7.1.3, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semver@^7.7.3:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
-send@0.18.0, send@^0.18.0:
+send@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
   integrity sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==
@@ -10091,16 +9877,6 @@ serve-index@^1.9.1:
     http-errors "~1.8.0"
     mime-types "~2.1.35"
     parseurl "~1.3.3"
-
-serve-static@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.15.0.tgz#faaef08cffe0a1a62f60cad0c4e513cff0ac9540"
-  integrity sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==
-  dependencies:
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    parseurl "~1.3.3"
-    send "0.18.0"
 
 serve-static@^1.13.1, serve-static@^1.16.2, serve-static@~1.16.2:
   version "1.16.3"
@@ -10233,7 +10009,7 @@ side-channel-weakmap@^1.0.2:
     object-inspect "^1.13.3"
     side-channel-map "^1.0.1"
 
-side-channel@^1.0.4, side-channel@^1.1.0:
+side-channel@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.0.tgz#c3fcff9c4da932784873335ec9765fa94ff66bc9"
   integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
@@ -10269,15 +10045,6 @@ simple-swizzle@^0.2.2:
   integrity sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==
   dependencies:
     is-arrayish "^0.3.1"
-
-sirv@^1.0.7:
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/sirv/-/sirv-1.0.19.tgz#1d73979b38c7fe91fcba49c85280daa9c2363b49"
-  integrity sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==
-  dependencies:
-    "@polka/url" "^1.0.0-next.20"
-    mrmime "^1.0.0"
-    totalist "^1.0.0"
 
 sirv@^2.0.3:
   version "2.0.4"
@@ -10901,11 +10668,6 @@ toidentifier@1.0.1, toidentifier@~1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-totalist@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
-  integrity sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
-
 totalist@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/totalist/-/totalist-3.0.1.tgz#ba3a3d600c915b1a97872348f79c127475f6acf8"
@@ -11258,7 +11020,7 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
-unpipe@1.0.0, unpipe@~1.0.0:
+unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
@@ -11326,6 +11088,11 @@ uuid@9.0.1, uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
+uuid@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 uuid@^7.0.3:
   version "7.0.3"
@@ -11466,43 +11233,6 @@ webpack-bundle-analyzer@4.10.2:
     sirv "^2.0.3"
     ws "^7.3.1"
 
-webpack-bundle-analyzer@4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.6.1.tgz#bee2ee05f4ba4ed430e4831a319126bb4ed9f5a6"
-  integrity sha512-oKz9Oz9j3rUciLNfpGFjOb49/jEpXNmWdVH8Ls//zNcnLlQdTGXQQMsBbb/gR7Zl8WNLxVCq+0Hqbx3zv6twBw==
-  dependencies:
-    acorn "^8.0.4"
-    acorn-walk "^8.0.0"
-    chalk "^4.1.0"
-    commander "^7.2.0"
-    gzip-size "^6.0.0"
-    lodash "^4.17.20"
-    opener "^1.5.2"
-    sirv "^1.0.7"
-    ws "^7.3.1"
-
-webpack-dev-middleware@6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-6.0.2.tgz#4aab69257378e01d6fe964a8b2d07e8a87623ebc"
-  integrity sha512-iOddiJzPcQC6lwOIu60vscbGWth8PCRcWRCwoQcTQf9RMoOWBHg5EyzpGdtSmGMrSPd5vHEfFXmVErQEmkRngQ==
-  dependencies:
-    colorette "^2.0.10"
-    memfs "^3.4.12"
-    mime-types "^2.1.31"
-    range-parser "^1.2.1"
-    schema-utils "^4.0.0"
-
-webpack-dev-middleware@^5.3.1:
-  version "5.3.4"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz#eb7b39281cbce10e104eb2b8bf2b63fce49a3517"
-  integrity sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==
-  dependencies:
-    colorette "^2.0.10"
-    memfs "^3.4.3"
-    mime-types "^2.1.31"
-    range-parser "^1.2.1"
-    schema-utils "^4.0.0"
-
 webpack-dev-middleware@^7.4.2:
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz#d4e8720aa29cb03bc158084a94edb4594e3b7ac0"
@@ -11514,42 +11244,6 @@ webpack-dev-middleware@^7.4.2:
     on-finished "^2.4.1"
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
-
-webpack-dev-server@4.13.1:
-  version "4.13.1"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.13.1.tgz#6417a9b5d2f528e7644b68d6ed335e392dccffe8"
-  integrity sha512-5tWg00bnWbYgkN+pd5yISQKDejRBYGEw15RaEEslH+zdbNDxxaZvEAO2WulaSaFKb5n3YG8JXsGaDsut1D0xdA==
-  dependencies:
-    "@types/bonjour" "^3.5.9"
-    "@types/connect-history-api-fallback" "^1.3.5"
-    "@types/express" "^4.17.13"
-    "@types/serve-index" "^1.9.1"
-    "@types/serve-static" "^1.13.10"
-    "@types/sockjs" "^0.3.33"
-    "@types/ws" "^8.5.1"
-    ansi-html-community "^0.0.8"
-    bonjour-service "^1.0.11"
-    chokidar "^3.5.3"
-    colorette "^2.0.10"
-    compression "^1.7.4"
-    connect-history-api-fallback "^2.0.0"
-    default-gateway "^6.0.3"
-    express "^4.17.3"
-    graceful-fs "^4.2.6"
-    html-entities "^2.3.2"
-    http-proxy-middleware "^2.0.3"
-    ipaddr.js "^2.0.1"
-    launch-editor "^2.6.0"
-    open "^8.0.9"
-    p-retry "^4.5.0"
-    rimraf "^3.0.2"
-    schema-utils "^4.0.0"
-    selfsigned "^2.1.1"
-    serve-index "^1.9.1"
-    sockjs "^0.3.24"
-    spdy "^4.0.2"
-    webpack-dev-middleware "^5.3.1"
-    ws "^8.13.0"
 
 webpack-dev-server@5.2.2:
   version "5.2.2"
@@ -11789,11 +11483,6 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@8.8.1:
-  version "8.8.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
-  integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==
-
 ws@^6.2.2:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.3.tgz#ccc96e4add5fd6fedbc491903075c85c5a11d9ee"
@@ -11806,7 +11495,7 @@ ws@^7, ws@^7.3.1, ws@^7.5.10:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
-ws@^8.11.0, ws@^8.12.1, ws@^8.13.0, ws@^8.18.0:
+ws@^8.11.0, ws@^8.12.1, ws@^8.18.0:
   version "8.20.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
   integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
@@ -11888,19 +11577,6 @@ yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
-
-yargs@17.6.2:
-  version "17.6.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
-  integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
-  dependencies:
-    cliui "^8.0.1"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
-    y18n "^5.0.5"
-    yargs-parser "^21.1.1"
 
 yargs@^17.3.1, yargs@^17.6.2:
   version "17.7.2"


### PR DESCRIPTION
## Summary

Add three new Ballerina language features for view component migration:

### List::any
- New stdlib operation: `List::any` with type `Λa.Λb. (a → () + b) → List[a] → () + b`
- Returns the first matching element wrapped in a sum type, or unit if none match
- Two-step closure implementation in Extension.fs

### View::memo
- New `ViewOperationKind.Memo` for memoized computations in views
- TsxGenerator hoists memo bindings to component body level as `React.useMemo()` calls
- Pre-scan pass (`extractMemosFromExpr`/`extractMemosFromNode`) ensures correct React hooks placement

### Inline style support
- Style attribute in views now accepts any record expression (type checker skip for `"style"` attr)
- Named style types (e.g. `MarginBottomStyle`) with record construction syntax

### Files changed
- `Types.fs` — `ViewOperationKind.Memo` variant
- `List/Model.fs`, `List/Patterns.fs`, `List/Extension.fs` — `List::any` operation
- `View/Extension.fs` — `View::memo` operation  
- `TypeCheck/View.fs` — Style attribute special-case

### Testing
- 26/26 Ballerina integration tests pass
- UScreen smoke test: Part A 10/10 ✓, Part B 7/7 ✓, Part C 28/28 ✓