### PR TITLE
Fix runnable lambda background job context

### DIFF
--- a/backend/apps/ballerina-db-api-playground-factory/BackgroundJobsExecutor.fs
+++ b/backend/apps/ballerina-db-api-playground-factory/BackgroundJobsExecutor.fs
@@ -103,9 +103,8 @@ type MemoryDBBackgroundJobExecutor
                       let result =
                         executeBackgroundJob
                           descriptor.DbExtension
-                          descriptor.EvalContext.ExtensionOps
+                          descriptor.EvalContext
                           injectBackgroundContext
-                          descriptor.EvalContext.RuntimeContext
                           backgroundJob
                           value
                           entity.EntityId

--- a/backend/libraries/ballerina-api-filedb-factory/API/Publication.fs
+++ b/backend/libraries/ballerina-api-filedb-factory/API/Publication.fs
@@ -23,6 +23,7 @@ module API =
   open Ballerina.DSL.Next.Types.Patterns
   open Ballerina.DSL.Next.Terms.FastEval
   open Ballerina.DSL.Next.Terms.Eval
+  open Ballerina.Collections.Map
   open Ballerina.Collections.NonEmptyList
   open Ballerina.Reader.WithError
   open System.Text
@@ -30,6 +31,16 @@ module API =
   type SchemaAPIPayload =
     { SchemaDefinition: SchemaFileDefinition[]
       IsDraft: bool }
+
+  let private mergeEvalScope
+    (baseScope: ExprEvalContextScope<'valueExtension>)
+    (evaluatedScope: ExprEvalContextScope<'valueExtension>)
+    : ExprEvalContextScope<'valueExtension> =
+    { Values =
+        evaluatedScope.Values
+        |> Map.merge (fun evaluatedValue _baseValue -> evaluatedValue) baseScope.Values
+      Symbols =
+        ExprEvalContextSymbols.Append baseScope.Symbols evaluatedScope.Symbols }
 
   let private runMain
     (languageContext:
@@ -164,7 +175,7 @@ module API =
 
       let evalContext =
         { evalContext with
-            Scope = dbio.EvalContext }
+            Scope = mergeEvalScope evalContext.Scope dbio.EvalContext }
 
 
       match schema with

--- a/backend/libraries/ballerina-api-filedb-factory/MemoryDBFactory.fs
+++ b/backend/libraries/ballerina-api-filedb-factory/MemoryDBFactory.fs
@@ -31,6 +31,16 @@ module MemoryDBAPIFactory =
   open Microsoft.AspNetCore.Http
   open CacheCompilation
 
+  let private mergeEvalScope
+    (baseScope: ExprEvalContextScope<'valueExtension>)
+    (evaluatedScope: ExprEvalContextScope<'valueExtension>)
+    : ExprEvalContextScope<'valueExtension> =
+    { Values =
+        evaluatedScope.Values
+        |> Map.merge (fun evaluatedValue _baseValue -> evaluatedValue) baseScope.Values
+      Symbols =
+        ExprEvalContextSymbols.Append baseScope.Symbols evaluatedScope.Symbols }
+
   let contextFactory dbFileConfig =
     hddcacheWithStdExtensions
       (Ballerina.DSL.Next.StdLib.String.Extension.StringTypeClass<_>.Console())
@@ -114,7 +124,7 @@ module MemoryDBAPIFactory =
           { DbExtension = dbio
             EvalContext =
               { evalContext with
-                  Scope = dbio.EvalContext }
+                  Scope = mergeEvalScope evalContext.Scope dbio.EvalContext }
             TypeCheckContext = typeCheckContext
             TypeCheckState = typeCheckState
             LanguageContext = languageContext
@@ -126,7 +136,7 @@ module MemoryDBAPIFactory =
           { DbExtension = dbio
             EvalContext =
               { evalContext with
-                  Scope = dbio.EvalContext }
+                  Scope = mergeEvalScope evalContext.Scope dbio.EvalContext }
             TypeCheckContext = typeCheckContext
             TypeCheckState = typeCheckState
             LanguageContext = languageContext

--- a/backend/libraries/ballerina-lang/Next/Models/TermPatterns.fs
+++ b/backend/libraries/ballerina-lang/Next/Models/TermPatterns.fs
@@ -1740,9 +1740,9 @@ module Patterns =
     static member Lambda
       (
         v: Var,
-        paramType: TypeValue<'valueExt>,
+        _paramType: TypeValue<'valueExt>,
         e: RunnableExpr<'valueExt>,
-        returnType: TypeValue<'valueExt>,
+        _returnType: TypeValue<'valueExt>,
         t: TypeValue<'valueExt>,
         k: Kind,
         loc: Location,
@@ -1751,9 +1751,7 @@ module Patterns =
       { Expr =
           RunnableExprRec.Lambda(
             { RunnableExprLambda.Param = v
-              ParamType = paramType
-              Body = e
-              BodyType = returnType }
+              Body = e }
           )
         Type = t
         Kind = k

--- a/backend/libraries/ballerina-lang/Next/Models/Types.fs
+++ b/backend/libraries/ballerina-lang/Next/Models/Types.fs
@@ -2527,12 +2527,10 @@ module Model =
 
   and [<RequireQualifiedAccess>] RunnableExprLambda<'valueExt> =
     { Param: Var
-      ParamType: TypeValue<'valueExt>
-      Body: RunnableExpr<'valueExt>
-      BodyType: TypeValue<'valueExt> }
+      Body: RunnableExpr<'valueExt> }
 
     override self.ToString() =
-      $"fun ({self.Param}: {self.ParamType}) -> {self.Body}"
+      $"fun {self.Param} -> {self.Body}"
 
   and [<RequireQualifiedAccess>] RunnableExprApply<'valueExt> =
     { F: RunnableExpr<'valueExt>
@@ -2934,9 +2932,9 @@ module Model =
       | RunnableExprRec.TypeLambda({ RunnableExprTypeLambda.Param = tp
                                      Body = body }) -> $"(Λ{tp} => {body})"
       | TypeApply({ Func = e; TypeArg = t }) -> $"{e} [{t}]"
-      | Lambda({ Param = v
-                 ParamType = t
-                 Body = body }) -> $"(fun ({v.Name}: {t}) -> {body})"
+      | RunnableExprRec.Lambda({ RunnableExprLambda.Param = v
+                                 RunnableExprLambda.Body = body }) ->
+        $"(fun {v.Name} -> {body})"
       | Apply({ F = e1; Arg = e2 }) -> $"({e1} {e2})"
       | FromValue({ Value = v
                     ValueType = t

--- a/backend/libraries/ballerina-lang/Next/Runners/BackgroundJob.fs
+++ b/backend/libraries/ballerina-lang/Next/Runners/BackgroundJob.fs
@@ -11,13 +11,23 @@ open Ballerina.DSL.Next.Terms.Eval
 open Ballerina.DSL.Next.Terms.Patterns
 open Ballerina.Errors
 open Ballerina.Collections.NonEmptyList
+open Ballerina.Collections.Map
+
+let private mergeEvalScope
+  (baseScope: ExprEvalContextScope<'valueExtension>)
+  (evaluatedScope: ExprEvalContextScope<'valueExtension>)
+  : ExprEvalContextScope<'valueExtension> =
+  { Values =
+      evaluatedScope.Values
+      |> Map.merge (fun evaluatedValue _baseValue -> evaluatedValue) baseScope.Values
+    Symbols =
+      ExprEvalContextSymbols.Append baseScope.Symbols evaluatedScope.Symbols }
 
 let executeBackgroundJob
   dbio
-  (evalContext: ValueExtensionOps<'runtimeContext, 'valueExtension>)
+  (baseEvalContext: ExprEvalContext<'runtimeContext, 'valueExtension>)
   (injectBackgroundContext:
     Updater<ExprEvalContext<'runtimeContext, 'valueExtension>>)
-  runtimeContext
   backgroundJob
   value
   entityId
@@ -57,11 +67,10 @@ let executeBackgroundJob
       Expr.Eval(NonEmptyList.OfList(backgroundJobExpr, []))
       |> Reader.mapContext injectBackgroundContext
       |> Reader.Run
-        { Scope = dbio.EvalContext
-          ValueOverlays = []
-          ExtensionOps = evalContext
-          RuntimeContext = runtimeContext
-          RootLevelEval = true }
+        { baseEvalContext with
+            Scope = mergeEvalScope baseEvalContext.Scope dbio.EvalContext
+            ValueOverlays = []
+            RootLevelEval = true }
 
     match backgroundJobResult with
     | Left(Value.Sum(_,

--- a/backend/libraries/ballerina-lang/Next/Stdlib/RunnableExprLegacyConstructors.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/RunnableExprLegacyConstructors.fs
@@ -34,7 +34,7 @@ module RunnableExprLegacyConstructors =
         e: RunnableExpr<'valueExt>,
         r: TypeValue<'valueExt>
       ) : RunnableExpr<'valueExt> =
-      { Expr = RunnableExprRec.Lambda { Param = v; ParamType = t; Body = e; BodyType = r }
+      { Expr = RunnableExprRec.Lambda { Param = v; Body = e }
         Location = Location.Unknown
         Type = TypeValue.CreateArrow(t, r)
         Kind = Kind.Star

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/Conversion/TypeCheckedExprToRunnable.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/Conversion/TypeCheckedExprToRunnable.fs
@@ -49,7 +49,7 @@ module Conversion =
     | TypeCheckedExprRec.Lambda l ->
       sum {
         let! body = convertExpression l.Body
-        return RunnableExprRec.Lambda { Param = l.Param; ParamType = l.ParamType; Body = body; BodyType = l.BodyType }
+        return RunnableExprRec.Lambda { Param = l.Param; Body = body }
       }
     | TypeCheckedExprRec.FromValue fv ->
       Left(RunnableExprRec.FromValue { Value = fv.Value; ValueType = fv.ValueType; ValueKind = fv.ValueKind })

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/Schema/SchemaTypeEval.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/Schema/SchemaTypeEval.fs
@@ -1163,9 +1163,7 @@ module SchemaTypeEval =
                 synth (
                   RunnableExprRec.Lambda
                     { Param = v
-                      ParamType = TypeValue.CreateUnit()
-                      Body = body
-                      BodyType = TypeValue.CreateUnit() }
+                      Body = body }
                 ))
               matchExpr
 


### PR DESCRIPTION
## Summary
- preserve the base eval context while merging db scope for background jobs and filedb publication paths
- align runnable lambda construction and conversion with the current lambda shape
- update playground background job execution to the new background job runner contract

## Testing
- not run (per request)