### PR TITLE
fix(openapi): use 'Date' instead of 'DateOnly' for DateOnly primitive type name

### DIFF
--- a/backend/libraries/ballerina-api/Common/OpenAPI/YamlGeneration.fs
+++ b/backend/libraries/ballerina-api/Common/OpenAPI/YamlGeneration.fs
@@ -55,7 +55,7 @@ module YamlGeneration =
         | PrimitiveType.Bool -> "Bool"
         | PrimitiveType.String -> "String"
         | PrimitiveType.DateTime -> "DateTime"
-        | PrimitiveType.DateOnly -> "DateOnly"
+        | PrimitiveType.DateOnly -> "Date"
         | PrimitiveType.TimeSpan -> "TimeSpan"
         | PrimitiveType.Vector -> "Vector"
 


### PR DESCRIPTION
## Summary
The OpenAPI YAML generation was emitting `DateOnly` as the type name for `PrimitiveType.DateOnly`, but the correct OpenAPI-facing name should be `Date` (matching how other consumers reference it).

## Changes
- `YamlGeneration.fs`: `PrimitiveType.DateOnly -> "Date"` (was `"DateOnly"`)