### PR TITLE
feat(stdlib): add AI configurator stdlib extensions

### DIFF
--- a/backend/libraries/ballerina-lang/Next/Stdlib/AIConfigurator/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/AIConfigurator/Extension.fs
@@ -1,0 +1,135 @@
+namespace Ballerina.DSL.Next.StdLib.AIConfigurator
+
+[<AutoOpen>]
+module Extension =
+  open System
+  open System.Net.Http
+  open System.Text
+  open System.Text.Json
+  open Ballerina
+  open Ballerina.Collections.Sum
+  open Ballerina.Reader.WithError
+  open Ballerina.LocalizedErrors
+  open Ballerina.Errors
+  open Ballerina.DSL.Next.Terms.Model
+  open Ballerina.DSL.Next.Terms.Patterns
+  open Ballerina.DSL.Next.Types.Model
+  open Ballerina.DSL.Next.Types.Patterns
+  open Ballerina.Lenses
+  open Ballerina.DSL.Next.Extensions
+
+  [<NoComparison; NoEquality>]
+  type AIConfiguratorTypeClass<'runtimeContext> =
+    { briefToPlan: 'runtimeContext -> string -> string }
+
+    static member FromEnvironment() : AIConfiguratorTypeClass<'runtimeContext> =
+      { briefToPlan =
+          fun _ prompt ->
+            try
+              let baseUrl =
+                Environment.GetEnvironmentVariable("BISE_LLM_URL")
+                |> Option.ofObj
+                |> Option.filter (fun x -> not (String.IsNullOrWhiteSpace(x)))
+                |> Option.defaultValue "http://localhost:8080"
+                |> fun x -> x.TrimEnd('/')
+
+              let model =
+                Environment.GetEnvironmentVariable("LLM_MODEL")
+                |> Option.ofObj
+                |> Option.filter (fun x -> not (String.IsNullOrWhiteSpace(x)))
+                |> Option.defaultValue "qwen3:8b"
+
+              use http = new HttpClient(Timeout = TimeSpan.FromMinutes(2.0))
+
+              let payload =
+                JsonSerializer.Serialize(
+                  {| model = model
+                     messages = [| {| role = "user"; content = prompt |} |]
+                     temperature = 0.1 |}
+                )
+
+              use request =
+                new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}/v1/chat/completions")
+
+              request.Content <- new StringContent(payload, Encoding.UTF8, "application/json")
+
+              use response = http.Send(request)
+              let body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+
+              if not response.IsSuccessStatusCode then
+                $"[AIConfigurator::briefToPlan error] status={(int response.StatusCode)} body={body}"
+              else
+                use doc = JsonDocument.Parse(body)
+                let root = doc.RootElement
+
+                let tryGetContent () =
+                  match root.TryGetProperty("choices") with
+                  | true, choices when choices.ValueKind = JsonValueKind.Array && choices.GetArrayLength() > 0 ->
+                    let first = choices[0]
+
+                    match first.TryGetProperty("message") with
+                    | true, message ->
+                      match message.TryGetProperty("content") with
+                      | true, content -> content.GetString() |> Option.ofObj
+                      | _ -> None
+                    | _ -> None
+                  | _ -> None
+
+                tryGetContent ()
+                |> Option.defaultValue "[AIConfigurator::briefToPlan error] missing choices[0].message.content"
+            with ex ->
+              $"[AIConfigurator::briefToPlan exception] {ex.Message}" }
+
+  let AIConfiguratorExtension<'runtimeContext, 'ext>
+    (ai_ops: AIConfiguratorTypeClass<'runtimeContext>)
+    (operationLens: PartialLens<'ext, AIConfiguratorOperations<'ext>>)
+    : OperationsExtension<'runtimeContext, 'ext, AIConfiguratorOperations<'ext>> =
+
+    let stringTypeValue = TypeValue.CreateString()
+
+    let briefToPlanId =
+      Identifier.FullyQualified([ "AIConfigurator" ], "briefToPlan")
+      |> TypeCheckScope.Empty.Resolve
+
+    let briefToPlanOperation
+      : ResolvedIdentifier *
+        OperationExtension<'runtimeContext, 'ext, AIConfiguratorOperations<'ext>> =
+      briefToPlanId,
+      { PublicIdentifiers =
+          Some
+          <| (TypeValue.CreateArrow(stringTypeValue, stringTypeValue),
+              Kind.Star,
+              AIConfiguratorOperations.BriefToPlan)
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | AIConfiguratorOperations.BriefToPlan -> Some AIConfiguratorOperations.BriefToPlan)
+        Apply =
+          fun loc0 _rest (op, v) ->
+            reader {
+              do!
+                op
+                |> AIConfiguratorOperations.AsBriefToPlan
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              let! v =
+                v
+                |> Value.AsPrimitive
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              let! prompt =
+                v
+                |> PrimitiveValue.AsString
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              let! ctx = reader.GetContext()
+              let response = ai_ops.briefToPlan ctx.RuntimeContext prompt
+
+              return Value<TypeValue<'ext>, 'ext>.Primitive(PrimitiveValue.String(response))
+            } }
+
+    { TypeVars = []
+      Operations = [ briefToPlanOperation ] |> Map.ofList }

--- a/backend/libraries/ballerina-lang/Next/Stdlib/AIConfigurator/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/AIConfigurator/Model.fs
@@ -1,0 +1,6 @@
+namespace Ballerina.DSL.Next.StdLib.AIConfigurator
+
+[<AutoOpen>]
+module Model =
+  type AIConfiguratorOperations<'ext> =
+    | BriefToPlan

--- a/backend/libraries/ballerina-lang/Next/Stdlib/AIConfigurator/Patterns.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/AIConfigurator/Patterns.fs
@@ -1,0 +1,14 @@
+namespace Ballerina.DSL.Next.StdLib.AIConfigurator
+
+[<AutoOpen>]
+module Patterns =
+  open Ballerina
+  open Ballerina.Collections.Sum
+  open Ballerina.Errors
+
+  type AIConfiguratorOperations<'ext> with
+    static member AsBriefToPlan
+      (op: AIConfiguratorOperations<'ext>)
+      : Sum<unit, Errors<Unit>> =
+      match op with
+      | AIConfiguratorOperations.BriefToPlan -> sum.Return()

--- a/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/StdExtensions.fs
@@ -14,6 +14,7 @@ open Ballerina.DSL.Next.StdLib.Map.Model
 open Ballerina.DSL.Next.StdLib.DB
 open Ballerina.Data.Delta
 open Ballerina.DSL.Next.StdLib.Email
+open Ballerina.DSL.Next.StdLib.AIConfigurator
 open Ballerina.DSL.Next.StdLib.String
 open Ballerina.DSL.Next.Types.TypeChecker.Model
 open Ballerina.Cat.Collections.OrderedMap
@@ -242,6 +243,10 @@ and PrimitiveExt<'runtimeContext, 'db, 'customExtension
     Email.Model.EmailOperations<
       ValueExt<'runtimeContext, 'db, 'customExtension>
      >
+  | AIConfiguratorOperations of
+    AIConfigurator.Model.AIConfiguratorOperations<
+      ValueExt<'runtimeContext, 'db, 'customExtension>
+     >
   | StringOperations of
     String.Model.StringOperations<
       ValueExt<'runtimeContext, 'db, 'customExtension>
@@ -256,6 +261,7 @@ and PrimitiveExt<'runtimeContext, 'db, 'customExtension
     | Float64Operations ops -> ops.ToString()
     | DecimalOperations ops -> ops.ToString()
     | EmailOperations ops -> ops.ToString()
+    | AIConfiguratorOperations ops -> ops.ToString()
     | StringOperations ops -> ops.ToString()
 
 and DeltaExt<'runtimeContext, 'db, 'customExtension
@@ -897,6 +903,18 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
           | _ -> None
         Set = EmailOperations >> VPrimitive }
 
+  let aiConfiguratorExtension =
+    AIConfigurator.Extension.AIConfiguratorExtension<
+      'runtimeContext,
+      ValueExt<'runtimeContext, 'db, 'customExtension>
+     >
+      (AIConfiguratorTypeClass<'runtimeContext>.FromEnvironment())
+      { Get =
+          function
+          | VPrimitive(AIConfiguratorOperations x) -> Some x
+          | _ -> None
+        Set = AIConfiguratorOperations >> VPrimitive }
+
   let guidExtension =
     Guid.Extension.GuidExtension<
       'runtimeContext,
@@ -987,6 +1005,7 @@ let makeExtensions<'runtimeContext, 'db, 'customExtension
     |> (float64Extension |> OperationsExtension.RegisterLanguageContext)
     |> (decimalExtension |> OperationsExtension.RegisterLanguageContext)
     |> (emailExtension |> OperationsExtension.RegisterLanguageContext)
+    |> (aiConfiguratorExtension |> OperationsExtension.RegisterLanguageContext)
     |> (stringExtension |> OperationsExtension.RegisterLanguageContext)
     |> (updaterExtension |> OperationsExtension.RegisterLanguageContext)
     |> (mapExtension |> TypeExtension.RegisterLanguageContext)

--- a/backend/libraries/ballerina-lang/Next/Stdlib/ballerina-lang-stdlib.fsproj
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/ballerina-lang-stdlib.fsproj
@@ -32,6 +32,9 @@
     <Compile Include="Email/Model.fs" />
     <Compile Include="Email/Patterns.fs" />
     <Compile Include="Email/Extension.fs" />
+    <Compile Include="AIConfigurator/Model.fs" />
+    <Compile Include="AIConfigurator/Patterns.fs" />
+    <Compile Include="AIConfigurator/Extension.fs" />
     <Compile Include="String/Model.fs" />
     <Compile Include="String/Patterns.fs" />
     <Compile Include="String/Extension.fs" />


### PR DESCRIPTION
## Summary
- add new `AIConfigurator` stdlib module files (`Model`, `Patterns`, `Extension`)
- wire stdlib project to include the new AI configurator code
- extend stdlib extensions to expose the AI configurator additions

## Notes
- This PR contains all currently pending changes from the local ballerina worktree.
- Follow-up BISE PR will reference this branch/commit.