### PR TITLE
Fix AIConfigurator operation matching and typechecker handling

### DIFF
--- a/backend/libraries/ballerina-api/Common/Utils.fs
+++ b/backend/libraries/ballerina-api/Common/Utils.fs
@@ -80,7 +80,7 @@ module APIUtils =
                   TypeCheckContext = typeCheckContext } })
 
       do!
-        Value.IsInstanceOf extensionChecker (value, typeValue)
+        Value.TypeCheck extensionChecker value typeValue
         |> reader.MapError(Errors.MapContext(replaceWith Location.Unknown))
         |> Reader.Run(typeCheckContext, typeCheckState)
         |> sum.MapError(fun errors ->

--- a/backend/libraries/ballerina-lang/Next/Stdlib/AIConfigurator/Extension.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/AIConfigurator/Extension.fs
@@ -17,68 +17,215 @@ module Extension =
   open Ballerina.DSL.Next.Types.Patterns
   open Ballerina.Lenses
   open Ballerina.DSL.Next.Extensions
+  open Ballerina.Parser
+  open Ballerina.DSL.Next.Syntax
+
+  [<CLIMutable>]
+  type CompletionResponse =
+    { content: string
+      stop: bool
+      tokens_predicted: int
+      tokens_evaluated: int }
 
   [<NoComparison; NoEquality>]
   type AIConfiguratorTypeClass<'runtimeContext> =
-    { briefToPlan: 'runtimeContext -> string -> string }
+    { briefToPlan: 'runtimeContext -> string -> string
+      cmsStage: 'runtimeContext -> string -> string
+      productsStage: 'runtimeContext -> string -> string }
 
     static member FromEnvironment() : AIConfiguratorTypeClass<'runtimeContext> =
+      let invalidSentinel opName = $"[AIConfigurator::{opName} invalid]"
+
+      let briefPlanGbnf =
+        """root ::= ws brief-plan ws
+
+brief-plan ::= "{" ws cms-field ws ";" ws products-field ws ";" ws media-field ws ";" ws theme-field ws "}"
+
+cms-field ::= "BriefPlan::Cms" ws "=" ws "2Of2(" ws cms-record ws ")"
+cms-record ::= "{" ws "PlanCmsInput::Pages" ws "=" ws "2Of2(" ws string-list ws ")" ws ";" ws "PlanCmsInput::HomepageSections" ws "=" ws "2Of2(" ws string-list ws ")" ws "}"
+
+products-field ::= "BriefPlan::Products" ws "=" ws "2Of2(" ws products-record ws ")"
+products-record ::= "{" ws "PlanProductsInput::Categories" ws "=" ws "2Of2(" ws string-list ws ")" ws ";" ws "PlanProductsInput::ProductIdeas" ws "=" ws "2Of2(" ws string-list ws ")" ws ";" ws "PlanProductsInput::PriceBandHint" ws "=" ws "2Of2(" ws label ws ")" ws "}"
+
+media-field ::= "BriefPlan::Media" ws "=" ws "2Of2(" ws media-record ws ")"
+media-record ::= "{" ws "PlanMediaInput::FeaturedAssets" ws "=" ws "1Of2()" ws ";" ws "PlanMediaInput::GalleryHints" ws "=" ws "2Of2(" ws string-list ws ")" ws "}"
+
+theme-field ::= "BriefPlan::Theme" ws "=" ws "2Of2(" ws theme-record ws ")"
+theme-record ::= "{" ws "PlanThemeInput::StyleKeywords" ws "=" ws "2Of2(" ws string-list ws ")" ws ";" ws "PlanThemeInput::LayoutHints" ws "=" ws "2Of2(" ws string-list ws ")" ws "}"
+
+string-list ::= "{" ws label (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? ws "}"
+
+label ::= "\"" jc jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? "\""
+jc ::= [^"\\\x00-\x1F]
+
+ws ::= [ \t\n\r]*
+"""
+
+      let cmsStageGbnf =
+        """root ::= ws cms-stage ws
+
+cms-stage ::= "{" ws "CmsStageOutput::Pages" ws "=" ws "2Of2(" ws string-list ws ")" ws ";" ws "CmsStageOutput::HomepageSections" ws "=" ws "2Of2(" ws string-list ws ")" ws "}"
+
+string-list ::= "{" ws label (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? ws "}"
+
+label ::= "\"" jc jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? "\""
+jc ::= [^"\\\x00-\x1F]
+
+ws ::= [ \t\n\r]*
+"""
+
+      let productsStageGbnf =
+        """root ::= ws products-stage ws
+
+products-stage ::= "{" ws "ProductsStageOutput::Categories" ws "=" ws "2Of2(" ws string-list ws ")" ws ";" ws "ProductsStageOutput::ProductIdeas" ws "=" ws "2Of2(" ws string-list ws ")" ws ";" ws "ProductsStageOutput::PriceBandHint" ws "=" ws "2Of2(" ws label ws ")" ws "}"
+
+string-list ::= "{" ws label (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? (ws ";" ws label)? ws "}"
+
+label ::= "\"" jc jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? jc? "\""
+jc ::= [^"\\\x00-\x1F]
+
+ws ::= [ \t\n\r]*
+"""
+
+      let validateWithBallerinaParser (candidate: string) : Result<string, string> =
+        let trimmed = candidate.Trim()
+
+        if String.IsNullOrWhiteSpace(trimmed) then
+          Error "empty completion"
+        else
+          let programText =
+            if trimmed.EndsWith(";", StringComparison.Ordinal) then
+              trimmed
+            else
+              trimmed + ";"
+
+          let initialLocation = Location.Initial "AIConfigurator::briefToPlan"
+
+          match
+            tokens
+            |> Parser.Run(programText |> Seq.toList, initialLocation)
+            |> sum.MapError fst
+          with
+          | Sum.Right err -> Error $"lexer failed: {err}"
+          | Sum.Left(ParserResult(actual, _)) ->
+            match
+              (Parser.Expr.program ()).Parser
+              |> Parser.Run(actual, initialLocation)
+              |> sum.MapError fst
+            with
+            | Sum.Right err -> Error $"parser failed: {err}"
+            | Sum.Left(ParserResult(_, _)) -> Ok trimmed
+
+      let runConstrainedCompletion
+        (opName: string)
+        (grammar: string)
+        (fullPrompt: string)
+        =
+        try
+          let baseUrl =
+            Environment.GetEnvironmentVariable("BISE_LLM_URL")
+            |> Option.ofObj
+            |> Option.filter (fun x -> not (String.IsNullOrWhiteSpace(x)))
+            |> Option.defaultValue "http://localhost:8080"
+            |> fun x -> x.TrimEnd('/')
+
+          let modelName =
+            Environment.GetEnvironmentVariable("BISE_LLM_MODEL")
+            |> Option.ofObj
+            |> Option.filter (fun x -> not (String.IsNullOrWhiteSpace(x)))
+            |> Option.defaultValue "qwen3-32b"
+
+          use http = new HttpClient(Timeout = TimeSpan.FromMinutes(2.0))
+
+          let requestOnce () : Result<string, string> =
+            let payload =
+              JsonSerializer.Serialize(
+                {| prompt = fullPrompt
+                   n_predict = 2048
+                   temperature = 0.2
+                   top_p = 0.9
+                   stop = [||]
+                   grammar = grammar
+                   model = modelName |}
+              )
+
+            use request =
+              new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}/completion")
+
+            request.Content <- new StringContent(payload, Encoding.UTF8, "application/json")
+
+            use response = http.Send(request)
+            let body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+
+            if not response.IsSuccessStatusCode then
+              Error
+                $"status={(int response.StatusCode)} body={body}"
+            else
+              try
+                let completion = JsonSerializer.Deserialize<CompletionResponse>(body)
+
+                if isNull (box completion) || String.IsNullOrWhiteSpace(completion.content) then
+                  Error "missing completion content"
+                else
+                  validateWithBallerinaParser completion.content
+              with ex ->
+                Error $"completion decode failed: {ex.Message}"
+
+          let maxAttempts = 3
+
+          let rec run attemptsLeft lastError =
+            if attemptsLeft <= 0 then
+              match lastError with
+              | Some err ->
+                Console.Error.WriteLine(
+                  $"[AIConfigurator::{opName} conformance error] {err}"
+                )
+              | None ->
+                Console.Error.WriteLine(
+                  $"[AIConfigurator::{opName} conformance error] unknown failure"
+                )
+
+              invalidSentinel opName
+            else
+              match requestOnce () with
+              | Ok parsed -> parsed
+              | Error err -> run (attemptsLeft - 1) (Some err)
+
+          run maxAttempts None
+        with ex ->
+          Console.Error.WriteLine($"[AIConfigurator::{opName} exception] {ex.Message}")
+          invalidSentinel opName
+
       { briefToPlan =
           fun _ prompt ->
             try
-              let baseUrl =
-                Environment.GetEnvironmentVariable("BISE_LLM_URL")
-                |> Option.ofObj
-                |> Option.filter (fun x -> not (String.IsNullOrWhiteSpace(x)))
-                |> Option.defaultValue "http://localhost:8080"
-                |> fun x -> x.TrimEnd('/')
-
-              let model =
-                Environment.GetEnvironmentVariable("LLM_MODEL")
-                |> Option.ofObj
-                |> Option.filter (fun x -> not (String.IsNullOrWhiteSpace(x)))
-                |> Option.defaultValue "qwen3:8b"
-
-              use http = new HttpClient(Timeout = TimeSpan.FromMinutes(2.0))
-
-              let payload =
-                JsonSerializer.Serialize(
-                  {| model = model
-                     messages = [| {| role = "user"; content = prompt |} |]
-                     temperature = 0.1 |}
-                )
-
-              use request =
-                new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}/v1/chat/completions")
-
-              request.Content <- new StringContent(payload, Encoding.UTF8, "application/json")
-
-              use response = http.Send(request)
-              let body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
-
-              if not response.IsSuccessStatusCode then
-                $"[AIConfigurator::briefToPlan error] status={(int response.StatusCode)} body={body}"
-              else
-                use doc = JsonDocument.Parse(body)
-                let root = doc.RootElement
-
-                let tryGetContent () =
-                  match root.TryGetProperty("choices") with
-                  | true, choices when choices.ValueKind = JsonValueKind.Array && choices.GetArrayLength() > 0 ->
-                    let first = choices[0]
-
-                    match first.TryGetProperty("message") with
-                    | true, message ->
-                      match message.TryGetProperty("content") with
-                      | true, content -> content.GetString() |> Option.ofObj
-                      | _ -> None
-                    | _ -> None
-                  | _ -> None
-
-                tryGetContent ()
-                |> Option.defaultValue "[AIConfigurator::briefToPlan error] missing choices[0].message.content"
+              let fullPrompt =
+                "You are a webshop plan generator. "
+                + "Generate a BriefPlan Ballerina record expression. "
+                + "Context: "
+                + prompt
+              runConstrainedCompletion "briefToPlan" briefPlanGbnf fullPrompt
             with ex ->
-              $"[AIConfigurator::briefToPlan exception] {ex.Message}" }
+              Console.Error.WriteLine($"[AIConfigurator::briefToPlan exception] {ex.Message}")
+              invalidSentinel "briefToPlan"
+        cmsStage =
+          fun _ prompt ->
+            let fullPrompt =
+              "You are a webshop CMS stage generator. "
+              + "Generate a CmsStageOutput Ballerina record expression. "
+              + "Context: "
+              + prompt
+
+            runConstrainedCompletion "cmsStage" cmsStageGbnf fullPrompt
+        productsStage =
+          fun _ prompt ->
+            let fullPrompt =
+              "You are a webshop products stage generator. "
+              + "Generate a ProductsStageOutput Ballerina record expression. "
+              + "Context: "
+              + prompt
+
+            runConstrainedCompletion "productsStage" productsStageGbnf fullPrompt }
 
   let AIConfiguratorExtension<'runtimeContext, 'ext>
     (ai_ops: AIConfiguratorTypeClass<'runtimeContext>)
@@ -89,6 +236,14 @@ module Extension =
 
     let briefToPlanId =
       Identifier.FullyQualified([ "AIConfigurator" ], "briefToPlan")
+      |> TypeCheckScope.Empty.Resolve
+
+    let cmsStageId =
+      Identifier.FullyQualified([ "AIConfigurator" ], "cmsStage")
+      |> TypeCheckScope.Empty.Resolve
+
+    let productsStageId =
+      Identifier.FullyQualified([ "AIConfigurator" ], "productsStage")
       |> TypeCheckScope.Empty.Resolve
 
     let briefToPlanOperation
@@ -103,7 +258,8 @@ module Extension =
         OperationsLens =
           operationLens
           |> PartialLens.BindGet (function
-            | AIConfiguratorOperations.BriefToPlan -> Some AIConfiguratorOperations.BriefToPlan)
+            | AIConfiguratorOperations.BriefToPlan -> Some AIConfiguratorOperations.BriefToPlan
+            | _ -> None)
         Apply =
           fun loc0 _rest (op, v) ->
             reader {
@@ -131,5 +287,91 @@ module Extension =
               return Value<TypeValue<'ext>, 'ext>.Primitive(PrimitiveValue.String(response))
             } }
 
+    let cmsStageOperation
+      : ResolvedIdentifier *
+        OperationExtension<'runtimeContext, 'ext, AIConfiguratorOperations<'ext>> =
+      cmsStageId,
+      { PublicIdentifiers =
+          Some
+          <| (TypeValue.CreateArrow(stringTypeValue, stringTypeValue),
+              Kind.Star,
+              AIConfiguratorOperations.CmsStage)
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | AIConfiguratorOperations.CmsStage -> Some AIConfiguratorOperations.CmsStage
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (op, v) ->
+            reader {
+              do!
+                op
+                |> AIConfiguratorOperations.AsCmsStage
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              let! v =
+                v
+                |> Value.AsPrimitive
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              let! prompt =
+                v
+                |> PrimitiveValue.AsString
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              let! ctx = reader.GetContext()
+              let response = ai_ops.cmsStage ctx.RuntimeContext prompt
+
+              return Value<TypeValue<'ext>, 'ext>.Primitive(PrimitiveValue.String(response))
+            } }
+
+    let productsStageOperation
+      : ResolvedIdentifier *
+        OperationExtension<'runtimeContext, 'ext, AIConfiguratorOperations<'ext>> =
+      productsStageId,
+      { PublicIdentifiers =
+          Some
+          <| (TypeValue.CreateArrow(stringTypeValue, stringTypeValue),
+              Kind.Star,
+              AIConfiguratorOperations.ProductsStage)
+        OperationsLens =
+          operationLens
+          |> PartialLens.BindGet (function
+            | AIConfiguratorOperations.ProductsStage -> Some AIConfiguratorOperations.ProductsStage
+            | _ -> None)
+        Apply =
+          fun loc0 _rest (op, v) ->
+            reader {
+              do!
+                op
+                |> AIConfiguratorOperations.AsProductsStage
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              let! v =
+                v
+                |> Value.AsPrimitive
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              let! prompt =
+                v
+                |> PrimitiveValue.AsString
+                |> sum.MapError(Errors.MapContext(replaceWith loc0))
+                |> reader.OfSum
+
+              let! ctx = reader.GetContext()
+              let response = ai_ops.productsStage ctx.RuntimeContext prompt
+
+              return Value<TypeValue<'ext>, 'ext>.Primitive(PrimitiveValue.String(response))
+            } }
+
     { TypeVars = []
-      Operations = [ briefToPlanOperation ] |> Map.ofList }
+      Operations =
+        [ briefToPlanOperation
+          cmsStageOperation
+          productsStageOperation ]
+        |> Map.ofList }

--- a/backend/libraries/ballerina-lang/Next/Stdlib/AIConfigurator/Model.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/AIConfigurator/Model.fs
@@ -4,3 +4,5 @@ namespace Ballerina.DSL.Next.StdLib.AIConfigurator
 module Model =
   type AIConfiguratorOperations<'ext> =
     | BriefToPlan
+    | CmsStage
+    | ProductsStage

--- a/backend/libraries/ballerina-lang/Next/Stdlib/AIConfigurator/Patterns.fs
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/AIConfigurator/Patterns.fs
@@ -12,3 +12,21 @@ module Patterns =
       : Sum<unit, Errors<Unit>> =
       match op with
       | AIConfiguratorOperations.BriefToPlan -> sum.Return()
+      | _ ->
+        sum.Throw(Errors.Singleton () (fun () -> "Expected BriefToPlan operation"))
+
+    static member AsCmsStage
+      (op: AIConfiguratorOperations<'ext>)
+      : Sum<unit, Errors<Unit>> =
+      match op with
+      | AIConfiguratorOperations.CmsStage -> sum.Return()
+      | _ ->
+        sum.Throw(Errors.Singleton () (fun () -> "Expected CmsStage operation"))
+
+    static member AsProductsStage
+      (op: AIConfiguratorOperations<'ext>)
+      : Sum<unit, Errors<Unit>> =
+      match op with
+      | AIConfiguratorOperations.ProductsStage -> sum.Return()
+      | _ ->
+        sum.Throw(Errors.Singleton () (fun () -> "Expected ProductsStage operation"))

--- a/backend/libraries/ballerina-lang/Next/Stdlib/ballerina-lang-stdlib.fsproj
+++ b/backend/libraries/ballerina-lang/Next/Stdlib/ballerina-lang-stdlib.fsproj
@@ -93,6 +93,7 @@
   <ItemGroup>
     <ProjectReference Include="../../../ballerina-cat/ballerina-cat.fsproj" />
     <ProjectReference Include="../../../ballerina-stdlib/ballerina-stdlib.fsproj" />
+    <ProjectReference Include="../Syntax/ballerina-lang-parser.fsproj" />
     <ProjectReference Include="../Models/ballerina-lang-models.fsproj" />
     <ProjectReference Include="../TypeChecker/ballerina-lang-typecheck.fsproj" />
     <ProjectReference Include="../Eval/ballerina-lang-eval.fsproj" />

--- a/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/Value.fs
+++ b/backend/libraries/ballerina-lang/Next/TypeChecker/TypeCheck/Value.fs
@@ -34,6 +34,17 @@ module Value =
        >
 
   type Value<'T, 'ext> with
+    static member TypeCheck<'valueExt when 'valueExt: comparison>
+      (ext_checker: IsExtInstanceOf<'valueExt>)
+      (v: Value<TypeValue<'valueExt>, 'valueExt>)
+      (t: TypeValue<'valueExt>)
+      : Reader<
+          Unit,
+          TypeCheckContext<'valueExt> * TypeCheckState<'valueExt>,
+          Errors<Unit>
+         > =
+      Value.IsInstanceOf ext_checker (v, t)
+
     static member IsInstanceOf<'valueExt when 'valueExt: comparison>
       (ext_checker: IsExtInstanceOf<'valueExt>)
       : IsValueInstanceOf<'valueExt> =


### PR DESCRIPTION
## Summary\n- tighten AIConfigurator stdlib operation model/pattern handling\n- update related stdlib and typechecker wiring touched in this fix\n- include supporting backend API/common utility updates\n\n## Notes\n- Requested workflow: open and merge PR without running the golden suite in BISE repo.