### PR TITLE
Change WebApp::run to take a schema callback

### DIFF
--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/DBRun.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/DBRun.fs
@@ -117,6 +117,32 @@ module DBRun =
       return res
     }
 
+  let BuildDBIO<'runtimeContext, 'db, 'ext when 'ext: comparison>
+    (loc0: Location)
+    (valueLens: PartialLens<'ext, DBValues<'runtimeContext, 'db, 'ext>>)
+    (db: 'db)
+    (schema: Schema<'ext>)
+    (value: Value<TypeValue<'ext>, 'ext>)
+    : ExprEvaluator<'runtimeContext, 'ext, DBIO<'runtimeContext, 'db, 'ext>> =
+    reader {
+      let! ctx = reader.GetContext()
+
+      let! schema_value =
+        MemoryDBSchemaToDescriptors<'runtimeContext, 'db, 'ext>
+          valueLens
+          db
+          schema
+        |> sum.MapError(Errors.MapContext(replaceWith loc0))
+        |> reader.OfSum
+
+      return
+        { Schema = schema
+          SchemaAsValue = schema_value
+          DB = db
+          EvalContext = ctx.Scope
+          Main = value }
+    }
+
 
   let DBRunExtension<'runtimeContext, 'db, 'ext, 'extDTO
     when 'ext: comparison and 'extDTO: not null and 'extDTO: not struct>
@@ -226,29 +252,13 @@ module DBRun =
       (_rest: List<RunnableExpr<'ext>>)
       : ExprEvaluator<'runtimeContext, 'ext, Value<TypeValue<'ext>, 'ext>> =
       reader {
-
-        // return!
-        //   Expr.Apply(
-        //     Expr.FromValue(value, TypeValue.CreatePrimitive PrimitiveType.Unit, Kind.Star),
-        //     Expr.FromValue(arg, TypeValue.CreatePrimitive PrimitiveType.Unit, Kind.Star)
-        //   )
-        //   |> fun e -> Expr.Eval(NonEmptyList.OfList(e, _rest))
-        let! ctx = reader.GetContext()
-
-        let! (schema_value: Value<TypeValue<'ext>, 'ext>) =
-          MemoryDBSchemaToDescriptors<'runtimeContext, 'db, 'ext>
+        let! result =
+          BuildDBIO<'runtimeContext, 'db, 'ext>
+            _loc0
             valueLens
             db
             schema
-          |> sum.MapError(Errors.MapContext(replaceWith _loc0))
-          |> reader.OfSum
-
-        let result: DBIO<'runtimeContext, 'db, 'ext> =
-          { Schema = schema
-            SchemaAsValue = schema_value
-            DB = db
-            EvalContext = ctx.Scope
-            Main = value }
+            value
 
         return (result |> DBValues.DBIO |> valueLens.Set, None) |> Ext
       }

--- a/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
@@ -750,11 +750,11 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
      >
       { Get = function | VWebApp x -> Some x | _ -> None
         Set = VWebApp }
+      db_ops
       DBExt<'runtimeContext, 'db, 'customExtension>.ValueLens
       None
       (Identifier.FullyQualified([ "Frontend" ], "View"))
       (Identifier.LocalScope "Co")
-      (Identifier.LocalScope "DBIO")
 
   let dateOnlyExtension =
     DateOnly.Extension.DateOnlyExtension<

--- a/backend/libraries/ballerina-lang/Next/Stdlib/WebApp/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/WebApp/Extension.fs
@@ -12,6 +12,7 @@ module Extension =
   open Ballerina.DSL.Next.Terms
   open Ballerina.DSL.Next.Terms.Patterns
   open Ballerina.DSL.Next.StdLib.DB
+  open Ballerina.DSL.Next.StdLib.DB.Extension
 
   type WebAppWithRouteArgs<'ext when 'ext: comparison> =
     { Path: Option<string>
@@ -29,7 +30,8 @@ module Extension =
 
   type WebAppOperations<'ext when 'ext: comparison> =
     | WebApp_Run
-    | WebApp_TypeAppliedRun
+    | WebApp_TypeAppliedRun of Schema<'ext>
+    | WebApp_ContextAppliedRun of Schema<'ext>
     | WebApp_WithRoute of WebAppWithRouteArgs<'ext>
     | WebApp_WithDbRoute of WebAppWithDbRouteArgs<'ext>
     | WebApp_WithComponent of WebAppWithComponentArgs<'ext>
@@ -42,11 +44,11 @@ module Extension =
     and 'deltaExtDTO: not null
     and 'deltaExtDTO: not struct>
     (operationLens: PartialLens<'ext, WebAppOperations<'ext>>)
+    (db_ops: DBTypeClass<'runtimeContext, 'db, 'ext>)
     (dbValuesLens: PartialLens<'ext, DBValues<'runtimeContext, 'db, 'ext>>)
     (webAppIOTypeSymbol: Option<TypeSymbol>)
     (viewTypeId: Identifier)
     (coTypeId: Identifier)
-    (dbIOTypeId: Identifier)
     : TypeExtension<
         'runtimeContext,
         'ext,
@@ -427,7 +429,7 @@ module Extension =
 
     // --- WebApp::run ---
     // run : Λschema::Schema. Λappctx::*.
-    //   DBIO[schema][()] -> WebAppIO[schema][appctx]
+    //   (schema -> ()) -> WebAppIO[schema][appctx]
     let webAppRunId =
       Identifier.FullyQualified([ "WebApp" ], "run")
       |> TypeCheckScope.Empty.Resolve
@@ -438,14 +440,10 @@ module Extension =
         TypeExpr.Lambda(
           TypeParameter.Create("appctx", appCtxKind),
           TypeExpr.Arrow(
-            TypeExpr.Apply(
-              TypeExpr.Apply(
-                TypeExpr.Lookup dbIOTypeId,
-                TypeExpr.Lookup(Identifier.LocalScope "schema")
-              ),
+            TypeExpr.Arrow(
+              TypeExpr.Lookup(Identifier.LocalScope "schema"),
               TypeExpr.Primitive PrimitiveType.Unit
-            )
-            ,
+            ),
             TypeExpr.Apply(
               TypeExpr.Apply(
                 TypeExpr.Lookup webAppIOId,
@@ -476,11 +474,24 @@ module Extension =
 
               match op with
               | WebApp_Run ->
-                // First type application [schema] — transition to TypeAppliedRun
+                // First type application [schema] captures the schema for internal DBIO construction.
+                return
+                  TypeApplicable(fun typeArg ->
+                    reader {
+                      let! schema =
+                        typeArg
+                        |> TypeValue.AsSchema
+                        |> Sum.mapRight (Errors.MapContext(fun _ -> Location.Unknown))
+                        |> reader.OfSum
+
+                      return (WebApp_TypeAppliedRun schema |> operationLens.Set, None) |> Ext
+                    })
+              | WebApp_TypeAppliedRun schema ->
+                // Remaining explicit appctx type argument is erased at runtime.
                 return
                   TypeApplicable(fun _typeArg ->
                     reader {
-                      return (WebApp_TypeAppliedRun |> operationLens.Set, None) |> Ext
+                      return (WebApp_ContextAppliedRun schema |> operationLens.Set, None) |> Ext
                     })
               | _ ->
                 return!
@@ -498,40 +509,30 @@ module Extension =
                 |> reader.OfSum
 
               match op with
-              | WebApp_TypeAppliedRun ->
-                // Remaining type application [appctx] is erased; now value application with DBIO arg
+              | WebApp_ContextAppliedRun schema ->
+                // The callback becomes the DBIO.Main function; WebApp::run constructs DBIO internally.
                 return
-                  Applicable(fun dbioValue ->
+                  Applicable(fun mainValue ->
                     reader {
-                      // Extract the DBIO from the argument value
-                      let! dbVals =
-                        match dbioValue with
-                        | Ext(ext, _) ->
-                          dbValuesLens.Get ext
-                          |> sum.OfOption(
-                            Errors.Singleton loc0 (fun () -> "WebApp::run: expected DBIO value")
-                          )
-                          |> reader.OfSum
-                        | _ ->
-                          Errors.Singleton loc0 (fun () -> "WebApp::run: expected an Ext value")
-                          |> reader.Throw
+                      let! dbio =
+                        BuildDBIO<'runtimeContext, 'db, 'ext>
+                          loc0
+                          dbValuesLens
+                          db_ops.DB
+                          schema
+                          mainValue
 
-                      match dbVals with
-                      | DBValues.DBIO dbio ->
-                        let webAppData: WebAppIOData<'runtimeContext, 'db, 'ext> =
-                          { DBIO = dbio
-                            Routes = []
-                            DbRoutes = []
-                            Components = [] }
-                        return (DBValues.WebAppIO webAppData |> dbValuesLens.Set, None) |> Ext
-                      | _ ->
-                        return!
-                          Errors.Singleton loc0 (fun () -> "WebApp::run: expected DBIO data")
-                          |> reader.Throw
+                      let webAppData: WebAppIOData<'runtimeContext, 'db, 'ext> =
+                        { DBIO = dbio
+                          Routes = []
+                          DbRoutes = []
+                          Components = [] }
+
+                      return (DBValues.WebAppIO webAppData |> dbValuesLens.Set, None) |> Ext
                     })
               | _ ->
                 return!
-                  Errors.Singleton loc0 (fun () -> "WebApp::run: expected WebApp_TypeAppliedRun")
+                  Errors.Singleton loc0 (fun () -> "WebApp::run: expected WebApp_ContextAppliedRun state")
                   |> reader.Throw
             } }
 

--- a/samples/24-views.bl
+++ b/samples/24-views.bl
@@ -339,13 +339,13 @@ let homeFlow = co {
 // ═════════════════════════════════════════════════════════════════════════
 // WEBAPP BUILDER
 // ═════════════════════════════════════════════════════════════════════════
-// WebApp::run wraps a DB::run and attaches routes and components.
+// WebApp::run wraps a unit-returning schema callback and attaches routes and components.
 // Routes map URL paths to coroutines (which manage page-level state).
 // Components register reusable views by name.
 // Routes are always coroutines — views are lifted via Co::show.
 
 let main = fun (schema: TodoSchema) ->
-  ((), "seeded");
+  ();
 
 let seed_todos = {
   { Todo::Title = "Learn Ballerina"; Todo::Done = true };
@@ -353,7 +353,7 @@ let seed_todos = {
   { Todo::Title = "Ship it"; Todo::Done = false }
 };
 
-WebApp::run [TodoSchema] (DB::run [TodoSchema] main)
+WebApp::run [TodoSchema] main
   |> WebApp::withRoute "/" (co {
     do! Co::show
       (replaceWith (1Of2()))


### PR DESCRIPTION
## Summary
- change `WebApp::run` so callers pass the same schema callback shape used by `DB::run`
- hide `DBIO` construction inside the stdlib runtime and reduce the public type to two parameters with `()` result
- update the sample caller to the new API

## Validation
- `dotnet build ballerina/backend/backend.sln`
- targeted typechecking of the updated callers
- ballerina samples integration executable
