### PR TITLE
fix: allow 'select' tag in parser

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+e2e-screenshots/

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/View.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/View.fs
@@ -40,6 +40,7 @@ module View =
     parser.Exactly(fun t ->
       match t.Token with
       | Token.Identifier id -> Some id
+      | Token.Keyword Keyword.Select -> Some "select"
       | _ -> None)
     |> AnnotatedParser.withNamedRule tagIdentifierRule
 


### PR DESCRIPTION
## Summary
- allow \ as a valid view tag identifier in the parser
- keeps admin view generation aligned with React node injection changes

## Validation
- local branch builds/tests already executed during development
