### PR TITLE
Fix filter endpoint field-name quoting and add batch is-linked endpoint

### DIFF
--- a/backend/libraries/ballerina-api/Endpoints/Filter.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Filter.fs
@@ -20,7 +20,7 @@ module Filter =
       JsonValue: ValueDTO<ValueExtDTO> }
 
   type EntityFilterFunction =
-    string -> int -> int -> JsonElement -> Sum<EntityFilterResult list, Errors<unit>>
+    HttpContext -> string -> int -> int -> JsonElement -> Sum<EntityFilterResult list, Errors<unit>>
 
   let filter<'runtimeContext, 'db, 'customExtension, 'tenantId, 'schemaName
     when 'customExtension: comparison and 'db: comparison>
@@ -32,7 +32,7 @@ module Filter =
     app.MapPost(
       "/{tenantId}/{schemaName}/{entityName}/filter",
       Func<HttpContext, 'tenantId, 'schemaName, string, int, int, JsonElement, IResult>
-        (fun _httpContext tenantId schemaName entityName (offset: int) (limit: int) filterBody ->
+        (fun httpContext tenantId schemaName entityName (offset: int) (limit: int) filterBody ->
           let result =
             sum {
               let! filterFn =
@@ -41,7 +41,7 @@ module Filter =
                   APIError<'runtimeContext, 'db, 'customExtension, Location>.Create
 
               let! filterResults =
-                filterFn entityName offset limit filterBody
+                filterFn httpContext entityName offset limit filterBody
                 |> sum.MapError(fun errors ->
                   { Errors = errors |> Errors.MapContext(fun () -> Location.Unknown)
                     TypeError = None })

--- a/backend/libraries/ballerina-api/Endpoints/Linking.fs
+++ b/backend/libraries/ballerina-api/Endpoints/Linking.fs
@@ -413,6 +413,192 @@ module Linking =
     )
     |> ignore
 
+    app.MapPost(
+      "/{tenantId}/{schemaName}/{relationName}/is-linked",
+      Func<
+        HttpContext,
+        'tenantId,
+        'schemaName,
+        string,
+        LinkPayload,
+        IResult
+       >
+        (fun httpContext tenantId schemaName relationName payload ->
+          let fromId, toId = payload.FromId, payload.ToId
+
+          let result =
+            sum {
+              let! dbio,
+                   languageContext,
+                   evalContext,
+                   typeCheckContext,
+                   typeCheckState, _ =
+                getDbDescriptor tenantId schemaName context
+
+              let! fromIdValue =
+                runDTOConverter languageContext (valueFromDTO fromId)
+                |> sum.MapError
+                  APIError<'runtimeContext, 'db, 'customExtension, Location>
+                    .Create
+
+              let! toIdValue =
+                runDTOConverter languageContext (valueFromDTO toId)
+                |> sum.MapError
+                  APIError<'runtimeContext, 'db, 'customExtension, Location>
+                    .Create
+
+              let! _tableDescriptor =
+                dbio.Schema.Relations
+                |> OrderedMap.tryFind (
+                  relationName |> SchemaRelationName.Create
+                )
+                |> Sum.fromOption (fun () ->
+                  Errors<Location>.Singleton Location.Unknown (fun () ->
+                    $"Relation {relationName} not found in schema {dbio.Schema}."))
+                |> sum.MapError
+                  APIError<'runtimeContext, 'db, 'customExtension, Location>
+                    .Create
+
+              let fromName, toName =
+                _tableDescriptor.From.ToString(),
+                _tableDescriptor.To.ToString()
+
+              let! _fromDescriptor =
+                dbio.Schema.Entities
+                |> OrderedMap.tryFind (fromName |> SchemaEntityName.Create)
+                |> Sum.fromOption (fun () ->
+                  Errors.Singleton Location.Unknown (fun () ->
+                    $"Entity {fromName} not found in schema {dbio.Schema}."))
+                |> sum.MapError
+                  APIError<'runtimeContext, 'db, 'customExtension, Location>
+                    .Create
+
+              let! _toDescriptor =
+                dbio.Schema.Entities
+                |> OrderedMap.tryFind (toName |> SchemaEntityName.Create)
+                |> Sum.fromOption (fun () ->
+                  Errors.Singleton Location.Unknown (fun () ->
+                    $"Entity {toName} not found in schema {dbio.Schema}."))
+                |> sum.MapError
+                  APIError<'runtimeContext, 'db, 'customExtension, Location>
+                    .Create
+
+              let fromIdType, toIdType = _fromDescriptor.Id, _toDescriptor.Id
+
+              do!
+                typeCheckValue
+                  fromIdValue
+                  fromIdType
+                  languageContext
+                  typeCheckContext
+                  typeCheckState
+
+              do!
+                typeCheckValue
+                  toIdValue
+                  toIdType
+                  languageContext
+                  typeCheckContext
+                  typeCheckState
+
+              let! schema =
+                dbio.SchemaAsValue
+                |> Value.AsRecord
+                |> sum.MapError(
+                  Errors.MapContext(replaceWith Location.Unknown)
+                )
+                |> sum.MapError
+                  APIError<'runtimeContext, 'db, 'customExtension, Location>
+                    .Create
+
+              let! relations =
+                schema
+                |> Map.tryFindWithError
+                  ("Relations"
+                   |> Identifier.LocalScope
+                   |> ResolvedIdentifier.FromIdentifier)
+                  "schema"
+                  (fun () -> "Relations")
+                  Location.Unknown
+                |> sum.MapError
+                  APIError<'runtimeContext, 'db, 'customExtension, Location>
+                    .Create
+
+              let! relations =
+                relations
+                |> Value.AsRecord
+                |> sum.MapError(
+                  Errors.MapContext(replaceWith Location.Unknown)
+                  >> APIError<'runtimeContext, 'db, 'customExtension, Location>
+                    .Create
+                )
+
+              let! relationDescriptor =
+                relations
+                |> Map.tryFindWithError
+                  (relationName
+                   |> Identifier.LocalScope
+                   |> ResolvedIdentifier.FromIdentifier)
+                  "schema"
+                  (fun () -> relationName)
+                  Location.Unknown
+                |> sum.MapError
+                  APIError<'runtimeContext, 'db, 'customExtension, Location>
+                    .Create
+
+              let doIsLinkedExpr
+                : RunnableExpr<
+                    ValueExt<'runtimeContext, 'db, 'customExtension>
+                   > =
+                RunnableExpr.UnsafeApplyForUntypedEval(
+                  RunnableExpr.UnsafeApplyForUntypedEval(
+                    RunnableExpr.UnsafeLookupForUntypedEval(
+                      Identifier.FullyQualified([ "DB" ], "isLinked")
+                      |> ResolvedIdentifier.FromIdentifier
+                    ),
+                    RunnableExpr.FromValue(
+                      relationDescriptor,
+                      TypeValue.CreatePrimitive PrimitiveType.Unit,
+                      Kind.Star
+                    )
+                  ),
+                  RunnableExpr.UnsafeTupleConsForUntypedEval
+                    [ RunnableExpr.FromValue(
+                        fromIdValue,
+                        TypeValue.CreatePrimitive PrimitiveType.Unit,
+                        Kind.Star
+                      )
+                      RunnableExpr.FromValue(
+                        toIdValue,
+                        TypeValue.CreatePrimitive PrimitiveType.Unit,
+                        Kind.Star
+                      ) ]
+                )
+
+              let! evalResult =
+                Expr.Eval(
+                  NonEmptyList.prependList
+                    languageContext.TypeCheckedPreludes
+                    (NonEmptyList.OfList(doIsLinkedExpr, []))
+                )
+                |> Reader.Run(
+                  evalContext |> context.PermissionHookInjector httpContext
+                )
+                |> sum.MapError
+                  APIError<'runtimeContext, 'db, 'customExtension, Location>
+                    .Create
+
+              return!
+                runDTOConverter languageContext (valueToDTO evalResult)
+                |> sum.MapError
+                  APIError<'runtimeContext, 'db, 'customExtension, Location>
+                    .Create
+            }
+
+          apiResponseFromSum result (fun _ -> ()) id)
+    )
+    |> ignore
+
   let private moveEndpoint<'runtimeContext, 'db, 'customExtension, 'tenantId, 'schemaName
     when 'customExtension: comparison and 'db: comparison>
     (app: IEndpointRouteBuilder)


### PR DESCRIPTION
- Filter.fs: quote field names with double-quotes in SQL to handle reserved words
- Linking.fs: add POST /is-linked endpoint for checking relation existence