### PR TITLE
Add ViewLet support for view expressions

### DIFF
--- a/backend/libraries/ballerina-lang/Next/Models/Types.fs
+++ b/backend/libraries/ballerina-lang/Next/Models/Types.fs
@@ -1518,6 +1518,7 @@ module Model =
     override self.ToString() = self.Node.ToString()
 
   and ExprViewNodeRec<'T, 'Id, 'valueExt when 'Id: comparison> =
+    | ViewLet of Var: Var * Value: Expr<'T, 'Id, 'valueExt> * Rest: ExprViewNode<'T, 'Id, 'valueExt>
     | ViewElement of ExprViewElement<'T, 'Id, 'valueExt>
     | ViewFragment of List<ExprViewNode<'T, 'Id, 'valueExt>>
     | ViewExprContainer of Expr<'T, 'Id, 'valueExt>
@@ -1528,6 +1529,7 @@ module Model =
 
     override self.ToString() =
       match self with
+      | ViewLet(var, value, rest) -> $"let {var} = {value}; {rest}"
       | ViewElement el -> el.ToString()
       | ViewFragment children ->
         let childStrs = children |> List.map (fun c -> c.ToString()) |> String.concat " "
@@ -2249,6 +2251,7 @@ module Model =
     override self.ToString() = self.Node.ToString()
 
   and [<RequireQualifiedAccess>] TypeCheckedViewNodeRec<'valueExt> =
+    | ViewLet of Var: Var * Value: TypeCheckedExpr<'valueExt> * Rest: TypeCheckedViewNode<'valueExt>
     | ViewElement of TypeCheckedViewElement<'valueExt>
     | ViewFragment of List<TypeCheckedViewNode<'valueExt>>
     | ViewExprContainer of TypeCheckedExpr<'valueExt>
@@ -2259,6 +2262,7 @@ module Model =
 
     override self.ToString() =
       match self with
+      | ViewLet(var, value, rest) -> $"let {var} = {value}; {rest}"
       | ViewElement el -> el.ToString()
       | ViewFragment children ->
         let childStrs = children |> List.map string |> String.concat " "
@@ -2800,6 +2804,7 @@ module Model =
     override self.ToString() = self.Node.ToString()
 
   and [<RequireQualifiedAccess>] RunnableViewNodeRec<'valueExt> =
+    | ViewLet of Var: Var * Value: RunnableExpr<'valueExt> * Rest: RunnableViewNode<'valueExt>
     | ViewElement of RunnableViewElement<'valueExt>
     | ViewFragment of List<RunnableViewNode<'valueExt>>
     | ViewExprContainer of RunnableExpr<'valueExt>
@@ -2809,6 +2814,7 @@ module Model =
 
     override self.ToString() =
       match self with
+      | ViewLet(var, value, rest) -> $"let {var} = {value}; {rest}"
       | ViewElement el -> el.ToString()
       | ViewFragment children ->
         let childStrs = children |> List.map string |> String.concat " "

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/View.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/View.fs
@@ -83,11 +83,26 @@ module View =
 
     let rec viewNode () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser.Any
-        [ viewElement ()
+        [ viewLet ()
+          viewElement ()
           viewFragment ()
           viewExprContainer ()
           viewTextNode () ]
       |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
+
+    and viewLet () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! loc = parser.Location
+        do! parseKeyword Keyword.Let
+        let! varName = singleIdentifier.Parser
+        do! equalsOperator
+        let! value = expr ()
+        do! semicolonOperator
+        let! rest = viewNode ()
+        return
+          { Location = loc
+            Node = ExprViewNodeRec.ViewLet(Var.Create varName, value, rest) }
+      }
 
     and viewElement () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {
@@ -245,7 +260,11 @@ module View =
 
   let viewNodeExprRule =
     { Name = "view-node-expr"
-      Rule = Alt [ NonTerminal "view-element"; NonTerminal "view-fragment"; NonTerminal "view-expr-container"; NonTerminal "view-text-node" ] }
+      Rule = Alt [ NonTerminal "view-let"; NonTerminal "view-element"; NonTerminal "view-fragment"; NonTerminal "view-expr-container"; NonTerminal "view-text-node" ] }
+
+  let viewLetRule: NamedRule =
+    { Name = "view-let"
+      Rule = Seq [ Terminal "let"; NonTerminal "identifier"; Terminal "="; NonTerminal "expr"; Terminal ";"; NonTerminal "view-node-expr" ] }
 
   /// Standalone JSX element expression: <tag .../> or <tag ...>children</tag>
   /// Used when JSX elements appear inside expression contexts (e.g. lambda bodies).
@@ -264,11 +283,26 @@ module View =
 
     let rec viewNode () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser.Any
-        [ viewElement ()
+        [ viewLet ()
+          viewElement ()
           viewFragment ()
           viewExprContainer ()
           viewTextNode () ]
       |> parser.MapError(Errors<_>.FilterHighestPriorityOnly)
+
+    and viewLet () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
+      parser {
+        let! loc = parser.Location
+        do! parseKeyword Keyword.Let
+        let! varName = singleIdentifier.Parser
+        do! equalsOperator
+        let! value = expr ()
+        do! semicolonOperator
+        let! rest = viewNode ()
+        return
+          { Location = loc
+            Node = ExprViewNodeRec.ViewLet(Var.Create varName, value, rest) }
+      }
 
     and viewElement () : Parser<ExprViewNode<TypeExpr<'valueExt>, Identifier, 'valueExt>, LocalizedToken, Location, Errors<Location>> =
       parser {
@@ -560,6 +594,7 @@ module View =
   let grammarRules: NamedRule list =
     [ lessThanOpRule; greaterThanOpRule; tagSelfCloseOpRule; tagCloseOpRule
       tagIdentifierRule; attrIdentifierRule; stringAttrValueRule
+      viewLetRule
       viewElementRule; viewFragmentRule; viewExprContainerRule; viewTextNodeRule
       viewExprRule; viewNodeExprRule; coExprRule
       coLetBangRule; coLetRule; coDoBangRule; coReturnRule; coReturnBangRule ]

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/Conversion/TypeCheckedExprToRunnable.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/Conversion/TypeCheckedExprToRunnable.fs
@@ -177,6 +177,11 @@ module Conversion =
     : Sum<RunnableViewNodeRec<'valueExt>, Errors<Location>>
     =
     match node with
+    | TypeCheckedViewNodeRec.ViewLet(var, value, rest) ->
+      sum {
+        let! value', rest' = sum.All2 (convertExpression value) (convertViewNode rest)
+        return RunnableViewNodeRec.ViewLet(var, value', rest')
+      }
     | TypeCheckedViewNodeRec.ViewElement el ->
       sum {
         let! el' = convertViewElement el

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/InstantiateSyntheticVars.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/InstantiateSyntheticVars.fs
@@ -311,6 +311,12 @@ module InstantiateSyntheticVars =
             state {
               match node.Node with
               | TypeCheckedViewNodeRec.ViewText _ -> return node
+              | TypeCheckedViewNodeRec.ViewLet(var, value, rest) ->
+                let! value = !value
+                let! rest = instantiateNode rest
+                return
+                  { node with
+                      Node = TypeCheckedViewNodeRec.ViewLet(var, value, rest) }
               | TypeCheckedViewNodeRec.ViewExprContainer e ->
                 let! e = !e
                 return

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/View.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/View.fs
@@ -38,7 +38,34 @@ module View =
       let (=>) c e = typeCheckExpr c e
 
       state {
+        let! ctx = state.GetContext()
+
         match node.Node with
+        | ExprViewNodeRec.ViewLet(var, valueExpr, rest) ->
+          let! checkedValue, _ = None => valueExpr
+
+          let! value_t =
+            checkedValue.Type
+            |> TypeValue.Instantiate
+              ()
+              (TypeExpr.Eval config typeCheckExpr)
+              loc0
+            |> Expr.liftInstantiation
+
+          let! checkedRest =
+            typeCheckNode rest
+            |> state.MapContext(
+              TypeCheckContext.Updaters.Values(
+                Map.add
+                  (var.Name |> Identifier.LocalScope |> ctx.Scope.Resolve)
+                  (value_t, checkedValue.Kind)
+              )
+            )
+
+          return
+            { TypeCheckedViewNode.Location = loc0
+              Node = TypeCheckedViewNodeRec.ViewLet(var, checkedValue, checkedRest) }
+
         | ExprViewNodeRec.ViewText text ->
           return
             { TypeCheckedViewNode.Location = loc0
@@ -60,7 +87,6 @@ module View =
               Node = TypeCheckedViewNodeRec.ViewFragment checkedChildren }
 
         | ExprViewNodeRec.ViewElement el ->
-          let! ctx = state.GetContext()
           let tagSchemaOpt = ctx.ViewAttributeSchemas |> Map.tryFind el.Tag
 
           let! checkedAttrs =


### PR DESCRIPTION
## Summary
Adds first-class `ViewLet` support across the view AST, parser, typechecker, runnable conversion, and synthetic-var instantiation so view-local bindings can be preserved into deferred targets.

## Validation
- `dotnet build backend.sln`
- `dotnet run` from `ballerina/backend/apps/ballerina-samples-integration-test`
- Full UScreen smoke test from the parent BISE repo after integrating the generator/runtime changes