### PR TITLE
Fix typecheck and cache behavior for AI configurator workflow

### DIFF
--- a/backend/libraries/ballerina-lang-build/HddCache.fs
+++ b/backend/libraries/ballerina-lang-build/HddCache.fs
@@ -15,7 +15,23 @@ module HddCache =
   open Ballerina.DSL.Next.StdLib.Email.Extension
   open Ballerina.DSL.Next.StdLib.String.Extension
   open Ballerina.Serialization.MessagePack
+  open System
   open System.IO
+
+  let private buildDiagnosticsEnabled =
+    match Environment.GetEnvironmentVariable("BISE_BUILD_DIAGNOSTICS") with
+    | null -> false
+    | value ->
+      match value.Trim().ToLowerInvariant() with
+      | "1"
+      | "true"
+      | "yes"
+      | "on" -> true
+      | _ -> false
+
+  let private logBuildDiagnostic (message: string) =
+    if buildDiagnosticsEnabled then
+      Console.WriteLine(message)
 
   [<CLIMutable>]
   type BuildCacheDto<'valueExt when 'valueExt: comparison> =
@@ -234,7 +250,13 @@ module HddCache =
               serializer.Serialize(BuildCacheDto<'valueExt>.FromDomain data)
             with
             | Left payload -> Some(fileName.Path, payload)
-            | Right _ -> None)
+            | Right errors ->
+              let errorText = Errors.ToString(errors, " | ")
+
+              logBuildDiagnostic
+                $"Build cache persist skipped | entry-serialize-failed | {fileName.Path} | {errorText}"
+
+              None)
           |> Array.ofSeq
 
         let container: BuildCacheContainerDto<'valueExt> =
@@ -258,9 +280,14 @@ module HddCache =
         | Left bytes ->
           Directory.CreateDirectory cacheFolder |> ignore
           File.WriteAllBytes(cacheFilePath, bytes)
-        | Right _ -> ()
-      with _ ->
-        ()
+        | Right errors ->
+          let errorText = Errors.ToString(errors, " | ")
+
+          logBuildDiagnostic
+            $"Build cache persist skipped | container-serialize-failed | {cacheFilePath} | {errorText}"
+      with ex ->
+        logBuildDiagnostic
+          $"Build cache persist exception | {cacheFilePath} | {ex.GetType().Name}: {ex.Message}"
 
     let mutable cache
       : Map<

--- a/backend/libraries/ballerina-lang-build/ProjectModel.fs
+++ b/backend/libraries/ballerina-lang-build/ProjectModel.fs
@@ -6,6 +6,7 @@ module ProjectModel =
   open Ballerina.State.WithError
   open Ballerina.Errors
   open System
+  open System.Diagnostics
   open Ballerina.DSL.Next.Types.Model
   open Ballerina.DSL.Next.Terms.Patterns
   open Ballerina.DSL.Next.Types.TypeChecker.Model
@@ -159,10 +160,150 @@ module ProjectModel =
         return nextState
       }
 
+  type TypeCheckState<'valueExt when 'valueExt: comparison> with
     static member RenderInlayHints
       (state: TypeCheckState<'valueExt>)
       : Map<Location, string> =
       state.InlayHints |> Map.map (fun _ hint -> hint.AsString())
+
+  let private parseFile<'valueExt when 'valueExt: comparison>
+    (file: FileBuildConfiguration)
+    : Sum<
+        ParserResult<
+          Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
+          LocalizedToken,
+          Location,
+          Errors<Location>
+         >,
+        Errors<Location>
+       > =
+    sum {
+      let initialLocation = Location.Initial file.FileName.Path
+
+      let! ParserResult(actual, _) =
+        tokens
+        |> Parser.Run(file.Content() |> Seq.toList, initialLocation)
+        |> sum.MapError fst
+
+      let! (parserResult:
+        ParserResult<
+          Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
+          LocalizedToken,
+          Location,
+          Errors<Location>
+         >) =
+        (Parser.Expr.program ()).Parser
+        |> Parser.Run(actual, initialLocation)
+        |> sum.MapError fst
+
+      parserResult
+    }
+
+  let private buildDiagnosticsEnabled =
+    match Environment.GetEnvironmentVariable("BISE_BUILD_DIAGNOSTICS") with
+    | null -> false
+    | value ->
+      match value.Trim().ToLowerInvariant() with
+      | "1"
+      | "true"
+      | "yes"
+      | "on" -> true
+      | _ -> false
+
+  let private logBuildDiagnostic
+    (phase: string)
+    (filePath: string)
+    (elapsed: TimeSpan)
+    =
+    if buildDiagnosticsEnabled then
+      Console.WriteLine(
+        $"Build diagnostics | {phase,-14} | {elapsed.TotalMilliseconds,8:F1} ms | {filePath}"
+      )
+
+  let private buildProjectFile<'valueExt when 'valueExt: comparison>
+    (config: TypeCheckingConfig<'valueExt>)
+    (project: ProjectBuildConfiguration)
+    (file: FileBuildConfiguration, index: int)
+    : State<
+        TypeCheckedExpr<'valueExt> * TypeValue<'valueExt>,
+        Unit,
+        TypeCheckContext<'valueExt> * TypeCheckState<'valueExt>,
+        Errors<Location>
+       > =
+    state {
+      let parseStopwatch = Stopwatch.StartNew()
+
+      let parseResult =
+        file
+        |> parseFile
+        |> sum.WithErrorContext(fun () ->
+          $"...while parsing {file.FileName.Path}")
+
+      parseStopwatch.Stop()
+      logBuildDiagnostic "parse" file.FileName.Path parseStopwatch.Elapsed
+
+      let! ParserResult(program, _) = parseResult |> state.OfSum
+
+      let! ctx, st = state.GetState()
+
+      let scopeHintStopwatch = Stopwatch.StartNew()
+
+      let scopePrefixHints =
+        TypeCheckState.ComputeScopePrefixHints ctx st
+
+      scopeHintStopwatch.Stop()
+
+      logBuildDiagnostic
+        "scope-hints"
+        file.FileName.Path
+        scopeHintStopwatch.Elapsed
+
+      let st =
+        { st with ScopePrefixHints = scopePrefixHints }
+
+      clearTypeCheckCategoryDiagnostics file.FileName.Path
+      clearTypeCheckMemoDiagnostics file.FileName.Path
+
+      let typecheckStopwatch = Stopwatch.StartNew()
+
+      let typecheckResult =
+        Expr.TypeCheck config None program
+        |> State.Run(ctx, st)
+        |> sum.MapError fst
+        |> sum.WithErrorContext(fun () ->
+          $"...while typechecking {file.FileName.Path}")
+
+      typecheckStopwatch.Stop()
+      logBuildDiagnostic "typecheck" file.FileName.Path typecheckStopwatch.Elapsed
+
+      renderTypeCheckCategoryDiagnostics file.FileName.Path
+      |> List.iter (fun (line: string) -> Console.WriteLine(line))
+
+      renderTypeCheckMemoDiagnostics file.FileName.Path
+      |> List.iter (fun (line: string) -> Console.WriteLine(line))
+
+      clearCurrentTypeCheckCategoryFilePath ()
+
+      let! (typeCheckedExpr, ctx'), st' = typecheckResult |> state.OfSum
+
+      let typeValue = typeCheckedExpr.Type
+
+      if index < project.Files.Tail.Length then
+        match typeValue with
+        | TypeValue.Primitive({ value = PrimitiveType.Unit }) ->
+          return ()
+        | _ ->
+          return!
+            state.Throw(
+              Errors.Singleton Location.Unknown (fun () ->
+                $"Expected returned unit type for {file.FileName.Path} but got {typeValue}. Intermediate files in the project should always return `()`, otherwise we discard possibly useful information by accident!")
+            )
+
+      let st' = st' |> Option.defaultValue st
+      do! state.SetState(replaceWith (ctx', st'))
+
+      return typeCheckedExpr, typeValue
+    }
 
   type ProjectBuildConfiguration with
     static member BuildCachedWithFileOutputs<'valueExt
@@ -179,58 +320,21 @@ module ProjectModel =
       =
       sum {
         let! expressionsWithTypes, finalContext, finalState =
-          cache.Fold project.Files (fun (file, index) ->
-            state {
-              let! ParserResult(program, _) =
-                file
-                |> ProjectBuildConfiguration.ParseFile
-                |> sum.WithErrorContext(fun () ->
-                  $"...while parsing {file.FileName.Path}")
-                |> state.OfSum
-
-              let! ctx, st = state.GetState()
-
-              let scopePrefixHints =
-                TypeCheckState.ComputeScopePrefixHints ctx st
-
-              let st =
-                { st with ScopePrefixHints = scopePrefixHints }
-
-              let! (typeCheckedExpr, ctx'), st' =
-                Expr.TypeCheck config None program
-                |> State.Run(ctx, st)
-                |> sum.MapError fst
-                |> sum.WithErrorContext(fun () ->
-                  $"...while typechecking {file.FileName.Path}")
-                |> state.OfSum
-
-              let typeValue = typeCheckedExpr.Type
-
-              if index < project.Files.Tail.Length then
-                match typeValue with
-                | TypeValue.Primitive({ value = PrimitiveType.Unit }) ->
-                  return ()
-                | _ ->
-                  return!
-                    state.Throw(
-                      Errors.Singleton Location.Unknown (fun () ->
-                        $"Expected returned unit type for {file.FileName.Path} but got {typeValue}. Intermediate files in the project should always return `()`, otherwise we discard possibly useful information by accident!")
-                    )
-
-              let st' = st' |> Option.defaultValue st
-              do! state.SetState(replaceWith (ctx', st'))
-
-              typeCheckedExpr, typeValue
-            })
+          cache.Fold project.Files (buildProjectFile config project)
 
         let expressionsWithTypesInOrder =
           expressionsWithTypes |> NonEmptyList.rev |> NonEmptyList.ToList
+
+        let inlayHintStopwatch = Stopwatch.StartNew()
 
         let! finalState =
           TypeCheckState.InstantiateInlayHints config
           |> State.Run(finalContext, finalState)
           |> sum.MapError fst
           |> sum.Map fst
+
+        inlayHintStopwatch.Stop()
+        logBuildDiagnostic "inlay-hints" project.Files.Head.FileName.Path inlayHintStopwatch.Elapsed
 
         let filesInOrder = project.Files |> NonEmptyList.ToList
 
@@ -274,58 +378,21 @@ module ProjectModel =
       =
       sum {
         let! expressionsWithTypes, finalContext, finalState =
-          cache.FoldStreaming project.Files (fun (file, index) ->
-            state {
-              let! ParserResult(program, _) =
-                file
-                |> ProjectBuildConfiguration.ParseFile
-                |> sum.WithErrorContext(fun () ->
-                  $"...while parsing {file.FileName.Path}")
-                |> state.OfSum
-
-              let! ctx, st = state.GetState()
-
-              let scopePrefixHints =
-                TypeCheckState.ComputeScopePrefixHints ctx st
-
-              let st =
-                { st with ScopePrefixHints = scopePrefixHints }
-
-              let! (typeCheckedExpr, ctx'), st' =
-                Expr.TypeCheck config None program
-                |> State.Run(ctx, st)
-                |> sum.MapError fst
-                |> sum.WithErrorContext(fun () ->
-                  $"...while typechecking {file.FileName.Path}")
-                |> state.OfSum
-
-              let typeValue = typeCheckedExpr.Type
-
-              if index < project.Files.Tail.Length then
-                match typeValue with
-                | TypeValue.Primitive({ value = PrimitiveType.Unit }) ->
-                  return ()
-                | _ ->
-                  return!
-                    state.Throw(
-                      Errors.Singleton Location.Unknown (fun () ->
-                        $"Expected returned unit type for {file.FileName.Path} but got {typeValue}. Intermediate files in the project should always return `()`, otherwise we discard possibly useful information by accident!")
-                    )
-
-              let st' = st' |> Option.defaultValue st
-              do! state.SetState(replaceWith (ctx', st'))
-
-              typeCheckedExpr, typeValue
-            }) onFileBuilt
+          cache.FoldStreaming project.Files (buildProjectFile config project) onFileBuilt
 
         let expressionsWithTypesInOrder =
           expressionsWithTypes |> NonEmptyList.rev |> NonEmptyList.ToList
+
+        let inlayHintStopwatch = Stopwatch.StartNew()
 
         let! finalState =
           TypeCheckState.InstantiateInlayHints config
           |> State.Run(finalContext, finalState)
           |> sum.MapError fst
           |> sum.Map fst
+
+        inlayHintStopwatch.Stop()
+        logBuildDiagnostic "inlay-hints" project.Files.Head.FileName.Path inlayHintStopwatch.Elapsed
 
         let filesInOrder = project.Files |> NonEmptyList.ToList
 
@@ -362,35 +429,16 @@ module ProjectModel =
           Errors<Location>
          >
       =
-      sum {
-        let initialLocation = Location.Initial file.FileName.Path
+      parseFile file
 
-        let! ParserResult(actual, _) =
-          tokens
-          |> Parser.Run(file.Content() |> Seq.toList, initialLocation)
-          |> sum.MapError fst
-
-        let! (parserResult:
-          ParserResult<
-            Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>,
-            LocalizedToken,
-            Location,
-            Errors<Location>
-           >) =
-          (Parser.Expr.program ()).Parser
-          |> Parser.Run(actual, initialLocation)
-          |> sum.MapError fst
-
-        parserResult
-      }
-
-    static member TypeCheckSingleFile<'valueExt when 'valueExt: comparison>
+    static member TypeCheckSingleFileWithOutput<'valueExt when 'valueExt: comparison>
       (config: TypeCheckingConfig<'valueExt>)
       (cache: ProjectCache<'valueExt>)
       (project: ProjectBuildConfiguration)
       (targetFilePath: string)
       (targetFileContent: string)
       : Sum<
+          FileTypeCheckedOutput<'valueExt> *
           TypeCheckContext<'valueExt> *
           TypeCheckState<'valueExt>,
           Errors<Location> *
@@ -469,12 +517,42 @@ module ProjectModel =
             |> State.Run(predecessorCtx, st)
 
           match typecheckResult with
-          | Left((_typeCheckedExpr, ctx'), stOpt) ->
+          | Left((typeCheckedExpr, ctx'), stOpt) ->
             let st' = stOpt |> Option.defaultValue st
-            Left(ctx', st')
+            Left(
+              { File = FileBuildConfiguration.FromFile(targetFilePath, targetFileContent)
+                Expr = typeCheckedExpr
+                TypeValue = typeCheckedExpr.Type },
+              ctx',
+              st'
+            )
           | Right(errors, partialStOpt) ->
             let partialSt = partialStOpt |> Option.defaultValue st
             Right(errors, Some partialSt)
+
+    static member TypeCheckSingleFile<'valueExt when 'valueExt: comparison>
+      (config: TypeCheckingConfig<'valueExt>)
+      (cache: ProjectCache<'valueExt>)
+      (project: ProjectBuildConfiguration)
+      (targetFilePath: string)
+      (targetFileContent: string)
+      : Sum<
+          TypeCheckContext<'valueExt> *
+          TypeCheckState<'valueExt>,
+          Errors<Location> *
+          Option<TypeCheckState<'valueExt>>
+         >
+      =
+      match
+        ProjectBuildConfiguration.TypeCheckSingleFileWithOutput
+          config
+          cache
+          project
+          targetFilePath
+          targetFileContent
+      with
+      | Left(_fileOutput, ctx, st) -> Left(ctx, st)
+      | Right errors -> Right errors
 
     static member BuildCached<'valueExt when 'valueExt: comparison>
       (config: TypeCheckingConfig<'valueExt>)

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/Expr.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/Expr.fs
@@ -84,236 +84,239 @@ module Expr =
 
         // let error e = Errors.Singleton loc0 e
 
-        state {
-          let! expr, ctx =
-            state {
-              match t.Expr with
-              | ExprRec.Primitive(p) ->
-                return!
-                  Expr.TypeCheckPrimitive
-                    (typeCheckExpr, t.Location)
-                    context_t
-                    p
+        timeTypeCheckCategory "general typecheck" loc0
+          (state {
+            let! expr, ctx =
+              state {
+                match t.Expr with
+                | ExprRec.Primitive(p) ->
+                  return!
+                    Expr.TypeCheckPrimitive
+                      (typeCheckExpr, t.Location)
+                      context_t
+                      p
 
-              | ExprRec.FromValue({ Value = v
-                                    ValueType = t_v
-                                    ValueKind = k }) ->
-                let! ctx = state.GetContext()
+                | ExprRec.FromValue({ Value = v
+                                      ValueType = t_v
+                                      ValueKind = k }) ->
+                  let! ctx = state.GetContext()
 
-                return
-                  TypeCheckedExpr.FromValue(v, t_v, k, t.Location, t.Scope), ctx
+                  return
+                    TypeCheckedExpr.FromValue(v, t_v, k, t.Location, t.Scope), ctx
 
-              | ExprRec.Lookup({ Id = id }) ->
-                return!
-                  Expr.TypeCheckLookup
-                    (typeCheckExpr, t.Location)
-                    context_t
-                    { Id = id }
+                | ExprRec.Lookup({ Id = id }) ->
+                  return!
+                    Expr.TypeCheckLookup
+                      (typeCheckExpr, t.Location)
+                      context_t
+                      { Id = id }
 
-              | ExprRec.Apply apply ->
-                return! Expr.TypeCheckApply config typeCheckExpr context_t apply
-              | ExprRec.If if_expr ->
-                return! Expr.TypeCheckIf config typeCheckExpr context_t if_expr
+                | ExprRec.Apply apply ->
+                  return! Expr.TypeCheckApply config typeCheckExpr context_t apply
+                | ExprRec.If if_expr ->
+                  return! Expr.TypeCheckIf config typeCheckExpr context_t if_expr
 
-              | ExprRec.Let let_expr ->
-                return!
-                  Expr.TypeCheckLet
-                    config
-                    typeCheckExpr
-                    context_t
-                    (t.Location, let_expr)
+                | ExprRec.Let let_expr ->
+                  return!
+                    Expr.TypeCheckLet
+                      config
+                      typeCheckExpr
+                      context_t
+                      (t.Location, let_expr)
 
-              | ExprRec.Do do_expr ->
-                return! Expr.TypeCheckDo config typeCheckExpr context_t do_expr
+                | ExprRec.Do do_expr ->
+                  return! Expr.TypeCheckDo config typeCheckExpr context_t do_expr
 
-              | ExprRec.Lambda(lambda) ->
-                return!
-                  Expr<'T, 'Id, 'valueExt>.TypeCheckLambda
-                    config
-                    typeCheckExpr
-                    context_t
-                    (t.Location, lambda)
-              | ExprRec.RecordCons record_cons_expr ->
-                return!
-                  Expr.TypeCheckRecordCons
-                    config
-                    typeCheckExpr
-                    context_t
-                    record_cons_expr
+                | ExprRec.Lambda(lambda) ->
+                  return!
+                    Expr<'T, 'Id, 'valueExt>.TypeCheckLambda
+                      config
+                      typeCheckExpr
+                      context_t
+                      (t.Location, lambda)
+                | ExprRec.RecordCons record_cons_expr ->
+                  return!
+                    Expr.TypeCheckRecordCons
+                      config
+                      typeCheckExpr
+                      context_t
+                      record_cons_expr
 
-              | ExprRec.RecordWith record_with_expr ->
-                return!
-                  Expr.TypeCheckRecordWith
-                    config
-                    typeCheckExpr
-                    context_t
-                    record_with_expr
+                | ExprRec.RecordWith record_with_expr ->
+                  return!
+                    Expr.TypeCheckRecordWith
+                      config
+                      typeCheckExpr
+                      context_t
+                      record_with_expr
 
-              | ExprRec.TupleCons tuple_cons_expr ->
-                return!
-                  Expr.TypeCheckTupleCons
-                    config
-                    typeCheckExpr
-                    context_t
-                    tuple_cons_expr
+                | ExprRec.TupleCons tuple_cons_expr ->
+                  return!
+                    Expr.TypeCheckTupleCons
+                      config
+                      typeCheckExpr
+                      context_t
+                      tuple_cons_expr
 
-              | ExprRec.SumCons sum_cons_expr ->
-                return!
-                  Expr.TypeCheckSumCons
-                    config
-                    (typeCheckExpr, t.Location)
-                    context_t
-                    sum_cons_expr
+                | ExprRec.SumCons sum_cons_expr ->
+                  return!
+                    Expr.TypeCheckSumCons
+                      config
+                      (typeCheckExpr, t.Location)
+                      context_t
+                      sum_cons_expr
 
-              | ExprRec.RecordDes record_des_expr ->
-                return!
-                  Expr.TypeCheckRecordDes
-                    config
-                    typeCheckExpr
-                    context_t
-                    record_des_expr
+                | ExprRec.RecordDes record_des_expr ->
+                  return!
+                    Expr.TypeCheckRecordDes
+                      config
+                      typeCheckExpr
+                      context_t
+                      record_des_expr
 
-              | ExprRec.TupleDes tuple_des_expr ->
-                return!
-                  Expr.TypeCheckTupleDes typeCheckExpr context_t tuple_des_expr
+                | ExprRec.TupleDes tuple_des_expr ->
+                  return!
+                    Expr.TypeCheckTupleDes typeCheckExpr context_t tuple_des_expr
 
-              | ExprRec.UnionDes union_des_handlers ->
-                return!
-                  Expr.TypeCheckUnionDes
-                    config
-                    typeCheckExpr
-                    context_t
-                    union_des_handlers
+                | ExprRec.UnionDes union_des_handlers ->
+                  return!
+                    Expr.TypeCheckUnionDes
+                      config
+                      typeCheckExpr
+                      context_t
+                      union_des_handlers
 
-              | ExprRec.SumDes sum_des_expr ->
-                return!
-                  Expr.TypeCheckSumDes
-                    config
-                    typeCheckExpr
-                    context_t
-                    sum_des_expr
+                | ExprRec.SumDes sum_des_expr ->
+                  return!
+                    Expr.TypeCheckSumDes
+                      config
+                      typeCheckExpr
+                      context_t
+                      sum_des_expr
 
-              | ExprRec.TypeLet type_let_expr ->
-                return!
-                  Expr.TypeCheckTypeLet
-                    config
-                    typeCheckExpr
-                    context_t
-                    type_let_expr
+                | ExprRec.TypeLet type_let_expr ->
+                  return!
+                    Expr.TypeCheckTypeLet
+                      config
+                      typeCheckExpr
+                      context_t
+                      type_let_expr
 
-              | ExprRec.TypeLambda type_lambda_expr ->
-                return!
-                  Expr.TypeCheckTypeLambda
-                    typeCheckExpr
-                    context_t
-                    type_lambda_expr
+                | ExprRec.TypeLambda type_lambda_expr ->
+                  return!
+                    Expr.TypeCheckTypeLambda
+                      typeCheckExpr
+                      context_t
+                      type_lambda_expr
 
-              | ExprRec.TypeApply type_apply_expr ->
-                return!
-                  Expr.TypeCheckTypeApply
-                    config
-                    typeCheckExpr
-                    context_t
-                    type_apply_expr
+                | ExprRec.TypeApply type_apply_expr ->
+                  return!
+                    Expr.TypeCheckTypeApply
+                      config
+                      typeCheckExpr
+                      context_t
+                      type_apply_expr
 
-              | ExprRec.EntityDes _
-              | ExprRec.RelationDes _
-              | ExprRec.EntitiesDes _
-              | ExprRec.RelationsDes _
-              | ExprRec.RelationLookupDes _ ->
-                return!
-                  Errors.Singleton loc0 (fun () ->
-                    $"Error: unexpected expression pattern schema entity and entities (should not occur, are only constructed as record destructuring) ")
-                  |> state.Throw
-              | ExprRec.Query q ->
-                let! q, t, k, ctx =
-                  Expr.TypeCheckQuery
-                    config
-                    typeCheckExpr
-                    context_t
-                    Map.empty
-                    Map.empty
-                    q
+                | ExprRec.EntityDes _
+                | ExprRec.RelationDes _
+                | ExprRec.EntitiesDes _
+                | ExprRec.RelationsDes _
+                | ExprRec.RelationLookupDes _ ->
+                  return!
+                    Errors.Singleton loc0 (fun () ->
+                      $"Error: unexpected expression pattern schema entity and entities (should not occur, are only constructed as record destructuring) ")
+                    |> state.Throw
+                | ExprRec.Query q ->
+                  let! q, t, k, ctx =
+                    Expr.TypeCheckQuery
+                      config
+                      typeCheckExpr
+                      context_t
+                      Map.empty
+                      Map.empty
+                      q
 
-                return TypeCheckedExpr.Query(q, t, k), ctx
+                  return TypeCheckedExpr.Query(q, t, k), ctx
 
-              | ExprRec.View v ->
-                let! result, ctx =
-                  Expr.TypeCheckView
-                    config
-                    typeCheckExpr
-                    context_t
-                    (loc0, v)
+                | ExprRec.View v ->
+                  let! result, ctx =
+                    Expr.TypeCheckView
+                      config
+                      typeCheckExpr
+                      context_t
+                      (loc0, v)
 
-                return result, ctx
+                  return result, ctx
 
-              | ExprRec.Co c ->
-                let! result, ctx =
-                  Expr.TypeCheckCo
-                    config
-                    typeCheckExpr
-                    context_t
-                    (loc0, c)
+                | ExprRec.Co c ->
+                  let! result, ctx =
+                    Expr.TypeCheckCo
+                      config
+                      typeCheckExpr
+                      context_t
+                      (loc0, c)
 
-                return result, ctx
+                  return result, ctx
 
-              | ExprRec.CoOp op ->
-                // Resolve Co::name to get the type from extension registration,
-                // but produce a CoOp node instead of a Lookup node
-                let id = Identifier.FullyQualified([ "Co" ], op.Name)
-                let! result, ctx =
-                  Expr.TypeCheckLookup
-                    (typeCheckExpr, t.Location)
-                    context_t
-                    { Id = id }
-                return
-                  { TypeCheckedExpr.Expr = TypeCheckedExprRec.CoOp op
-                    TypeCheckedExpr.Type = result.Type
-                    TypeCheckedExpr.Kind = result.Kind
-                    TypeCheckedExpr.Location = result.Location
-                    TypeCheckedExpr.Scope = result.Scope },
-                  ctx
+                | ExprRec.CoOp op ->
+                  // Resolve Co::name to get the type from extension registration,
+                  // but produce a CoOp node instead of a Lookup node
+                  let id = Identifier.FullyQualified([ "Co" ], op.Name)
+                  let! result, ctx =
+                    Expr.TypeCheckLookup
+                      (typeCheckExpr, t.Location)
+                      context_t
+                      { Id = id }
 
-              | ExprRec.ViewOp op ->
-                // Resolve View::name to get the type from extension registration,
-                // but produce a ViewOp node instead of a Lookup node
-                let id = Identifier.FullyQualified([ "View" ], op.Name)
-                let! result, ctx =
-                  Expr.TypeCheckLookup
-                    (typeCheckExpr, t.Location)
-                    context_t
-                    { Id = id }
-                return
-                  { TypeCheckedExpr.Expr = TypeCheckedExprRec.ViewOp op
-                    TypeCheckedExpr.Type = result.Type
-                    TypeCheckedExpr.Kind = result.Kind
-                    TypeCheckedExpr.Location = result.Location
-                    TypeCheckedExpr.Scope = result.Scope },
-                  ctx
+                  return
+                    { TypeCheckedExpr.Expr = TypeCheckedExprRec.CoOp op
+                      TypeCheckedExpr.Type = result.Type
+                      TypeCheckedExpr.Kind = result.Kind
+                      TypeCheckedExpr.Location = result.Location
+                      TypeCheckedExpr.Scope = result.Scope },
+                    ctx
 
-              | ExprRec.RecoveredSyntaxError err ->
-                return!
-                  Errors.Singleton err.ErrorLocation (fun () -> err.ErrorMessage)
-                  |> state.Throw
+                | ExprRec.ViewOp op ->
+                  // Resolve View::name to get the type from extension registration,
+                  // but produce a ViewOp node instead of a Lookup node
+                  let id = Identifier.FullyQualified([ "View" ], op.Name)
+                  let! result, ctx =
+                    Expr.TypeCheckLookup
+                      (typeCheckExpr, t.Location)
+                      context_t
+                      { Id = id }
 
-              | ExprRec.ErrorDanglingRecordDes({ Expr = record_expr; Field = _field }) ->
-                return!
-                  Expr.TypeCheckErrorDanglingRecordDes
-                    typeCheckExpr
-                    context_t
-                    record_expr
-                    loc0
+                  return
+                    { TypeCheckedExpr.Expr = TypeCheckedExprRec.ViewOp op
+                      TypeCheckedExpr.Type = result.Type
+                      TypeCheckedExpr.Kind = result.Kind
+                      TypeCheckedExpr.Location = result.Location
+                      TypeCheckedExpr.Scope = result.Scope },
+                    ctx
 
-              | ExprRec.ErrorDanglingScopedIdentifier({ PrefixParts = prefixParts }) ->
-                return!
-                  Expr.TypeCheckErrorDanglingScopedIdentifier
-                    prefixParts
-                    loc0
-            }
+                | ExprRec.RecoveredSyntaxError err ->
+                  return!
+                    Errors.Singleton err.ErrorLocation (fun () -> err.ErrorMessage)
+                    |> state.Throw
 
-          let! expr =
-            expr
-            |> TypeCheckedExpr.InstantiateSyntheticVars config typeCheckExpr
+                | ExprRec.ErrorDanglingRecordDes({ Expr = record_expr; Field = _field }) ->
+                  return!
+                    Expr.TypeCheckErrorDanglingRecordDes
+                      typeCheckExpr
+                      context_t
+                      record_expr
+                      loc0
 
-          return expr, ctx
-        }
+                | ExprRec.ErrorDanglingScopedIdentifier({ PrefixParts = prefixParts }) ->
+                  return!
+                    Expr.TypeCheckErrorDanglingScopedIdentifier
+                      prefixParts
+                      loc0
+              }
+
+            let! expr =
+              expr
+              |> TypeCheckedExpr.InstantiateSyntheticVars config typeCheckExpr
+
+            return expr, ctx
+          })

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/TypeEval.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/TypeEval.fs
@@ -82,7 +82,7 @@ module Eval =
               |> state.AllMap
 
             return TypeQueryRow.Record qs
-        }
+          }
 
   and TypeExpr<'valueExt> with
     static member EvalAsSymbol<'ve when 've: comparison>
@@ -167,7 +167,8 @@ module Eval =
       (config: TypeCheckingConfig<'ve>)
       : TypeExprEval<'ve> =
       fun typeCheckExpr n loc0 t ->
-        state {
+        let evalState =
+          state {
           let { QueryTypeSymbol = _query_type_symbol
                 MkQueryType = _mk_query_type
                 MkListType = mk_list_type } =
@@ -1347,4 +1348,17 @@ module Eval =
             return
               TypeValue.QueryTypeFunction, Kind.Arrow(Kind.QueryRow, Kind.Star)
 
+          }
+
+        state {
+          let! ctx = state.GetContext()
+          let! stateSnapshot = state.GetState()
+
+          recordTypeCheckMemoDiagnostic
+            "type eval"
+            loc0
+            (n, t)
+            (n, t, ctx, stateSnapshot.VarsVersion)
+
+          return! timeTypeCheckCategory "type eval" loc0 evalState
         }

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/Unification/Unification.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/Unification/Unification.fs
@@ -20,6 +20,268 @@ module Unification =
   open Ballerina.DSL.Next.Types.TypeChecker.Patterns
   open Ballerina.StdLib.OrderPreservingMap
   open Ballerina.Cat.Collections.OrderedMap
+  open System.Collections.Concurrent
+  open System.Collections.Generic
+  open System.IO
+  open System.Threading
+  open Ballerina.Stackless.State.WithError.StacklessStateWithError
+
+  let private typeCheckCategoryDiagnosticsEnabled =
+    match Environment.GetEnvironmentVariable("BISE_TYPECHECK_CATEGORY_DIAGNOSTICS") with
+    | null -> false
+    | value ->
+      match value.Trim().ToLowerInvariant() with
+      | "1"
+      | "true"
+      | "yes"
+      | "on" -> true
+      | _ -> false
+
+  let private typeCheckMemoDiagnosticsEnabled =
+    match Environment.GetEnvironmentVariable("BISE_TYPECHECK_MEMO_DIAGNOSTICS") with
+    | null -> false
+    | value ->
+      match value.Trim().ToLowerInvariant() with
+      | "1"
+      | "true"
+      | "yes"
+      | "on" -> true
+      | _ -> false
+
+  let private anyTypeCheckDiagnosticsEnabled =
+    typeCheckCategoryDiagnosticsEnabled || typeCheckMemoDiagnosticsEnabled
+
+  let private typeCheckCategoryTotals =
+    ConcurrentDictionary<string * string, int64 * int64>()
+
+  type private TypeCheckMemoDiagnosticCounter() =
+    let syncRoot = obj ()
+    let rawInputs = HashSet<struct(int * int)>()
+    let contextualInputs = HashSet<struct(int * int)>()
+    let mutable totalCalls = 0L
+
+    member _.Record(rawInputKey: struct(int * int), contextualInputKey: struct(int * int)) =
+      lock syncRoot (fun () ->
+        totalCalls <- totalCalls + 1L
+        rawInputs.Add(rawInputKey) |> ignore
+        contextualInputs.Add(contextualInputKey) |> ignore)
+
+    member _.Snapshot() =
+      lock syncRoot (fun () -> totalCalls, rawInputs.Count, contextualInputs.Count)
+
+  let private typeCheckMemoDiagnostics =
+    ConcurrentDictionary<string * string, TypeCheckMemoDiagnosticCounter>()
+
+  type private TypeCheckCategoryFrame =
+    { Category: string
+      FilePath: string
+      StartTimestamp: int64
+      mutable NestedElapsedTicks: int64 }
+
+  let private typeCheckCategoryStack =
+    AsyncLocal<TypeCheckCategoryFrame list>()
+
+  let private currentTypeCheckCategoryFilePath =
+    AsyncLocal<string>()
+
+  let private normalizeTypeCheckCategoryFilePath (filePath: string) =
+    if String.IsNullOrWhiteSpace filePath then
+      filePath
+    else
+      Path.GetFileName filePath
+
+  let private resolveTypeCheckCategoryFilePath (location: Location) =
+    let currentFilePath = currentTypeCheckCategoryFilePath.Value
+
+    if String.IsNullOrWhiteSpace currentFilePath then
+      normalizeTypeCheckCategoryFilePath location.File
+    else
+      currentFilePath
+
+  let private makeTypeCheckMemoDiagnosticKey (value: 'a) =
+    struct (hash value, hash (value, 0x9E3779B9))
+
+  let addTypeCheckCategoryTiming
+    (category: string)
+    (filePath: string)
+    (elapsed: TimeSpan)
+    =
+    if typeCheckCategoryDiagnosticsEnabled then
+      let normalizedFilePath = normalizeTypeCheckCategoryFilePath filePath
+
+      typeCheckCategoryTotals.AddOrUpdate(
+        (normalizedFilePath, category),
+        (elapsed.Ticks, 1L),
+        fun _ (ticks, count) -> ticks + elapsed.Ticks, count + 1L
+      )
+      |> ignore
+
+  let recordTypeCheckMemoDiagnostic
+    (operation: string)
+    (location: Location)
+    (rawInput: 'rawInput)
+    (contextualInput: 'contextualInput)
+    =
+    if typeCheckMemoDiagnosticsEnabled then
+      let filePath = resolveTypeCheckCategoryFilePath location
+
+      let counter =
+        typeCheckMemoDiagnostics.GetOrAdd(
+          (filePath, operation),
+          fun _ -> TypeCheckMemoDiagnosticCounter()
+        )
+
+      counter.Record(
+        makeTypeCheckMemoDiagnosticKey rawInput,
+        makeTypeCheckMemoDiagnosticKey contextualInput
+      )
+
+  let private pushTypeCheckCategoryFrame (category: string) (location: Location) =
+    let frame =
+      { Category = category
+        FilePath = resolveTypeCheckCategoryFilePath location
+        StartTimestamp = Diagnostics.Stopwatch.GetTimestamp()
+        NestedElapsedTicks = 0L }
+
+    let stack =
+      let existing = typeCheckCategoryStack.Value
+
+      if obj.ReferenceEquals(existing, null) then
+        []
+      else
+        existing
+
+    typeCheckCategoryStack.Value <- frame :: stack
+    frame
+
+  let private popTypeCheckCategoryFrame (frame: TypeCheckCategoryFrame) =
+    let totalElapsedTicks =
+      Diagnostics.Stopwatch.GetElapsedTime(frame.StartTimestamp).Ticks
+
+    let exclusiveElapsedTicks = max 0L (totalElapsedTicks - frame.NestedElapsedTicks)
+
+    addTypeCheckCategoryTiming
+      frame.Category
+      frame.FilePath
+      (TimeSpan.FromTicks exclusiveElapsedTicks)
+
+    match typeCheckCategoryStack.Value with
+    | current :: remaining when obj.ReferenceEquals(current, frame) ->
+      typeCheckCategoryStack.Value <- remaining
+
+      match remaining with
+      | parent :: _ ->
+        parent.NestedElapsedTicks <- parent.NestedElapsedTicks + totalElapsedTicks
+      | [] -> ()
+    | _ -> ()
+
+  let timeTypeCheckCategory<'result, 'context, 'state, 'error>
+    (category: string)
+    (location: Location)
+    (computation: State<'result, 'context, 'state, 'error>)
+    : State<'result, 'context, 'state, 'error> =
+    if not typeCheckCategoryDiagnosticsEnabled then
+      computation
+    else
+      State(
+        FreeNode.fromStep (fun (context, state) ->
+          let frame = pushTypeCheckCategoryFrame category location
+
+          try
+            computation.run (context, state)
+          finally
+            popTypeCheckCategoryFrame frame)
+      )
+
+  let clearTypeCheckCategoryDiagnostics (filePath: string) =
+    if anyTypeCheckDiagnosticsEnabled then
+      let normalizedFilePath = normalizeTypeCheckCategoryFilePath filePath
+
+      currentTypeCheckCategoryFilePath.Value <- normalizedFilePath
+
+      if typeCheckCategoryDiagnosticsEnabled then
+        typeCheckCategoryTotals.Keys
+        |> Seq.filter (fun (trackedFilePath, _category) -> trackedFilePath = normalizedFilePath)
+        |> Seq.iter (fun key -> typeCheckCategoryTotals.TryRemove(key) |> ignore)
+
+  let clearTypeCheckMemoDiagnostics (filePath: string) =
+    if typeCheckMemoDiagnosticsEnabled then
+      let normalizedFilePath = normalizeTypeCheckCategoryFilePath filePath
+
+      typeCheckMemoDiagnostics.Keys
+      |> Seq.filter (fun (trackedFilePath, _operation) -> trackedFilePath = normalizedFilePath)
+      |> Seq.iter (fun key -> typeCheckMemoDiagnostics.TryRemove(key) |> ignore)
+
+  let clearCurrentTypeCheckCategoryFilePath () =
+    if anyTypeCheckDiagnosticsEnabled then
+      currentTypeCheckCategoryFilePath.Value <- null
+
+  let renderTypeCheckCategoryDiagnostics (filePath: string) : string list =
+    if not typeCheckCategoryDiagnosticsEnabled then
+      []
+    else
+      let normalizedFilePath = normalizeTypeCheckCategoryFilePath filePath
+
+      let renderedLines =
+        typeCheckCategoryTotals
+        |> Seq.choose (fun kvp ->
+          let trackedFilePath, category = kvp.Key
+          let ticks, count = kvp.Value
+
+          if trackedFilePath <> normalizedFilePath then
+            None
+          else
+            let totalMs = TimeSpan.FromTicks(ticks).TotalMilliseconds
+            let avgMs = if count = 0L then 0.0 else totalMs / float count
+
+            Some(
+              totalMs,
+              $"Typecheck category summary  | total {totalMs,8:F1} ms | avg {avgMs,8:F3} ms | calls {count,8} | {trackedFilePath} | {category}"
+            ))
+        |> Seq.sortByDescending fst
+        |> Seq.map snd
+        |> List.ofSeq
+
+      renderedLines
+
+  let renderTypeCheckMemoDiagnostics (filePath: string) : string list =
+    if not typeCheckMemoDiagnosticsEnabled then
+      []
+    else
+      let normalizedFilePath = normalizeTypeCheckCategoryFilePath filePath
+
+      typeCheckMemoDiagnostics
+      |> Seq.choose (fun kvp ->
+        let trackedFilePath, operation = kvp.Key
+
+        if trackedFilePath <> normalizedFilePath then
+          None
+        else
+          let totalCalls, rawDistinctCount, contextualDistinctCount =
+            kvp.Value.Snapshot()
+
+          let rawReusePct =
+            if totalCalls = 0L then
+              0.0
+            else
+              (1.0 - (float rawDistinctCount / float totalCalls)) * 100.0
+
+          let contextualReusePct =
+            if totalCalls = 0L then
+              0.0
+            else
+              (1.0 - (float contextualDistinctCount / float totalCalls)) * 100.0
+
+          let rawReuseLabel = $"{rawReusePct:F2}%%"
+          let contextualReuseLabel = $"{contextualReusePct:F2}%%"
+
+          Some(
+            totalCalls,
+            $"Typecheck memo summary      | total {totalCalls,8} | raw distinct {rawDistinctCount,8} | contextual distinct {contextualDistinctCount,8} | raw reuse {rawReuseLabel} | contextual reuse {contextualReuseLabel} | {trackedFilePath} | {operation}"
+          ))
+      |> Seq.sortByDescending fst
+      |> Seq.map snd
+      |> List.ofSeq
 
 
   type TypeExpr<'ve> with
@@ -663,7 +925,8 @@ module Unification =
         bind_un_s |> TypeValue.EquivalenceClassesOp<_, 'valueExt> loc0
 
 
-      state {
+      let unifyState =
+        state {
         let! ctx = state.GetContext()
 
         match left, right with
@@ -908,7 +1171,9 @@ module Unification =
             (fun () -> $"Cannot unify types: {left} and {right}")
             |> error
             |> state.Throw
-      }
+        }
+
+      timeTypeCheckCategory "type unify" loc0 unifyState
 
 
   and SymbolicTypeApplication<'ve> with
@@ -929,7 +1194,8 @@ module Unification =
 
       let (==) a b = TypeValue.Unify(loc0, a, b)
 
-      state {
+      let unifyState =
+        state {
         match left, right with
         | SymbolicTypeApplication.FromQueryRow id1,
           SymbolicTypeApplication.FromQueryRow id2 when id1 = id2 ->
@@ -948,7 +1214,9 @@ module Unification =
               $"Cannot unify type applications: {left} and {right}")
             |> error
             |> state.Throw
-      }
+        }
+
+      timeTypeCheckCategory "type unify" loc0 unifyState
 
 
   and TypeQueryRow<'ve> with
@@ -970,7 +1238,8 @@ module Unification =
       let (==) a b = TypeValue.Unify(loc0, a, b)
       let (===) a b = TypeQueryRow.Unify(loc0, a, b)
 
-      state {
+      let unifyState =
+        state {
         match left, right with
         | TypeQueryRow.PrimaryKey k1, TypeQueryRow.PrimaryKey k2 ->
           return! k1 == k2
@@ -1011,7 +1280,9 @@ module Unification =
             (fun () -> $"Cannot unify query row types: {left} and {right}")
             |> error
             |> state.Throw
-      }
+        }
+
+      timeTypeCheckCategory "type unify" loc0 unifyState
 
 
   type SymbolicTypeApplication<'ve> with
@@ -1130,7 +1401,8 @@ module Unification =
            >
       =
       fun typeEval loc0 t ->
-        state {
+        let instantiateState =
+          state {
           if TypeValue.IsConcrete t then
             return t
           else
@@ -1553,6 +1825,19 @@ module Unification =
           | TypeValue.QueryRow row ->
             let! row = TypeQueryRow.Instantiate () typeEval loc0 row
             return TypeValue.QueryRow(row)
+          }
+
+        state {
+          let! ctx = state.GetContext()
+          let! stateSnapshot = state.GetState()
+
+          recordTypeCheckMemoDiagnostic
+            "type instantiate"
+            loc0
+            t
+            (t, ctx, stateSnapshot.VarsVersion)
+
+          return! timeTypeCheckCategory "type instantiate" loc0 instantiateState
         }
 
 


### PR DESCRIPTION
## Summary
- adjust typecheck behavior in expression/type evaluation paths used by AI configurator flows
- update HDD cache / project model handling to align with the new workflow
- include related unification and build-path updates required by these changes

## Validation
- Changes were committed from local worktree and pushed on `feature/uscreen-ai-configurator`.
