### PR TITLE
Propagate admin mutation errors from DB runtime

### DIFF
--- a/backend/apps/ballerina-stdlib.Tests/OpenApi/YamlGenerationTests.fs
+++ b/backend/apps/ballerina-stdlib.Tests/OpenApi/YamlGenerationTests.fs
@@ -1,0 +1,33 @@
+namespace Ballerina.StdLib.Tests.OpenApi
+
+open NUnit.Framework
+open Ballerina.DSL.Next
+open Ballerina.DSL.Next.OpenAPIModel
+open Ballerina.DSL.Next.Types
+
+module YamlGenerationTests =
+
+  [<Test>]
+  let ``Generated OpenAPI includes JSON schema for bad requests`` () =
+    let spec =
+      { Title = "Test API"
+        Version = "1.0.0"
+        Endpoints =
+          [ { Path = "/tenant/schema/Example/create"
+              Method = OpenAPIEndpointModel.Post
+              QueryParameters = []
+              RequestModel = None
+              ResponseModel =
+                Some(
+                  OpenAPIDataModel.Object
+                    [ "Primitive" |> ResolvedIdentifier.Create,
+                      OpenAPIDataModel.Primitive PrimitiveType.Bool ]
+                ) } ]
+        DataModels = Map.empty }
+
+    let yaml = YamlGeneration.to_yaml spec
+
+    Assert.That(yaml, Does.Contain("'400':"))
+    Assert.That(yaml, Does.Contain("application/json:"))
+    Assert.That(yaml, Does.Contain("$ref: '#/components/schemas/ApiErrorResponse'"))
+    Assert.That(yaml, Does.Contain("'ApiErrorResponse':"))

--- a/backend/apps/ballerina-stdlib.Tests/ballerina-stdlib.Tests.fsproj
+++ b/backend/apps/ballerina-stdlib.Tests/ballerina-stdlib.Tests.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="Core\MemoizeTests.fs" />
     <Compile Include="Formats\Iso8601\DateOnlyTests.fs" />
     <Compile Include="Formats\Iso8601\DateTimeTests.fs" />
+    <Compile Include="OpenApi\YamlGenerationTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
@@ -30,6 +31,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../libraries/ballerina-cat/ballerina-cat.fsproj" />
+    <ProjectReference Include="../../libraries/ballerina-api/ballerina-api.fsproj" />
     <ProjectReference Include="../../libraries/ballerina-stdlib/ballerina-stdlib.fsproj" />
   </ItemGroup>
 </Project>

--- a/backend/libraries/ballerina-api/Common/OpenAPI/YamlGeneration.fs
+++ b/backend/libraries/ballerina-api/Common/OpenAPI/YamlGeneration.fs
@@ -12,6 +12,8 @@ module YamlGeneration =
 
   let private compare_ordinal (a: string) (b: string) = String.CompareOrdinal(a, b)
 
+  let private api_error_response_schema_ref = "#/components/schemas/ApiErrorResponse"
+
 
   let private resolved_identifier_to_string (id: ResolvedIdentifier) =
     match id.Type with
@@ -408,8 +410,31 @@ module YamlGeneration =
     @ response_lines
     @ [ $"{indent (level + 3)}'400':"
         $"{indent (level + 4)}description: Bad Request"
+        $"{indent (level + 4)}content:"
+        $"{indent (level + 5)}application/json:"
+        $"{indent (level + 6)}schema:"
+        $"{indent (level + 7)}$ref: {yaml_string api_error_response_schema_ref}"
         $"{indent (level + 3)}'404':"
         $"{indent (level + 4)}description: Not Found" ]
+
+  let private api_error_component_lines =
+    [ $"{indent 2}'ApiErrorResponse':"
+      $"{indent 3}type: object"
+      $"{indent 3}properties:"
+      $"{indent 4}'Errors':"
+      $"{indent 5}type: array"
+      $"{indent 5}items:"
+      $"{indent 6}type: object"
+      $"{indent 6}additionalProperties: true"
+      $"{indent 4}'Examples':"
+      $"{indent 5}type: array"
+      $"{indent 5}items:"
+      $"{indent 6}type: object"
+      $"{indent 6}additionalProperties: true"
+      $"{indent 3}required:"
+      $"{indent 4}- 'Errors'"
+      $"{indent 4}- 'Examples'"
+      $"{indent 3}additionalProperties: false" ]
 
   let to_yaml (spec: OpenAPISpec) =
     let sorted_endpoints =
@@ -445,6 +470,7 @@ module YamlGeneration =
       "paths:" ]
     @ (if List.isEmpty paths_lines then [ "  {}" ] else paths_lines)
     @ [ "components:"; "  schemas:" ]
+    @ api_error_component_lines
     @ (if List.isEmpty components_lines then
          [ "    {}" ]
        else

--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/CUD/Create.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/CUD/Create.fs
@@ -23,6 +23,10 @@ module Create =
   open Ballerina
   open Ballerina.DSL.Next.StdLib.DB
 
+  let private deniedCreateError loc0 entityName =
+    Errors.Singleton loc0 (fun () ->
+      $"Create failed for {entityName}: you are not allowed to perform this action.")
+
 
   let onCreatingHook<'runtimeContext, 'db, 'ext when 'ext: comparison>
     (db_ops: DBTypeClass<'runtimeContext, 'db, 'ext>)
@@ -335,11 +339,11 @@ module Create =
                           ->
                           return! actual_creation
                         | _ ->
-                          return
-                            Value.Sum(
-                              { Case = 1; Count = 2 },
-                              Value.Primitive PrimitiveValue.Unit
+                          return!
+                            sum.Throw(
+                              deniedCreateError loc0 entity.Name.Name
                             )
+                            |> reader.OfSum
                       | _, None -> return! actual_creation
                     }
                 | _ ->

--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/CUD/Delete.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/CUD/Delete.fs
@@ -23,6 +23,14 @@ module Delete =
   open Ballerina
   open Ballerina.DSL.Next.StdLib.DB
 
+  let private missingDeleteTargetError loc0 entityName =
+    Errors.Singleton loc0 (fun () ->
+      $"Delete failed for {entityName}: the item was not found or is no longer accessible.")
+
+  let private deniedDeleteError loc0 entityName =
+    Errors.Singleton loc0 (fun () ->
+      $"Delete failed for {entityName}: you are not allowed to perform this action.")
+
   let onDeletingHook<'runtimeContext, 'db, 'ext when 'ext: comparison>
     (_db_ops: DBTypeClass<'runtimeContext, 'db, 'ext>)
     (entity_ref: EntityRef<'db, 'ext>)
@@ -229,11 +237,16 @@ module Delete =
                   db_ops.GetById entity_ref entityId
                   |> reader.MapError(Errors.MapContext(replaceWith loc0))
                   |> reader.Catch
-                  |> reader.Map Sum.toOption
 
                 match existingValue with
-                | None -> return Value.Primitive(PrimitiveValue.Bool false)
-                | Some currentValueWithProps ->
+                | Right _ ->
+                  let _, _, entity, _ = entity_ref
+                  return!
+                    sum.Throw(
+                      missingDeleteTargetError loc0 entity.Name.Name
+                    )
+                    |> reader.OfSum
+                | Left currentValueWithProps ->
                   let actual_delete =
                     reader {
                       do!
@@ -244,10 +257,9 @@ module Delete =
                           entityId
                           currentValueWithProps
 
-                      let! result =
+                      do!
                         db_ops.Delete entity_ref entityId
                         |> reader.MapError(Errors.MapContext(replaceWith loc0))
-                        |> reader.Catch
 
                       do!
                         onDeletedHook
@@ -257,7 +269,7 @@ module Delete =
                           entityId
                           currentValueWithProps
 
-                      return Value.Primitive(PrimitiveValue.Bool(result.IsLeft))
+                      return Value.Primitive(PrimitiveValue.Bool true)
                     }
                     |> reader.MapContext(
                       ExprEvalContext.Updaters.RootLevelEval(replaceWith false)
@@ -303,7 +315,11 @@ module Delete =
                           ->
                           return! actual_delete
                         | _ ->
-                          return Value.Primitive(PrimitiveValue.Bool(false))
+                          return!
+                            sum.Throw(
+                              deniedDeleteError loc0 entity.Name.Name
+                            )
+                            |> reader.OfSum
                     }
 
             } }

--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/CUD/Update.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/CUD/Update.fs
@@ -23,6 +23,10 @@ module Update =
   open Ballerina
   open Ballerina.DSL.Next.StdLib.DB
 
+  let private deniedUpdateError loc0 entityName =
+    Errors.Singleton loc0 (fun () ->
+      $"Update failed for {entityName}: you are not allowed to perform this action.")
+
   let onUpdatingHook<'runtimeContext, 'db, 'ext when 'ext: comparison>
     (db_ops: DBTypeClass<'runtimeContext, 'db, 'ext>)
     (calculateProps:
@@ -310,15 +314,8 @@ module Update =
 
 
                   match existingValue with
-                  | Right _errors ->
-                    // let _, _, entity, _ = entity_ref
-                    // do Console.WriteLine $"Error getting {entity.Name.Name} with id {_entityId}: {errors.Errors()}"
-                    // do Console.ReadLine() |> ignore
-                    return
-                      Value.Sum(
-                        { Case = 1; Count = 2 },
-                        Value.Primitive PrimitiveValue.Unit
-                      )
+                  | Right errors ->
+                    return! sum.Throw(errors) |> reader.OfSum
                   | Left existingValue ->
                     let actual_update =
                       reader {
@@ -432,14 +429,11 @@ module Update =
                             ->
                             return! actual_update
                           | _res ->
-                            // do Console.WriteLine $"Unexpected result from canUpdate hook: {res}"
-                            // do Console.ReadLine() |> ignore
-
-                            return
-                              Value.Sum(
-                                { Case = 1; Count = 2 },
-                                Value.Primitive PrimitiveValue.Unit
+                            return!
+                              sum.Throw(
+                                deniedUpdateError loc0 entity.Name.Name
                               )
+                              |> reader.OfSum
                         | _ ->
                           // do Console.WriteLine $"There is no canUpdate hook for entity {entity.Name}, proceeding with update"
                           // do Console.ReadLine() |> ignore


### PR DESCRIPTION
## Summary
Surface DB mutation failures instead of silently swallowing them in the runtime and add test coverage for the generated OpenAPI YAML output.

## What changed
- throw SQL errors from create, delete, update, link, and unlink paths instead of returning success on failure
- adjust OpenAPI YAML generation to reflect the improved error behavior
- add/update stdlib OpenAPI tests for the generated YAML

## Validation
- No additional validation was run as part of the PR flow.
