### PR TITLE
feat: Add View::ReactNode and View::ReactComponent[P] types

### DIFF
--- a/backend/libraries/ballerina-lang-build/HddCache.fs
+++ b/backend/libraries/ballerina-lang-build/HddCache.fs
@@ -51,6 +51,7 @@ module HddCache =
       ListTypeSymbol: Option<TypeSymbol>
       ViewTypeSymbol: Option<TypeSymbol>
       ViewPropsTypeSymbol: Option<TypeSymbol>
+
       ReactNodeTypeSymbol: Option<TypeSymbol>
       ReactComponentTypeSymbol: Option<TypeSymbol>
       CoTypeSymbol: Option<TypeSymbol> }

--- a/backend/libraries/ballerina-lang-build/HddCache.fs
+++ b/backend/libraries/ballerina-lang-build/HddCache.fs
@@ -51,6 +51,8 @@ module HddCache =
       ListTypeSymbol: Option<TypeSymbol>
       ViewTypeSymbol: Option<TypeSymbol>
       ViewPropsTypeSymbol: Option<TypeSymbol>
+      ReactNodeTypeSymbol: Option<TypeSymbol>
+      ReactComponentTypeSymbol: Option<TypeSymbol>
       CoTypeSymbol: Option<TypeSymbol> }
 
   type PersistedCacheData<'valueExt when 'valueExt: comparison> =
@@ -63,6 +65,8 @@ module HddCache =
       TypeCheckContext<'valueExt> *
       TypeCheckState<'valueExt>
      > *
+    Option<TypeSymbol> *
+    Option<TypeSymbol> *
     Option<TypeSymbol> *
     Option<TypeSymbol> *
     Option<TypeSymbol> *
@@ -100,15 +104,17 @@ module HddCache =
           container.ListTypeSymbol,
           container.ViewTypeSymbol,
           container.ViewPropsTypeSymbol,
+          container.ReactNodeTypeSymbol,
+          container.ReactComponentTypeSymbol,
           container.CoTypeSymbol
         | Right _ ->
           // Legacy cache format has no TypeCheckingConfig and can lead to symbol mismatches.
           // Force a clean rebuild so the next persisted cache includes the config.
-          Map.empty, None, None, None, None, None
+          Map.empty, None, None, None, None, None, None, None
       else
-        Map.empty, None, None, None, None, None
+        Map.empty, None, None, None, None, None, None, None
     with _ ->
-      Map.empty, None, None, None, None, None
+      Map.empty, None, None, None, None, None, None, None
 
   let private tryDeleteCacheFile (cacheFilePath: string) =
     try
@@ -122,7 +128,7 @@ module HddCache =
     : Option<TypeCheckingConfig<'valueExt>> =
     let serializer = MessagePackSerializerAdapter()
 
-    let _, queryTypeSymbol, listTypeSymbol, viewTypeSymbol, viewPropsTypeSymbol, coTypeSymbol =
+    let _, queryTypeSymbol, listTypeSymbol, viewTypeSymbol, viewPropsTypeSymbol, reactNodeTypeSymbol, reactComponentTypeSymbol, coTypeSymbol =
       loadPersistedCacheData<'valueExt> serializer cacheFilePath
 
     let dbQueryId = Identifier.FullyQualified([ "DB" ], "Query")
@@ -130,15 +136,19 @@ module HddCache =
     let listId = Identifier.LocalScope "List" |> TypeCheckScope.Empty.Resolve
     let viewId = Identifier.FullyQualified([ "Frontend" ], "View") |> TypeCheckScope.Empty.Resolve
     let viewPropsId = Identifier.FullyQualified([ "View" ], "Props") |> TypeCheckScope.Empty.Resolve
+    let _reactNodeId = Identifier.FullyQualified([ "View" ], "ReactNode") |> TypeCheckScope.Empty.Resolve
+    let _reactComponentId = Identifier.FullyQualified([ "View" ], "ReactComponent") |> TypeCheckScope.Empty.Resolve
     let coId = Identifier.LocalScope "Co" |> TypeCheckScope.Empty.Resolve
 
-    match queryTypeSymbol, listTypeSymbol, viewTypeSymbol, viewPropsTypeSymbol, coTypeSymbol with
-    | Some queryTypeSymbol, Some listTypeSymbol, Some viewTypeSymbol, Some viewPropsTypeSymbol, Some coTypeSymbol ->
+    match queryTypeSymbol, listTypeSymbol, viewTypeSymbol, viewPropsTypeSymbol, reactNodeTypeSymbol, reactComponentTypeSymbol, coTypeSymbol with
+    | Some queryTypeSymbol, Some listTypeSymbol, Some viewTypeSymbol, Some viewPropsTypeSymbol, Some reactNodeTypeSymbol, Some reactComponentTypeSymbol, Some coTypeSymbol ->
       Some
         { QueryTypeSymbol = queryTypeSymbol
           ListTypeSymbol = listTypeSymbol
           ViewTypeSymbol = viewTypeSymbol
           ViewPropsTypeSymbol = viewPropsTypeSymbol
+          ReactNodeTypeSymbol = reactNodeTypeSymbol
+          ReactComponentTypeSymbol = reactComponentTypeSymbol
           CoTypeSymbol = coTypeSymbol
           // This config is only used to bootstrap stdExtensions with stable symbols.
           MkQueryType =
@@ -208,7 +218,7 @@ module HddCache =
     let cacheFilePath = Path.Combine(cacheFolder, "build-cache.msgpack")
 
     let loadCache () =
-      let cache, _, _, _, _, _ =
+      let cache, _, _, _, _, _, _, _ =
         loadPersistedCacheData<'valueExt> serializer cacheFilePath
 
       cache
@@ -236,6 +246,10 @@ module HddCache =
               typeCheckingConfig |> Option.map (fun cfg -> cfg.ViewTypeSymbol)
             ViewPropsTypeSymbol =
               typeCheckingConfig |> Option.map (fun cfg -> cfg.ViewPropsTypeSymbol)
+            ReactNodeTypeSymbol =
+              typeCheckingConfig |> Option.map (fun cfg -> cfg.ReactNodeTypeSymbol)
+            ReactComponentTypeSymbol =
+              typeCheckingConfig |> Option.map (fun cfg -> cfg.ReactComponentTypeSymbol)
             CoTypeSymbol =
               typeCheckingConfig |> Option.map (fun cfg -> cfg.CoTypeSymbol) }
 

--- a/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
@@ -711,7 +711,7 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
       DeltaExt<_, _, _>.ListDeltaDTOLens
       (typeCheckingConfig |> Option.map (fun cfg -> cfg.ListTypeSymbol))
 
-  let viewExtension, viewPropsExtension, view_sym, view_props_sym, mk_view_type, mk_view_props_type =
+  let viewExtension, viewPropsExtension, reactNodeExtension, reactComponentExtension, view_sym, view_props_sym, react_node_sym, react_component_sym, mk_view_type, mk_view_props_type, _react_node_type, _mk_react_component_type =
     View.Extension.ViewExtension<
       'runtimeContext,
       ValueExt<'runtimeContext, 'db, 'customExtension>,
@@ -723,6 +723,8 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
         Set = VViewProps }
       (typeCheckingConfig |> Option.map (fun cfg -> cfg.ViewTypeSymbol))
       (typeCheckingConfig |> Option.map (fun cfg -> cfg.ViewPropsTypeSymbol))
+      (typeCheckingConfig |> Option.map (fun cfg -> cfg.ReactNodeTypeSymbol))
+      (typeCheckingConfig |> Option.map (fun cfg -> cfg.ReactComponentTypeSymbol))
 
   let coroutineExtension, co_sym, mk_co_type =
     Coroutine.Extension.CoroutineExtension<
@@ -969,6 +971,8 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
     |> (listExtension |> TypeExtension.RegisterLanguageContext)
     |> (viewExtension |> TypeExtension.RegisterLanguageContext)
     |> (viewPropsExtension |> TypeExtension.RegisterLanguageContext)
+    |> (reactNodeExtension |> TypeExtension.RegisterLanguageContext)
+    |> (reactComponentExtension |> TypeExtension.RegisterLanguageContext)
     |> (coroutineExtension |> TypeExtension.RegisterLanguageContext)
     |> (webAppIOExtension |> TypeExtension.RegisterLanguageContext)
     |> (webAppRunExtension |> TypeLambdaExtension.RegisterLanguageContext)
@@ -1325,6 +1329,8 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
       ListTypeSymbol = list_sym
       ViewTypeSymbol = view_sym
       ViewPropsTypeSymbol = view_props_sym
+      ReactNodeTypeSymbol = react_node_sym
+      ReactComponentTypeSymbol = react_component_sym
       CoTypeSymbol = co_sym
       MkQueryType = mk_query
       MkListType = mk_list_type

--- a/backend/libraries/ballerina-lang/Next/Stdlib/View/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/View/Extension.fs
@@ -30,6 +30,8 @@ module Extension =
     (operationLens: PartialLens<'ext, ViewPropsOperations<'ext>>)
     (viewTypeSymbol: Option<TypeSymbol>)
     (viewPropsTypeSymbol: Option<TypeSymbol>)
+    (reactNodeTypeSymbol: Option<TypeSymbol>)
+    (reactComponentTypeSymbol: Option<TypeSymbol>)
     : TypeExtension<
         'runtimeContext,
         'ext,
@@ -50,10 +52,34 @@ module Extension =
         Unit,
         ViewPropsOperations<'ext>
        > *
+      TypeExtension<
+        'runtimeContext,
+        'ext,
+        'extDTO,
+        'deltaExt,
+        'deltaExtDTO,
+        Unit,
+        Unit,
+        Unit
+       > *
+      TypeExtension<
+        'runtimeContext,
+        'ext,
+        'extDTO,
+        'deltaExt,
+        'deltaExtDTO,
+        Unit,
+        Unit,
+        Unit
+       > *
+      TypeSymbol *
+      TypeSymbol *
       TypeSymbol *
       TypeSymbol *
       (TypeValue<'ext> -> TypeValue<'ext> -> TypeValue<'ext> -> TypeValue<'ext>) *
-      (TypeValue<'ext> -> TypeValue<'ext> -> TypeValue<'ext> -> TypeValue<'ext>)
+      (TypeValue<'ext> -> TypeValue<'ext> -> TypeValue<'ext> -> TypeValue<'ext>) *
+      TypeValue<'ext> *
+      (TypeValue<'ext> -> TypeValue<'ext>)
     =
     // --- View ---
     let viewId = Identifier.FullyQualified([ "Frontend" ], "View")
@@ -460,4 +486,54 @@ module Extension =
         Serialization = None
         ExtTypeChecker = None }
 
-    viewExtension, viewPropsExtension, viewSymbolId, viewPropsSymbolId, make_viewType, make_viewPropsType
+    // --- View::ReactNode ---
+    let reactNodeId = Identifier.FullyQualified([ "View" ], "ReactNode")
+
+    let reactNodeSymbolId =
+      reactNodeTypeSymbol |> Option.defaultWith (fun () -> reactNodeId |> TypeSymbol.Create)
+
+    let reactNodeResolvedId = reactNodeId |> TypeCheckScope.Empty.Resolve
+
+    let reactNodeType =
+      TypeValue.Imported
+        { Id = reactNodeResolvedId
+          Sym = reactNodeSymbolId
+          Parameters = []
+          Arguments = [] }
+
+    let reactNodeExtension =
+      { TypeName = reactNodeResolvedId, reactNodeSymbolId
+        TypeVars = []
+        Cases = Map.empty
+        Operations = Map.empty
+        Serialization = None
+        ExtTypeChecker = None }
+
+    // --- View::ReactComponent[P] ---
+    let reactComponentId = Identifier.FullyQualified([ "View" ], "ReactComponent")
+
+    let reactComponentSymbolId =
+      reactComponentTypeSymbol |> Option.defaultWith (fun () -> reactComponentId |> TypeSymbol.Create)
+
+    let reactComponentResolvedId = reactComponentId |> TypeCheckScope.Empty.Resolve
+
+    let propsVar, propsKind = TypeVar.Create("props"), Kind.Star
+
+    let make_reactComponentType (propsType: TypeValue<'ext>) =
+      TypeValue.Imported
+        { Id = reactComponentResolvedId
+          Sym = reactComponentSymbolId
+          Parameters = []
+          Arguments = [ propsType ] }
+
+    let reactComponentExtension =
+      { TypeName = reactComponentResolvedId, reactComponentSymbolId
+        TypeVars = [ (propsVar, propsKind) ]
+        Cases = Map.empty
+        Operations = Map.empty
+        Serialization = None
+        ExtTypeChecker = None }
+
+    viewExtension, viewPropsExtension, reactNodeExtension, reactComponentExtension,
+    viewSymbolId, viewPropsSymbolId, reactNodeSymbolId, reactComponentSymbolId,
+    make_viewType, make_viewPropsType, reactNodeType, make_reactComponentType

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/Model.fs
@@ -181,6 +181,8 @@ module Model =
       ListTypeSymbol: TypeSymbol
       ViewTypeSymbol: TypeSymbol
       ViewPropsTypeSymbol: TypeSymbol
+      ReactNodeTypeSymbol: TypeSymbol
+      ReactComponentTypeSymbol: TypeSymbol
       CoTypeSymbol: TypeSymbol
       MkQueryType:
         Schema<'valueExt> -> TypeQueryRow<'valueExt> -> TypeValue<'valueExt>


### PR DESCRIPTION
## Summary

Add two new opaque types to the Ballerina view system for passing React components/elements from TypeScript adapters into Ballerina-generated layouts via the context record:

- **`View::ReactNode`** (kind `*`, no args) — represents `React.ReactNode`
- **`View::ReactComponent[P]`** (kind `* → *`, 1 arg) — represents `React.ComponentType<P>`

## Changes

- **Extension.fs**: Define both types with TypeSymbol, ResolvedId, and extensions
- **Model.fs**: Add `ReactNodeTypeSymbol` and `ReactComponentTypeSymbol` to `TypeCheckingConfig`
- **StdExtensions.fs**: Register both extensions, wire symbols into the language context
- **HddCache.fs**: Persist new symbols in build cache (tuple expanded 6→8)

## Testing

- Ballerina `backend.sln` builds clean (0 errors)
- Integration tests: 26/26 passed
- UScreen smoke test Part A: 10/10 passed

## Note
**DO NOT MERGE** — waiting for companion BISE PR to be reviewed together.