### PR TITLE
feat: Grammar type system + GBNF/EBNF serializers (Phases 1-3)

### DIFF
--- a/backend/libraries/ballerina-cat/Grammar/Gbnf.fs
+++ b/backend/libraries/ballerina-cat/Grammar/Gbnf.fs
@@ -14,7 +14,7 @@ module Gbnf =
     | Seq rules ->
       rules
       |> List.map serializeRuleGrouped
-      |> String.concat " "
+      |> String.concat " ows "
     | Alt rules ->
       rules
       |> List.map serializeRule
@@ -29,7 +29,14 @@ module Gbnf =
     | Alt _ -> "(" + serializeRule rule + ")"
     | _ -> serializeRule rule
 
+  let private preamble =
+    [ "# Whitespace rules (auto-generated)"
+      "ows ::= [ \\t\\n\\r]? [ \\t\\n\\r]? [ \\t\\n\\r]? [ \\t\\n\\r]?"
+      "ws ::= [ \\t\\n\\r] [ \\t\\n\\r]? [ \\t\\n\\r]? [ \\t\\n\\r]?" ]
+
   let serialize (rules: NamedRule list) : string =
-    rules
-    |> List.map (fun r -> $"{sanitizeName r.Name} ::= {serializeRule r.Rule}")
-    |> String.concat "\n"
+    let body =
+      rules
+      |> List.map (fun r -> $"{sanitizeName r.Name} ::= {serializeRule r.Rule}")
+
+    (preamble @ body) |> String.concat "\n"


### PR DESCRIPTION
## Summary

Adds grammar infrastructure for LLM-constrained code generation:

### Phase 1: Grammar Type System
- `GrammarRule` DU and `NamedRule` type in `ballerina-cat/Grammar/Model.fs`
- `AnnotatedParser<'a,...>` type carrying both Parser and GrammarRule
- 8 combinator overloads on `ParserBuilder` for AnnotatedParser
- EBNF serializer (ISO 14977) and GBNF serializer (llama.cpp format)

### Phase 2: Parser Annotation
- 72 production rules annotated across all parser modules
- Collecting module `Parser/Grammar.fs` aggregating `allRules`
- Zero regressions: 26/26 integration tests pass

### Phase 3: CLI + Validation
- `grammar` subcommand on `bise-publication-cli` (--format ebnf/gbnf, --output, --validate)
- Grammar completeness: 72 defined rules, 0 undefined non-terminals
- Bounded whitespace in GBNF to prevent infinite loops during constrained decoding

### Testing
- `ballerina-samples-integration-test`: 26/26 pass
- `bise-publication-cli typecheck` on uscreen.blproj: passes