### PR TITLE
Add relation can-link hook support

### DIFF
--- a/backend/libraries/ballerina-lang/Next/Models/Types.fs
+++ b/backend/libraries/ballerina-lang/Next/Models/Types.fs
@@ -393,6 +393,7 @@ module Model =
     | Unlinking
     | Linked
     | Unlinked
+    | CanLink
 
     override self.ToString() =
       match self with
@@ -400,19 +401,22 @@ module Model =
       | Unlinking -> "unlinking"
       | Linked -> "linked"
       | Unlinked -> "unlinked"
+      | CanLink -> "canLink"
 
   and SchemaRelationHooksExpr<'valueExt> =
     { OnLinking: Option<Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>>
       OnUnlinking: Option<Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>>
       OnLinked: Option<Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>>
-      OnUnlinked: Option<Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>> }
+      OnUnlinked: Option<Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>>
+      CanLink: Option<Expr<TypeExpr<'valueExt>, Identifier, 'valueExt>> }
 
     override self.ToString() =
       let enabledHooks =
         [ ("linking", self.OnLinking)
           ("unlinking", self.OnUnlinking)
           ("linked", self.OnLinked)
-          ("unlinked", self.OnUnlinked) ]
+          ("unlinked", self.OnUnlinked)
+          ("canLink", self.CanLink) ]
         |> List.choose (fun (name, body) ->
           body |> Option.map (fun b -> $"{name} -> {b}"))
 
@@ -703,14 +707,16 @@ module Model =
     { OnLinking: Option<RunnableExpr<'valueExt>>
       OnUnlinking: Option<RunnableExpr<'valueExt>>
       OnLinked: Option<RunnableExpr<'valueExt>>
-      OnUnlinked: Option<RunnableExpr<'valueExt>> }
+      OnUnlinked: Option<RunnableExpr<'valueExt>>
+      CanLink: Option<RunnableExpr<'valueExt>> }
 
     override self.ToString() =
       let enabledHooks =
         [ ("linking", self.OnLinking)
           ("unlinking", self.OnUnlinking)
           ("linked", self.OnLinked)
-          ("unlinked", self.OnUnlinked) ]
+          ("unlinked", self.OnUnlinked)
+          ("canLink", self.CanLink) ]
         |> List.choose (fun (name, body) ->
           body |> Option.map (fun b -> $"{name} -> {b}"))
 

--- a/backend/libraries/ballerina-lang/Next/Stdlib/DB/CUD/Link.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/DB/CUD/Link.fs
@@ -23,6 +23,58 @@ module Link =
   open Ballerina
   open Ballerina.DSL.Next.StdLib.DB
 
+  let private deniedLinkError loc0 relationName =
+    Errors.Singleton loc0 (fun () ->
+      $"Link failed for relation {relationName}: you are not allowed to perform this action.")
+
+  let canLinkHook
+    (_db_ops: DBTypeClass<'runtimeContext, 'db, 'ext>)
+    (relation: RelationRef<'db, 'ext>)
+    (loc0: Location)
+    (_fromId: Value<TypeValue<'ext>, 'ext>)
+    (_toId: Value<TypeValue<'ext>, 'ext>)
+    =
+    reader {
+      let _schema, _db, relation, _from, _to, schema_as_value = relation
+      let _schema_as_value = schema_as_value.Value.Value
+
+      let! ctx = reader.GetContext()
+
+      match ctx.RootLevelEval, relation.Hooks.CanLink with
+      | false, _ -> return ()
+      | _, Some canLinkExpr ->
+        let! run_hook_result =
+          RunnableExpr.UnsafeApplyForUntypedEval(
+            RunnableExpr.UnsafeApplyForUntypedEval(
+              RunnableExpr.UnsafeApplyForUntypedEval(
+                canLinkExpr,
+                RunnableExpr.FromValue(
+                  _schema_as_value,
+                  TypeValue.CreateUnit(),
+                  Kind.Star
+                )
+              ),
+              RunnableExpr.FromValue(
+                _fromId,
+                TypeValue.CreateUnit(),
+                Kind.Star
+              )
+            ),
+            RunnableExpr.FromValue(_toId, TypeValue.CreateUnit(), Kind.Star)
+          )
+          |> NonEmptyList.One
+          |> Expr.Eval
+
+        match run_hook_result with
+        | Value.Primitive(PrimitiveValue.Bool canLink) when canLink ->
+          return ()
+        | _ ->
+          return!
+            sum.Throw(deniedLinkError loc0 relation.Name.Name)
+            |> reader.OfSum
+      | _, None -> return ()
+    }
+
   let onLinkingHook
     (_db_ops: DBTypeClass<'runtimeContext, 'db, 'ext>)
     (relation: RelationRef<'db, 'ext>)
@@ -260,6 +312,7 @@ module Link =
 
                 match v with
                 | [ _fromId; _toId ] ->
+                  do! canLinkHook db_ops relation_ref loc0 _fromId _toId
 
                   do! onLinkingHook db_ops relation_ref loc0 _fromId _toId
 
@@ -428,6 +481,9 @@ module Link =
 
                       match v with
                       | [ _fromId; _toId ] ->
+
+                        do!
+                          canLinkHook db_ops relation_ref loc0 _fromId _toId
 
                         do!
                           onLinkingHook db_ops relation_ref loc0 _fromId _toId

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Common.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Common.fs
@@ -269,6 +269,7 @@ module Common =
   let canReadKeyword = softKeyword "read"
   let canUpdateKeyword = softKeyword "update"
   let canDeleteKeyword = softKeyword "delete"
+  let canLinkKeyword = softKeyword "link"
   let canKeyword = parseKeyword Keyword.Can
 
 

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type/HooksAndProperties.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type/HooksAndProperties.fs
@@ -27,15 +27,30 @@ module TypeHooksAndProperties =
 
   let relationHooksRule =
     { Name = "relation-hooks"
-      Rule = Repeat (Seq [ Terminal "let"; Terminal "on"; Alt [ Terminal "linking"; Terminal "linked"; Terminal "unlinking"; Terminal "unlinked" ]; Terminal "="; NonTerminal "expr" ]) }
+      Rule =
+        Repeat(
+          Seq
+            [ Terminal "let"
+              Alt
+                [ Seq
+                    [ Terminal "on"
+                      Alt
+                        [ Terminal "linking"
+                          Terminal "linked"
+                          Terminal "unlinking"
+                          Terminal "unlinked" ] ]
+                  Seq [ Terminal "can"; Terminal "link" ] ]
+              Terminal "="
+              NonTerminal "expr" ]
+        ) }
 
   let relation_hooks (parseExpr: TypeExprParser<'valueExt>) () =
-    let onHook (hookKeyword, hookKeywordParser) =
+    let onHook (preHookKeyword) (hookKeyword, hookKeywordParser) =
       parser {
         let! startsWithHookKeyword =
           parser {
             do! letKeyword
-            do! onKeyword
+            do! preHookKeyword
             do! hookKeywordParser
           }
           |> parser.Lookahead
@@ -48,17 +63,18 @@ module TypeHooksAndProperties =
           return! parser.Throw(Errors.Singleton loc (fun () -> "No hook found"))
         | Left _ ->
           do! letKeyword
-          do! onKeyword
+          do! preHookKeyword
           do! hookKeywordParser
           do! equalsOperator
           let! hookExpr = parseExpr
           return hookKeyword, hookExpr
       }
 
-    [ (SchemaRelationHook.Linking, linkingKeyword) |> onHook
-      (SchemaRelationHook.Linked, linkedKeyword) |> onHook
-      (SchemaRelationHook.Unlinking, unlinkingKeyword) |> onHook
-      (SchemaRelationHook.Unlinked, unlinkedKeyword) |> onHook ]
+    [ (SchemaRelationHook.Linking, linkingKeyword) |> onHook onKeyword
+      (SchemaRelationHook.Linked, linkedKeyword) |> onHook onKeyword
+      (SchemaRelationHook.Unlinking, unlinkingKeyword) |> onHook onKeyword
+      (SchemaRelationHook.Unlinked, unlinkedKeyword) |> onHook onKeyword
+      (SchemaRelationHook.CanLink, canLinkKeyword) |> onHook canKeyword ]
     |> parser.Any
     |> parser.Many
     |> parser.Map(Map.ofList)

--- a/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type/Schema.fs
+++ b/backend/libraries/ballerina-lang/Next/Syntax/Parser/Type/Schema.fs
@@ -174,12 +174,14 @@ module TypeSchema =
         let onLinked = hooks |> Map.tryFind SchemaRelationHook.Linked
         let onUnlinking = hooks |> Map.tryFind SchemaRelationHook.Unlinking
         let onUnlinked = hooks |> Map.tryFind SchemaRelationHook.Unlinked
+        let canLink = hooks |> Map.tryFind SchemaRelationHook.CanLink
 
         let relationHooksExpr: SchemaRelationHooksExpr<'valueExt> =
           { SchemaRelationHooksExpr.OnLinking = onLinking
             SchemaRelationHooksExpr.OnLinked = onLinked
             SchemaRelationHooksExpr.OnUnlinking = onUnlinking
-            SchemaRelationHooksExpr.OnUnlinked = onUnlinked }
+            SchemaRelationHooksExpr.OnUnlinked = onUnlinked
+            SchemaRelationHooksExpr.CanLink = canLink }
 
         do! closeCurlyBracketOperator
 
@@ -244,6 +246,7 @@ module TypeSchema =
           let onLinked = hooks |> Map.tryFind SchemaRelationHook.Linked
           let onUnlinking = hooks |> Map.tryFind SchemaRelationHook.Unlinking
           let onUnlinked = hooks |> Map.tryFind SchemaRelationHook.Unlinked
+          let canLink = hooks |> Map.tryFind SchemaRelationHook.CanLink
 
           do! closeCurlyBracketOperator
 
@@ -258,7 +261,8 @@ module TypeSchema =
                 { OnLinking = onLinking
                   OnLinked = onLinked
                   OnUnlinking = onUnlinking
-                  OnUnlinked = onUnlinked } }
+                  OnUnlinked = onUnlinked
+                  CanLink = canLink } }
         })
         |> parser.MapError(Errors.MapPriority(replaceWith ErrorPriority.High))
     }

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/Schema/SchemaTypeEval.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/Schema/SchemaTypeEval.fs
@@ -280,7 +280,8 @@ module SchemaTypeEval =
                       { SchemaRelationHooks.OnLinking = None
                         SchemaRelationHooks.OnLinked = None
                         SchemaRelationHooks.OnUnlinking = None
-                        SchemaRelationHooks.OnUnlinked = None } }
+                        SchemaRelationHooks.OnUnlinked = None
+                        SchemaRelationHooks.CanLink = None } }
               })
             |> OrderedMap.ofList
             |> state.AllMapOrdered
@@ -890,6 +891,7 @@ module SchemaTypeEval =
                 Errors<Location>
                >)
             (relation_hook_type: TypeValue<'ve>)
+            (relation_can_link_hook_type: TypeValue<'ve>)
             (parsed_hooks: SchemaRelationHooksExpr<'ve>)
             =
             state {
@@ -897,7 +899,8 @@ module SchemaTypeEval =
                 { OnLinking = None
                   OnLinked = None
                   OnUnlinking = None
-                  OnUnlinked = None }
+                  OnUnlinked = None
+                  CanLink = None }
 
               let! r_typechecked =
                 state {
@@ -1064,6 +1067,55 @@ module SchemaTypeEval =
                     return
                       { r_typechecked with
                           OnUnlinked = Some on_unlinked_runnable }
+                }
+
+              let! r_typechecked =
+                state {
+                  match parsed_hooks.CanLink with
+                  | None -> return { r_typechecked with CanLink = None }
+                  | Some can_link ->
+                    do! assert_no_cardinality
+
+                    let! ctx = state.GetContext()
+                    let extra_scope = ctx.PermissionHooksExtraScope
+
+                    let! can_link_expr, _ =
+                      typeCheckExpr None can_link
+                      |> state.MapContext(
+                        TypeCheckContext.Updaters.Values(
+                          Map.merge (fun _ -> id) extra_scope
+                        )
+                        >> TypeCheckContext.Updaters.Scope(
+                          TypeCheckScope.Empty |> replaceWith
+                        )
+                      )
+
+                    let can_link_t = can_link_expr.Type
+
+                    let can_link_k = can_link_expr.Kind
+
+                    do! can_link_k |> Kind.AsStar |> ofSum |> state.Ignore
+
+                    do!
+                      TypeValue.Unify(
+                        can_link.Location,
+                        can_link_t,
+                        relation_can_link_hook_type
+                      )
+                      |> Expr.liftUnification
+                      |> state.MapContext(
+                        TypeCheckContext.Updaters.Scope(
+                          TypeCheckScope.Empty |> replaceWith
+                        )
+                      )
+
+                    let! can_link_runnable =
+                      Conversion.convertExpression can_link_expr
+                      |> state.OfSum
+
+                    return
+                      { r_typechecked with
+                          CanLink = Some can_link_runnable }
                 }
 
               return r_typechecked
@@ -1375,6 +1427,15 @@ module SchemaTypeEval =
                     )
                   )
 
+                let relation_can_link_hook_type =
+                  TypeValue.CreateArrow(
+                    TypeValue.Schema resulting_schema_without_hooks,
+                    TypeValue.CreateArrow(
+                      from_e.Id,
+                      TypeValue.CreateArrow(to_e.Id, TypeValue.CreateBool())
+                    )
+                  )
+
                 let assert_no_cardinality =
                   match included_relation.Cardinality with
                   | None ->
@@ -1389,6 +1450,7 @@ module SchemaTypeEval =
                   typecheck_relation_hooks
                     assert_no_cardinality
                     relation_hook_type
+                    relation_can_link_hook_type
                     hooks
 
                 return relationName, typechecked_hooks
@@ -1415,7 +1477,10 @@ module SchemaTypeEval =
                               |> Option.orElse hooks.OnUnlinking
                             SchemaRelationHooks.OnUnlinked =
                               v.Hooks.OnUnlinked
-                              |> Option.orElse hooks.OnUnlinked } }
+                              |> Option.orElse hooks.OnUnlinked
+                            SchemaRelationHooks.CanLink =
+                              v.Hooks.CanLink
+                              |> Option.orElse hooks.CanLink } }
 
                   acc |> OrderedMap.add relationName v
                 | None -> acc)
@@ -1529,6 +1594,15 @@ module SchemaTypeEval =
                     )
                   )
 
+                let relation_can_link_hook_type =
+                  TypeValue.CreateArrow(
+                    TypeValue.Schema resulting_schema_without_hooks,
+                    TypeValue.CreateArrow(
+                      from_e.Id,
+                      TypeValue.CreateArrow(to_e.Id, TypeValue.CreateBool())
+                    )
+                  )
+
                 let assert_no_cardinality =
                   match r_parsed.Cardinality with
                   | None ->
@@ -1542,6 +1616,7 @@ module SchemaTypeEval =
                   typecheck_relation_hooks
                     assert_no_cardinality
                     relation_hook_type
+                    relation_can_link_hook_type
                     r_parsed.Hooks
 
                 return


### PR DESCRIPTION
## Summary
- add parser support for relation hook syntax `let can link = ...`
- extend schema/type models with `CanLink`
- typecheck `can link` relation hooks as boolean predicates
- enforce `can link` in DB link operations before persisting relation links

## Validation
- `cd backend && dotnet build backend.sln`
- ran sample integration checks earlier in session
- verified end-to-end denial behavior from BISE side with browser test (`regular user cannot self-link UserRoles`)
